### PR TITLE
fix: Referencing a parameter with the same name as the property attribute

### DIFF
--- a/src/hover/HoverRouter.ts
+++ b/src/hover/HoverRouter.ts
@@ -85,7 +85,7 @@ export class HoverRouter implements Configurable, Closeable {
             return this.hoverProviderMap.get(HoverType.IntrinsicFunction)?.getInformation(context);
         } else if (context.isPseudoParameter) {
             return this.hoverProviderMap.get(HoverType.PseudoParameter)?.getInformation(context);
-        } else if (context.section === TopLevelSection.Resources&& !context.intrinsicContext.inIntrinsic()) {
+        } else if (context.section === TopLevelSection.Resources && !context.intrinsicContext.inIntrinsic()) {
             const doc = this.hoverProviderMap.get(HoverType.ResourceSection)?.getInformation(context);
             if (doc) {
                 return doc;

--- a/tst/e2e/hover/Hover.test.ts
+++ b/tst/e2e/hover/Hover.test.ts
@@ -2007,9 +2007,7 @@ Resources:
                         description: 'Test invalid parameter reference hover should return undefined',
                         verification: {
                             position: { line: 7, character: 30 }, // Position on "NonExistentParam" in !Ref NonExistentParam
-                            expectation: HoverExpectationBuilder.create()
-                                .expectUndefined()
-                                .build(),
+                            expectation: HoverExpectationBuilder.create().expectUndefined().build(),
                         },
                     },
                 ],


### PR DESCRIPTION
- Resolves an edge case where if the reference matched the property attribute name and didn't have a matching parameter, it would hover as if it was an attribute and not as a reference. Example:
```
AWSTemplateFormatVersion: '2010-09-09'
# Parameters:
#   BucketName:
#     Type: String
Resources:
  MyBucket:
    Type: AWS::S3::Bucket
    Properties:
      BucketName: !Ref BucketName
```
Since the parameter "BucketName" is commented out, BucketName inside !Ref was still showing attribute info on hover instead of nothing
- added a condition to check if we're inside an intrinsic function when determining hover behavior in the Resources section. This prevents incorrect hover information from appearing when a parameter has the same name as a property attribute.