### PR TITLE
change ResourceStateImportResult to use Record and remove redundant s…

### DIFF
--- a/src/resourceState/ResourceStateImporter.ts
+++ b/src/resourceState/ResourceStateImporter.ts
@@ -90,8 +90,8 @@ export class ResourceStateImporter {
         const fetchedResourceStates: ResourceTemplateFormat[] = [];
         const importResult: ResourceStateImportResult = {
             title: 'Resource State Import',
-            failedImports: new Map<ResourceType, ResourceIdentifier[]>(),
-            successfulImports: new Map<ResourceType, ResourceIdentifier[]>(),
+            failedImports: {},
+            successfulImports: {},
         };
 
         const generatedLogicalIds = new Set<string>();
@@ -294,24 +294,22 @@ export class ResourceStateImporter {
 
     private getFailureResponse(
         title: string,
-        successfulImports?: Map<ResourceType, ResourceIdentifier[]>,
-        failedImports?: Map<ResourceType, ResourceIdentifier[]>,
+        successfulImports?: Record<ResourceType, ResourceIdentifier[]>,
+        failedImports?: Record<ResourceType, ResourceIdentifier[]>,
     ): ResourceStateImportResult {
         return {
             title: title,
-            successfulImports: successfulImports ?? new Map<ResourceType, ResourceIdentifier[]>(),
-            failedImports: failedImports ?? new Map<ResourceType, ResourceIdentifier[]>(),
+            successfulImports: successfulImports ?? {},
+            failedImports: failedImports ?? {},
         };
     }
 
-    private getOrCreate<K, V>(map: Map<K, V>, key: K, createValue: V): V {
-        if (map.has(key)) {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            return map.get(key)!; // non-null assertion after check with has()
+    private getOrCreate<V>(record: Record<string, V>, key: string, createValue: V): V {
+        if (key in record) {
+            return record[key];
         } else {
-            const newValue = createValue;
-            map.set(key, newValue);
-            return newValue;
+            record[key] = createValue;
+            return createValue;
         }
     }
 

--- a/src/resourceState/ResourceStateManager.ts
+++ b/src/resourceState/ResourceStateManager.ts
@@ -198,9 +198,6 @@ export class ResourceStateManager implements Configurable, Closeable {
             this.settingsSubscription.unsubscribe();
         }
 
-        const newSettings = settingsManager.getCurrentSettings().profile;
-        this.onSettingsChanged(newSettings);
-
         this.settingsSubscription = settingsManager.subscribe('profile', (newResourceStateSettings) => {
             this.onSettingsChanged(newResourceStateSettings);
         });

--- a/src/resourceState/ResourceStateTypes.ts
+++ b/src/resourceState/ResourceStateTypes.ts
@@ -22,8 +22,8 @@ export interface ResourceStateImportParams extends CodeActionParams {
 }
 
 export interface ResourceStateImportResult extends CodeAction {
-    successfulImports: Map<ResourceType, ResourceIdentifier[]>;
-    failedImports: Map<ResourceType, ResourceIdentifier[]>;
+    successfulImports: Record<ResourceType, ResourceIdentifier[]>;
+    failedImports: Record<ResourceType, ResourceIdentifier[]>;
 }
 
 export const ResourceStateImportRequest = new RequestType<ResourceStateImportParams, ResourceStateImportResult, void>(

--- a/tst/unit/resourceState/ResourceStateImporter.test.ts
+++ b/tst/unit/resourceState/ResourceStateImporter.test.ts
@@ -233,8 +233,8 @@ Resources:
 
             expect(result.edit).toBeUndefined();
             expect(result.title).toBe('No resources selected for import.');
-            expect(result.successfulImports.size).toBe(0);
-            expect(result.failedImports.size).toBe(0);
+            expect(Object.keys(result.successfulImports)).toHaveLength(0);
+            expect(Object.keys(result.failedImports)).toHaveLength(0);
         });
 
         it('should return failure when document is not found', async () => {
@@ -254,8 +254,8 @@ Resources:
 
             expect(result.edit).toBeUndefined();
             expect(result.title).toBe('Import failed. Document not found.');
-            expect(result.successfulImports.size).toBe(0);
-            expect(result.failedImports.size).toBe(0);
+            expect(Object.keys(result.successfulImports)).toHaveLength(0);
+            expect(Object.keys(result.failedImports)).toHaveLength(0);
         });
 
         it('should return failure when syntax tree is not found', async () => {
@@ -282,8 +282,8 @@ Resources:
 
             expect(result.edit).toBeUndefined();
             expect(result.title).toBe('Import failed. Syntax tree not found');
-            expect(result.successfulImports.size).toBe(0);
-            expect(result.failedImports.size).toBe(0);
+            expect(Object.keys(result.successfulImports)).toHaveLength(0);
+            expect(Object.keys(result.failedImports)).toHaveLength(0);
 
             // Cleanup
             (documentManager as any).documents._syncedDocuments.delete(uri);


### PR DESCRIPTION
…ettings assignment

*Issue #, if available:*

*Description of changes:*
- changed the success and failure data in resource import result from Map to Record in preparation for importing user notification


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
