### PR TITLE
rename resource state requests and methods

### DIFF
--- a/src/handlers/ResourceHandler.ts
+++ b/src/handlers/ResourceHandler.ts
@@ -1,12 +1,12 @@
 import { ServerRequestHandler } from 'vscode-languageserver';
 import {
-    GetResourceTypesResult,
+    ResourceTypesResult,
     ListResourcesParams,
     ListResourcesResult,
-    RefreshResourceListParams,
-    RefreshResourceListResult,
-    ResourceStateImportParams,
-    ResourceStateImportResult,
+    RefreshResourcesParams,
+    RefreshResourcesResult,
+    ResourceStateParams,
+    ResourceStateResult,
     ResourceSummary,
 } from '../resourceState/ResourceStateTypes';
 import { ServerComponents } from '../server/ServerComponents';
@@ -17,8 +17,8 @@ const log = LoggerFactory.getLogger('ResourceHandler');
 
 export function getResourceTypesHandler(
     components: ServerComponents,
-): ServerRequestHandler<void, GetResourceTypesResult, never, void> {
-    return (): GetResourceTypesResult => {
+): ServerRequestHandler<void, ResourceTypesResult, never, void> {
+    return (): ResourceTypesResult => {
         try {
             const resourceTypes = components.resourceStateManager.getResourceTypes();
             return { resourceTypes };
@@ -61,16 +61,16 @@ export function listResourcesHandler(
 
 export function importResourceStateHandler(
     components: ServerComponents,
-): ServerRequestHandler<ResourceStateImportParams, ResourceStateImportResult, never, void> {
-    return async (params: ResourceStateImportParams): Promise<ResourceStateImportResult> => {
+): ServerRequestHandler<ResourceStateParams, ResourceStateResult, never, void> {
+    return async (params: ResourceStateParams): Promise<ResourceStateResult> => {
         return await components.resourceStateImporter.importResourceState(params);
     };
 }
 
 export function refreshResourceListHandler(
     components: ServerComponents,
-): ServerRequestHandler<RefreshResourceListParams, RefreshResourceListResult, never, void> {
-    return async (params: RefreshResourceListParams): Promise<RefreshResourceListResult> => {
+): ServerRequestHandler<RefreshResourcesParams, RefreshResourcesResult, never, void> {
+    return async (params: RefreshResourcesParams): Promise<RefreshResourcesResult> => {
         try {
             const timeout = new Promise<never>((resolve, reject) =>
                 setTimeout(() => reject(new Error('Resource list refresh timed out')), 30_000),

--- a/src/protocol/LspResourceHandlers.ts
+++ b/src/protocol/LspResourceHandlers.ts
@@ -1,16 +1,16 @@
 import { Connection, ServerRequestHandler } from 'vscode-languageserver';
 import {
-    GetResourceTypesResult,
-    GetResourceTypesRequest,
+    ResourceTypesResult,
+    ResourceTypesRequest,
     ListResourcesParams,
     ListResourcesResult,
     ListResourcesRequest,
-    ResourceStateImportParams,
-    ResourceStateImportResult,
-    ResourceStateImportRequest,
+    ResourceStateParams,
+    ResourceStateResult,
+    ResourceStateRequest,
     RefreshResourceListRequest,
-    RefreshResourceListParams,
-    RefreshResourceListResult,
+    RefreshResourcesParams,
+    RefreshResourcesResult,
 } from '../resourceState/ResourceStateTypes';
 
 export class LspResourceHandlers {
@@ -20,19 +20,15 @@ export class LspResourceHandlers {
         this.connection.onRequest(ListResourcesRequest.method, handler);
     }
 
-    onRefreshResourceList(
-        handler: ServerRequestHandler<RefreshResourceListParams, RefreshResourceListResult, never, void>,
-    ) {
+    onRefreshResourceList(handler: ServerRequestHandler<RefreshResourcesParams, RefreshResourcesResult, never, void>) {
         this.connection.onRequest(RefreshResourceListRequest.method, handler);
     }
 
-    onGetResourceTypes(handler: ServerRequestHandler<void, GetResourceTypesResult, never, void>) {
-        this.connection.onRequest(GetResourceTypesRequest.method, handler);
+    onGetResourceTypes(handler: ServerRequestHandler<void, ResourceTypesResult, never, void>) {
+        this.connection.onRequest(ResourceTypesRequest.method, handler);
     }
 
-    onResourceStateImport(
-        handler: ServerRequestHandler<ResourceStateImportParams, ResourceStateImportResult, never, void>,
-    ) {
-        this.connection.onRequest(ResourceStateImportRequest.method, handler);
+    onResourceStateImport(handler: ServerRequestHandler<ResourceStateParams, ResourceStateResult, never, void>) {
+        this.connection.onRequest(ResourceStateRequest.method, handler);
     }
 }

--- a/src/resourceState/ResourceStateImporter.ts
+++ b/src/resourceState/ResourceStateImporter.ts
@@ -16,8 +16,8 @@ import { ResourceStateManager } from './ResourceStateManager';
 import {
     ResourceIdentifier,
     ResourceSelection,
-    ResourceStateImportParams,
-    ResourceStateImportResult,
+    ResourceStateParams,
+    ResourceStateResult,
     ResourceTemplateFormat,
     ResourceType,
 } from './ResourceStateTypes';
@@ -39,7 +39,7 @@ export class ResourceStateImporter {
         private readonly stackManagementInfoProvider: StackManagementInfoProvider,
     ) {}
 
-    public async importResourceState(params: ResourceStateImportParams): Promise<ResourceStateImportResult> {
+    public async importResourceState(params: ResourceStateParams): Promise<ResourceStateResult> {
         const { resourceSelections, textDocument } = params;
         if (!resourceSelections) {
             return this.getFailureResponse('No resources selected for import.');
@@ -86,9 +86,9 @@ export class ResourceStateImporter {
     private async getResourceStates(
         resourceSelections: ResourceSelection[],
         syntaxTree: SyntaxTree,
-    ): Promise<{ fetchedResourceStates: ResourceTemplateFormat[]; importResult: ResourceStateImportResult }> {
+    ): Promise<{ fetchedResourceStates: ResourceTemplateFormat[]; importResult: ResourceStateResult }> {
         const fetchedResourceStates: ResourceTemplateFormat[] = [];
-        const importResult: ResourceStateImportResult = {
+        const importResult: ResourceStateResult = {
             title: 'Resource State Import',
             failedImports: {},
             successfulImports: {},
@@ -296,7 +296,7 @@ export class ResourceStateImporter {
         title: string,
         successfulImports?: Record<ResourceType, ResourceIdentifier[]>,
         failedImports?: Record<ResourceType, ResourceIdentifier[]>,
-    ): ResourceStateImportResult {
+    ): ResourceStateResult {
         return {
             title: title,
             successfulImports: successfulImports ?? {},

--- a/src/resourceState/ResourceStateManager.ts
+++ b/src/resourceState/ResourceStateManager.ts
@@ -7,7 +7,7 @@ import { DefaultSettings, ProfileSettings, SettingsSubscription } from '../setti
 import { SettingsManager } from '../settings/SettingsManager';
 import { ClientMessage } from '../telemetry/ClientMessage';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { ListResourcesResult, RefreshResourceListResult } from './ResourceStateTypes';
+import { ListResourcesResult, RefreshResourcesResult } from './ResourceStateTypes';
 
 const log = LoggerFactory.getLogger('ResourceStateManager');
 
@@ -140,7 +140,7 @@ export class ResourceStateManager implements Configurable, Closeable {
         };
     }
 
-    public async refreshResourceList(resourceTypes: string[]): Promise<RefreshResourceListResult> {
+    public async refreshResourceList(resourceTypes: string[]): Promise<RefreshResourcesResult> {
         if (this.isRefreshing) {
             // return cached resource list
             return {

--- a/src/resourceState/ResourceStateTypes.ts
+++ b/src/resourceState/ResourceStateTypes.ts
@@ -2,14 +2,14 @@ import { CodeAction, CodeActionParams } from 'vscode-languageserver';
 import { RequestType } from 'vscode-languageserver-protocol';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export type GetResourceTypesParams = {};
+export type ResourceTypesParams = {};
 
-export type GetResourceTypesResult = {
+export type ResourceTypesResult = {
     resourceTypes: string[];
 };
 
-export const GetResourceTypesRequest = new RequestType<GetResourceTypesParams, GetResourceTypesResult, void>(
-    'aws/cfn/resourceTypes',
+export const ResourceTypesRequest = new RequestType<ResourceTypesParams, ResourceTypesResult, void>(
+    'aws/cfn/resources/types',
 );
 
 export type ResourceSelection = {
@@ -17,17 +17,17 @@ export type ResourceSelection = {
     resourceIdentifiers: string[];
 };
 
-export interface ResourceStateImportParams extends CodeActionParams {
+export interface ResourceStateParams extends CodeActionParams {
     resourceSelections?: ResourceSelection[];
 }
 
-export interface ResourceStateImportResult extends CodeAction {
+export interface ResourceStateResult extends CodeAction {
     successfulImports: Record<ResourceType, ResourceIdentifier[]>;
     failedImports: Record<ResourceType, ResourceIdentifier[]>;
 }
 
-export const ResourceStateImportRequest = new RequestType<ResourceStateImportParams, ResourceStateImportResult, void>(
-    'aws/cfn/resourceStateImport',
+export const ResourceStateRequest = new RequestType<ResourceStateParams, ResourceStateResult, void>(
+    'aws/cfn/resources/state',
 );
 
 export type ResourceType = string;
@@ -48,20 +48,20 @@ export type ListResourcesResult = {
 };
 
 export const ListResourcesRequest = new RequestType<ListResourcesParams, ListResourcesResult, void>(
-    'aws/cfn/resources',
+    'aws/cfn/resources/list',
 );
 
-export type RefreshResourceListParams = {
+export type RefreshResourcesParams = {
     resourceTypes: string[];
 };
 
-export type RefreshResourceListResult = {
+export type RefreshResourcesResult = {
     resources: ResourceSummary[];
     refreshFailed: boolean;
 };
 
-export const RefreshResourceListRequest = new RequestType<RefreshResourceListParams, RefreshResourceListResult, void>(
-    'aws/cfn/refreshResourceList',
+export const RefreshResourceListRequest = new RequestType<RefreshResourcesParams, RefreshResourcesResult, void>(
+    'aws/cfn/resources/refresh',
 );
 
 export interface ResourceTemplateFormat {

--- a/tst/unit/resourceState/ResourceStateImporter.test.ts
+++ b/tst/unit/resourceState/ResourceStateImporter.test.ts
@@ -5,7 +5,7 @@ import { SyntaxTreeManager } from '../../../src/context/syntaxtree/SyntaxTreeMan
 import { DocumentType } from '../../../src/document/Document';
 import { DocumentManager } from '../../../src/document/DocumentManager';
 import { ResourceStateImporter } from '../../../src/resourceState/ResourceStateImporter';
-import { ResourceSelection, ResourceStateImportParams } from '../../../src/resourceState/ResourceStateTypes';
+import { ResourceSelection, ResourceStateParams } from '../../../src/resourceState/ResourceStateTypes';
 import {
     createMockClientMessage,
     createMockSchemaRetriever,
@@ -159,7 +159,7 @@ Resources:
             });
 
             // Execute the import
-            const params: ResourceStateImportParams = {
+            const params: ResourceStateParams = {
                 resourceSelections,
                 textDocument: { uri },
                 range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
@@ -222,7 +222,7 @@ Resources:
     // Test cases for failure scenarios
     describe('Failure scenarios', () => {
         it('should return failure when no resources are selected', async () => {
-            const params: ResourceStateImportParams = {
+            const params: ResourceStateParams = {
                 resourceSelections: undefined as any,
                 textDocument: { uri: 'test://test.template' },
                 range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
@@ -238,7 +238,7 @@ Resources:
         });
 
         it('should return failure when document is not found', async () => {
-            const params: ResourceStateImportParams = {
+            const params: ResourceStateParams = {
                 resourceSelections: [
                     {
                         resourceType: 'AWS::S3::Bucket',
@@ -266,7 +266,7 @@ Resources:
             const textDocument = TextDocument.create(uri, 'json', 1, content);
             (documentManager as any).documents._syncedDocuments.set(uri, textDocument);
 
-            const params: ResourceStateImportParams = {
+            const params: ResourceStateParams = {
                 resourceSelections: [
                     {
                         resourceType: 'AWS::S3::Bucket',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- aligning naming with best practices
- removing 'import' and using state in preparation to support two workflows: clone and import

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
