### PR TITLE
Force the yaml loader over c loader

### DIFF
--- a/src/services/cfnLint/pyodide-worker.ts
+++ b/src/services/cfnLint/pyodide-worker.ts
@@ -116,6 +116,14 @@ async function initializePyodide(): Promise<InitializeResult> {
         // Load required packages
         await pyodide.loadPackage('micropip');
         await pyodide.loadPackage('ssl');
+        await pyodide.loadPackage('pyyaml');
+
+        // Replace CSafeLoader with SafeLoader to avoid Pyodide parsing issues
+        await pyodide.runPythonAsync(`
+       import yaml
+       if hasattr(yaml, 'CSafeLoader'):
+           yaml.CSafeLoader = yaml.SafeLoader
+     `);
 
         // Install cfn-lint
         await pyodide.runPythonAsync(`


### PR DESCRIPTION
*Issue #, if available:*
Added PyYAML package loading to the Pyodide worker and replaced CSafeLoader with SafeLoader to prevent parsing issues in the CloudFormation linting service. This ensures compatibility with Pyodide's execution environment.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
