### PR TITLE
feat: Hover on parameter attributes

### DIFF
--- a/src/artifacts/ParameterAttributeDocs.ts
+++ b/src/artifacts/ParameterAttributeDocs.ts
@@ -1,0 +1,214 @@
+export const parameterAttributeDocsMap = getParameterAttributeDocsMap();
+
+function getParameterAttributeDocsMap(): Map<string, string> {
+    const parameterAttributeDocsMap = new Map<string, string>();
+
+    parameterAttributeDocsMap.set(
+        'Type',
+        [
+            '**Type**',
+            '\n',
+            '---',
+            'The data type for the parameter (`DataType`). ',
+            '\n',
+            '*Required*: Yes ',
+            '\n',
+            'CloudFormation supports the following parameter types: ',
+            '\n',
+            '**String**',
+            '\n',
+            'A literal string. You can use the following attributes to declare constraints: `MinLength`, `MaxLength`, `Default`, `AllowedValues`, and `AllowedPattern`.',
+            '\n',
+            'For example, users could specify `"MyUserName"`.',
+            '\n',
+            '**Number**',
+            '\n',
+            'An integer or float. CloudFormation validates the parameter value as a number; however, when you use the parameter elsewhere in your template (for example, by using the `Ref` intrinsic function), the parameter value becomes a string.',
+            '\n',
+            'You can use the following attributes to declare constraints: `MinValue`, `MaxValue`, `Default`, and `AllowedValues`.',
+            '\n',
+            'For example, users could specify `"8888"`.',
+            '\n',
+            '**List<Number>**',
+            '\n',
+            'An array of integers or floats that are separated by commas. CloudFormation validates the parameter value as numbers; however, when you use the parameter elsewhere in your template (for example, by using the `Ref` intrinsic function), the parameter value becomes a list of strings.',
+            '\n',
+            'For example, users could specify `"80,20"`, and a Ref would result in `["80","20"]`.',
+            '\n',
+            '**CommaDelimitedList**',
+            '\n',
+            'An array of literal strings that are separated by commas. The total number of strings should be one more than the total number of commas. Also, each member string is space trimmed.',
+            '\n',
+            'For example, users could specify `"test,dev,prod"`, and a Ref would result in `["test","dev","prod"]`.',
+            '\n',
+            '**AWS-specific parameter types**',
+            '\n',
+            'AWS values such as Amazon EC2 key pair names and VPC IDs. For more information, see [Specify existing resources at runtime](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-supplied-parameter-types.html).',
+            '\n',
+            '**Systems Manager parameter types**',
+            '\n',
+            'Parameters that correspond to existing parameters in Systems Manager Parameter Store. You specify a Systems Manager parameter key as the value of the Systems Manager parameter type, and CloudFormation retrieves the latest value from Parameter Store to use for the stack. For more information, see [Specify existing resources at runtime](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-supplied-parameter-types.html).',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'Default',
+        [
+            '**Default**',
+            '\n',
+            '---',
+            'A value of the appropriate type for the template to use if no value is specified when a stack is created. ',
+            'If you define constraints for the parameter, you must specify a value that adheres to those constraints. ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'Description',
+        [
+            '**Description**',
+            '\n',
+            '---',
+            'A string of up to 4000 characters that describes the parameter. ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'AllowedValues',
+        [
+            '**AllowedValues**',
+            '\n',
+            '---',
+            'An array containing the list of values allowed for the parameter. ',
+            'When applied to a parameter of type `String`, the parameter value must be one of the allowed values. ',
+            'When applied to a parameter of type `CommaDelimitedList`, each value in the list must be one of the specified allowed values. ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'AllowedPattern',
+        [
+            '**AllowedPattern**',
+            '\n',
+            '---',
+            'A regular expression that represents the patterns to allow for `String` or `CommaDelimitedList` types. ',
+            'When applied on a parameter of type `String`, the pattern must match the entire parameter value provided. ',
+            'When applied to a parameter of type `CommaDelimitedList`, the pattern must match each value in the list. ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'MinLength',
+        [
+            '**MinLength**',
+            '\n',
+            '---',
+            'An integer value that determines the smallest number of characters you want to allow for `String` types. ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'MaxLength',
+        [
+            '**MaxLength**',
+            '\n',
+            '---',
+            'An integer value that determines the largest number of characters you want to allow for `String` types. ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'MinValue',
+        [
+            '**MinValue**',
+            '\n',
+            '---',
+            'A numeric value that determines the smallest numeric value you want to allow for `Number` types. ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'MaxValue',
+        [
+            '**MaxValue**',
+            '\n',
+            '---',
+            'A numeric value that determines the largest numeric value you want to allow for `Number` types. ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'NoEcho',
+        [
+            '**NoEcho**',
+            '\n',
+            '---',
+            'Whether to mask the parameter value to prevent it from being displayed in the console, command line tools, or API. ',
+            'If you set the NoEcho attribute to true, CloudFormation returns the parameter value masked as asterisks (*****) for any calls that describe the stack or stack events, except for information stored in the locations specified below. ',
+            '\n',
+            '- The `Metadata` template section. CloudFormation does not transform, modify, or redact any information you include in the `Metadata` section. For more information, see [Metadata](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/metadata-section-structure.html).',
+            '- The `Outputs` template section. For more information, see [Outputs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html).',
+            '- The Metadata attribute of a resource definition. For more information, see [Metadata attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-metadata.html).',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    parameterAttributeDocsMap.set(
+        'ConstraintDescription',
+        [
+            '**ConstraintDescription**',
+            '\n',
+            '---',
+            'A string that explains a constraint when the constraint is violated. ',
+            'For example, without a constraint description, a parameter that has an allowed pattern of [A-Za-z0-9]+ displays the following error message when the user specifies an invalid value: ',
+            '\n',
+            'Malformed input-Parameter `MyParameter` must match pattern `[A-Za-z0-9]+` ',
+            '\n',
+            'By adding a constraint description, such as *must only contain letters (uppercase and lowercase) and numbers*, you can display the following customized error message: ',
+            '\n',
+            'Malformed input-Parameter `MyParameter` must only contain uppercase and lowercase letters and numbers ',
+            '\n',
+            '*Required*: No ',
+            '\n',
+            '[Source Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)',
+        ].join('\n'),
+    );
+
+    return parameterAttributeDocsMap;
+}

--- a/src/hover/HoverRouter.ts
+++ b/src/hover/HoverRouter.ts
@@ -13,6 +13,7 @@ import { HoverProvider } from './HoverProvider';
 import { IntrinsicFunctionArgumentHoverProvider } from './IntrinsicFunctionArgumentHoverProvider';
 import { IntrinsicFunctionHoverProvider } from './IntrinsicFunctionHoverProvider';
 import { MappingHoverProvider } from './MappingHoverProvider';
+import { ParameterAttributeHoverProvider } from './ParameterAttributeHoverProvider';
 import { ParameterHoverProvider } from './ParameterHoverProvider';
 import { PseudoParameterHoverProvider } from './PseudoParameterHoverProvider';
 import { ResourceSectionHoverProvider } from './ResourceSectionHoverProvider';
@@ -90,6 +91,12 @@ export class HoverRouter implements Configurable, Closeable {
                 return doc;
             }
         } else if (context.section === TopLevelSection.Parameters) {
+            if (this.isParameterAttribute(context)) {
+                const doc = this.hoverProviderMap.get(HoverType.ParameterAttribute)?.getInformation(context);
+                if (doc) {
+                    return doc;
+                }
+            }
             const doc = this.hoverProviderMap.get(HoverType.Parameter)?.getInformation(context);
             if (doc) {
                 return doc;
@@ -104,12 +111,21 @@ export class HoverRouter implements Configurable, Closeable {
         hoverProviderMap.set(HoverType.TopLevelSection, new TemplateSectionHoverProvider());
         hoverProviderMap.set(HoverType.ResourceSection, new ResourceSectionHoverProvider(schemaRetriever));
         hoverProviderMap.set(HoverType.Parameter, new ParameterHoverProvider());
+        hoverProviderMap.set(HoverType.ParameterAttribute, new ParameterAttributeHoverProvider());
         hoverProviderMap.set(HoverType.PseudoParameter, new PseudoParameterHoverProvider());
         hoverProviderMap.set(HoverType.Condition, new ConditionHoverProvider());
         hoverProviderMap.set(HoverType.Mapping, new MappingHoverProvider());
         hoverProviderMap.set(HoverType.IntrinsicFunction, new IntrinsicFunctionHoverProvider());
         hoverProviderMap.set(HoverType.IntrinsicFunctionArgument, new IntrinsicFunctionArgumentHoverProvider());
         return hoverProviderMap;
+    }
+
+    private isParameterAttribute(context: Context): boolean {
+        if (context.section !== TopLevelSection.Parameters) {
+            return false;
+        }
+
+        return ParameterAttributeHoverProvider.isParameterAttribute(context.text);
     }
 
     private getTopLevelReference(context: ContextWithRelatedEntities): string | undefined {
@@ -153,6 +169,7 @@ enum HoverType {
     IntrinsicFunction,
     IntrinsicFunctionArgument,
     Parameter,
+    ParameterAttribute,
     PseudoParameter,
     Condition,
     Mapping,

--- a/src/hover/ParameterAttributeHoverProvider.ts
+++ b/src/hover/ParameterAttributeHoverProvider.ts
@@ -1,0 +1,33 @@
+import { parameterAttributeDocsMap } from '../artifacts/ParameterAttributeDocs';
+import { Context } from '../context/Context';
+import { HoverProvider } from './HoverProvider';
+
+export class ParameterAttributeHoverProvider implements HoverProvider {
+    private static readonly PARAMETER_ATTRIBUTES = new Set([
+        'AllowedPattern',
+        'AllowedValues',
+        'ConstraintDescription',
+        'Default',
+        'Description',
+        'MaxLength',
+        'MaxValue',
+        'MinLength',
+        'MinValue',
+        'NoEcho',
+        'Type',
+    ]);
+
+    getInformation(context: Context): string | undefined {
+        const attributeName = context.text;
+
+        if (!ParameterAttributeHoverProvider.PARAMETER_ATTRIBUTES.has(attributeName)) {
+            return undefined;
+        }
+
+        return parameterAttributeDocsMap.get(attributeName);
+    }
+
+    static isParameterAttribute(text: string): boolean {
+        return ParameterAttributeHoverProvider.PARAMETER_ATTRIBUTES.has(text);
+    }
+}

--- a/tst/e2e/hover/Hover.test.ts
+++ b/tst/e2e/hover/Hover.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { intrinsicFunctionsDocsMap } from '../../../src/artifacts/IntrinsicFunctionsDocs';
+import { parameterAttributeDocsMap } from '../../../src/artifacts/ParameterAttributeDocs';
 import { pseudoParameterDocsMap } from '../../../src/artifacts/PseudoParameterDocs';
 import { resourceAttributeDocsMap } from '../../../src/artifacts/ResourceAttributeDocs';
 import { templateSectionDocsMap } from '../../../src/artifacts/TemplateSectionDocs';
@@ -157,6 +158,126 @@ Parameters:
                             position: { line: 31, character: 5 },
                             expectation: HoverExpectationBuilder.create()
                                 .expectContainsText(['**Type:** String', '**Default Value:** "production"'])
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on Type Parameter Atribute',
+                        verification: {
+                            position: { line: 32, character: 6 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('Type'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on Default Parameter Atribute',
+                        verification: {
+                            position: { line: 33, character: 8 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('Default'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on AllowedValues Parameter Atribute',
+                        verification: {
+                            position: { line: 34, character: 10 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('AllowedValues'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on ConstraintDescription Parameter Atribute',
+                        verification: {
+                            position: { line: 35, character: 10 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('ConstraintDescription'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on NoEcho Parameter Atribute',
+                        verification: {
+                            position: { line: 48, character: 9 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('NoEcho'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on MinLength Parameter Atribute',
+                        verification: {
+                            position: { line: 49, character: 9 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('MinLength'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on MaxLength Parameter Atribute',
+                        verification: {
+                            position: { line: 50, character: 9 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('MaxLength'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on MinValue Parameter Atribute',
+                        verification: {
+                            position: { line: 55, character: 9 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('MinValue'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on MaxValue Parameter Atribute',
+                        verification: {
+                            position: { line: 56, character: 9 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('MaxValue'))
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: ``,
+                        position: { line: 69, character: 36 },
+                        description: 'Hover on Description Parameter Atribute',
+                        verification: {
+                            position: { line: 60, character: 9 },
+                            expectation: HoverExpectationBuilder.create()
+                                .expectContent(parameterAttributeDocsMap.get('Description'))
                                 .build(),
                         },
                     },

--- a/tst/unit/hover/ParameterAttributeHoverProvider.test.ts
+++ b/tst/unit/hover/ParameterAttributeHoverProvider.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import { TopLevelSection } from '../../../src/context/ContextType';
+import { ParameterAttributeHoverProvider } from '../../../src/hover/ParameterAttributeHoverProvider';
+import { createMockContext } from '../../utils/MockContext';
+
+describe('ParameterAttributeHoverProvider', () => {
+    const parameterAttributeHoverProvider = new ParameterAttributeHoverProvider();
+
+    describe('Parameter Attribute Hover', () => {
+        it('should return Type documentation when hovering on Type attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'Type',
+                propertyPath: ['Parameters', 'MyParam', 'Type'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**Type**');
+            expect(result).toContain('The data type for the parameter');
+            expect(result).toContain('**String**');
+            expect(result).toContain('**Number**');
+            expect(result).toContain('**CommaDelimitedList**');
+            expect(result).toContain('AWS-specific parameter types');
+        });
+
+        it('should return Default documentation when hovering on Default attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'Default',
+                propertyPath: ['Parameters', 'MyParam', 'Default'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**Default**');
+            expect(result).toContain(
+                'A value of the appropriate type for the template to use if no value is specified when a stack is created',
+            );
+            expect(result).toContain('*Required*: No');
+        });
+
+        it('should return Description documentation when hovering on Description attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'Description',
+                propertyPath: ['Parameters', 'MyParam', 'Description'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**Description**');
+            expect(result).toContain('A string of up to 4000 characters that describes the parameter');
+            expect(result).toContain('*Required*: No');
+        });
+
+        it('should return AllowedValues documentation when hovering on AllowedValues attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'AllowedValues',
+                propertyPath: ['Parameters', 'MyParam', 'AllowedValues'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**AllowedValues**');
+            expect(result).toContain('An array containing the list of values allowed for the parameter');
+            expect(result).toContain(
+                'When applied to a parameter of type `String`, the parameter value must be one of the allowed values',
+            );
+        });
+
+        it('should return AllowedPattern documentation when hovering on AllowedPattern attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'AllowedPattern',
+                propertyPath: ['Parameters', 'MyParam', 'AllowedPattern'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**AllowedPattern**');
+            expect(result).toContain(
+                'A regular expression that represents the patterns to allow for `String` or `CommaDelimitedList` types',
+            );
+            expect(result).toContain(
+                'When applied on a parameter of type `String`, the pattern must match the entire parameter value provided',
+            );
+        });
+
+        it('should return MinLength documentation when hovering on MinLength attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'MinLength',
+                propertyPath: ['Parameters', 'MyParam', 'MinLength'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**MinLength**');
+            expect(result).toContain(
+                'An integer value that determines the smallest number of characters you want to allow for `String` types',
+            );
+            expect(result).toContain('*Required*: No');
+        });
+
+        it('should return MaxLength documentation when hovering on MaxLength attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'MaxLength',
+                propertyPath: ['Parameters', 'MyParam', 'MaxLength'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**MaxLength**');
+            expect(result).toContain(
+                'An integer value that determines the largest number of characters you want to allow for `String` types',
+            );
+            expect(result).toContain('*Required*: No');
+        });
+
+        it('should return MinValue documentation when hovering on MinValue attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'MinValue',
+                propertyPath: ['Parameters', 'MyParam', 'MinValue'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**MinValue**');
+            expect(result).toContain(
+                'A numeric value that determines the smallest numeric value you want to allow for `Number` types',
+            );
+            expect(result).toContain('*Required*: No');
+        });
+
+        it('should return MaxValue documentation when hovering on MaxValue attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'MaxValue',
+                propertyPath: ['Parameters', 'MyParam', 'MaxValue'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**MaxValue**');
+            expect(result).toContain(
+                'A numeric value that determines the largest numeric value you want to allow for `Number` types',
+            );
+            expect(result).toContain('*Required*: No');
+        });
+
+        it('should return NoEcho documentation when hovering on NoEcho attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'NoEcho',
+                propertyPath: ['Parameters', 'MyParam', 'NoEcho'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**NoEcho**');
+            expect(result).toContain(
+                'Whether to mask the parameter value to prevent it from being displayed in the console, command line tools, or API',
+            );
+            expect(result).toContain('CloudFormation returns the parameter value masked as asterisks');
+        });
+
+        it('should return ConstraintDescription documentation when hovering on ConstraintDescription attribute', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'ConstraintDescription',
+                propertyPath: ['Parameters', 'MyParam', 'ConstraintDescription'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toContain('**ConstraintDescription**');
+            expect(result).toContain('A string that explains a constraint when the constraint is violated');
+            expect(result).toContain('Malformed input-Parameter `MyParameter` must match pattern');
+        });
+
+        it('should return undefined for non-parameter attributes', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: 'InvalidAttribute',
+                propertyPath: ['Parameters', 'MyParam', 'InvalidAttribute'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toBeUndefined();
+        });
+
+        it('should return undefined for empty text', () => {
+            const mockContext = createMockContext(TopLevelSection.Parameters, 'MyParam', {
+                text: '',
+                propertyPath: ['Parameters', 'MyParam'],
+            });
+
+            const result = parameterAttributeHoverProvider.getInformation(mockContext);
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('isParameterAttribute static method', () => {
+        it('should return true for valid parameter attributes', () => {
+            const validAttributes = [
+                'Type',
+                'Default',
+                'Description',
+                'AllowedValues',
+                'AllowedPattern',
+                'MinLength',
+                'MaxLength',
+                'MinValue',
+                'MaxValue',
+                'NoEcho',
+                'ConstraintDescription',
+            ];
+
+            for (const attribute of validAttributes) {
+                expect(ParameterAttributeHoverProvider.isParameterAttribute(attribute)).toBe(true);
+            }
+        });
+
+        it('should return false for invalid parameter attributes', () => {
+            const invalidAttributes = [
+                'InvalidAttribute',
+                'Properties',
+                'Condition',
+                'DependsOn',
+                'type',
+                'default',
+                '',
+            ];
+
+            for (const attribute of invalidAttributes) {
+                expect(ParameterAttributeHoverProvider.isParameterAttribute(attribute)).toBe(false);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Added hover documentation support for CloudFormation parameter attributes (Type, Default, Description, etc.) in the Parameters section. This enhancement provides users with detailed information about each parameter attribute directly in the editor, improving the template authoring experience.