### PR TITLE
Only support available runner os and arch. Fix build process bugs

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,4 +1,5 @@
 name: Release Beta
+run-name: Release Beta ${{ inputs.version }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ on:
 
       ref:
         description: 'The Git ref to checkout.'
-        required: false
+        required: true
         type: string
 
 jobs:
@@ -25,6 +25,9 @@ jobs:
     uses: ./.github/workflows/configs.yml
 
   build-test-nodejs:
+    permissions:
+      contents: read
+      pull-requests: write
     needs: [get-configs]
     runs-on: ${{ inputs.runs-on }}
     steps:
@@ -36,24 +39,43 @@ jobs:
         shell: bash
         run: echo "Checked out commit ${{ github.sha }} on ref ${{ github.ref_name }}"
 
-      - name: Setup Node.js ${{ needs.get-configs.outputs.node-version }} ${{ inputs.runs-on }} (${{ inputs.arch }})
+      - name: Setup Node.js ${{ needs.get-configs.outputs.node-version }} (${{ inputs.runs-on }}-${{ inputs.arch }})
         uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.get-configs.outputs.node-version }}
           cache: 'npm'
-          architecture: ${{ needs.get-configs.outputs.arch }}
+          architecture: ${{ inputs.arch }}
 
       - name: Install Dependencies
         run: npm ci
-      
-      - name: Lint
-        run: npm run lint
 
       - name: Build
         run: npm run build
 
-      - name: Test
-        run: npm run test
+      - name: Lint and Test
+        if: runner.os != 'Windows'
+        run: npm run lint && npm run test
+
+      - name: Code Coverage
+        if: runner.os != 'Windows' && github.event_name == 'pull_request'
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage/**/cobertura-coverage.xml
+          badge: false
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: false
+          indicators: true
+          output: both
+          thresholds: '80 85'
+
+      - name: Add Coverage PR Comment
+        if: runner.os != 'Windows' && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          recreate: true
+          path: code-coverage-results.md
 
   build-test-go:
     needs: [get-configs]
@@ -68,14 +90,16 @@ jobs:
         shell: bash
         run: echo "Checked out commit ${{ github.sha }} on ref ${{ github.ref_name }}"
 
-      - name: Setup Go ${{ needs.get-configs.outputs.go-version }} ${{ inputs.runs-on }} (${{ inputs.arch }})
+      - name: Setup Go ${{ needs.get-configs.outputs.go-version }} (${{ inputs.runs-on }}-${{ inputs.arch }})
         uses: actions/setup-go@v4
         with:
           go-version: ${{ needs.get-configs.outputs.go-version }}
           cache: true
 
       - name: Build
+        shell: bash
         run: GOPROXY=direct go build -C ./cfn-init ./...
 
       - name: Test
+        shell: bash
         run: GOPROXY=direct go test -C ./cfn-init -v -cover ./...

--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -19,10 +19,10 @@ jobs:
           JSON_STRING=$(cat <<EOF
           {
             "include": [
-              { "os": "ubuntu-latest", "arch": "x64", "runner": "ubuntu-latest" },
-              { "os": "ubuntu-latest", "arch": "arm64", "runner": "ubuntu-latest" },
-              { "os": "macos-latest", "arch": "x64", "runner": "macos-latest" },
-              { "os": "macos-latest", "arch": "arm64", "runner": "macos-latest" },
+              { "runner": "ubuntu-24.04", "arch": "x64" },
+              { "runner": "macos-15", "arch": "x64" },
+              { "runner": "macos-15", "arch": "arm64" },
+              { "runner": "windows-2022", "arch": "x64" },
             ]
           }
           EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Main branch CI
+name: Main CI
 
 on:
   push:
@@ -9,3 +9,8 @@ on:
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-and-test.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      ref: ${{ github.sha }}

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -1,4 +1,5 @@
 name: Release Prod
+run-name: Release Prod ${{ inputs.version }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release ${{ inputs.tag }}
 
 on:
   workflow_call:
@@ -80,14 +81,14 @@ jobs:
         with:
           ref: ${{ needs.version-and-tag.outputs.tag }}
 
-      - name: Setup Node.js ${{ needs.get-configs.outputs.node-version }} ${{ matrix.runner }} (${{ matrix.arch }})
+      - name: Setup Node.js ${{ needs.get-configs.outputs.node-version }} (${{ matrix.runner }}-${{ matrix.arch }})
         uses: actions/setup-node@v4
         with:
           node-version: ${{ needs.get-configs.outputs.node-version }}
           cache: 'npm'
           architecture: ${{ matrix.arch }}
 
-      - name: Setup Go ${{ needs.get-configs.outputs.go-version }} ${{ matrix.runner }} (${{ matrix.arch }})
+      - name: Setup Go ${{ needs.get-configs.outputs.go-version }} (${{ matrix.runner }}-${{ matrix.arch }})
         uses: actions/setup-go@v4
         with:
           go-version: ${{ needs.get-configs.outputs.go-version }}
@@ -106,6 +107,7 @@ jobs:
           fi
 
       # - name: Bundle Go
+        # shell: bash
         # run: npm run build:go:prod
 
       - name: Set release asset name
@@ -114,31 +116,38 @@ jobs:
         run: |
           APP_NAME=${{ needs.get-configs.outputs.app-name }}
           VERSION=${{ needs.version-and-tag.outputs.tag }}
-          OS=${{ matrix.os }}
+          OS=${{ matrix.runner }}
           ARCH=${{ matrix.arch }}
 
           ASSET_NAME="${APP_NAME}-${VERSION}-${OS}-${ARCH}.zip"
           echo "ASSET_NAME=${ASSET_NAME}"
           echo "ASSET_NAME=${ASSET_NAME}" >> $GITHUB_OUTPUT
-          echo "ASSET_PATH=./${ASSET_NAME}" >> $GITHUB_OUTPUT
-      
-      - name: Create Zip 
-        shell: bash
+
+      - name: Create Zip (Unix)
+        if: runner.os != 'Windows'
         env:
           ASSET_NAME: ${{ steps.set-asset-name.outputs.ASSET_NAME }}
         run: |
-          echo "Creating zip: $ASSET_NAME"
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            powershell -Command "Compress-Archive -Path 'bundle/production/*' -DestinationPath '$env:ASSET_NAME'"
-          else
-            zip -r "$ASSET_NAME" bundle/production
-          fi
+          echo "Creating zip: ${{ env.ASSET_NAME }}"
+          (cd ./bundle/production && zip -r ../../${{ env.ASSET_NAME }} .)
+          ls -la
+
+      - name: Create Zip (Windows)
+        if: runner.os == 'Windows'
+        env:
+          ASSET_NAME: ${{ steps.set-asset-name.outputs.ASSET_NAME }}
+        run: |
+          echo "Creating zip: ${{ env.ASSET_NAME }}"
+          Compress-Archive -Path ./bundle/production/* -DestinationPath ./${{ env.ASSET_NAME }}
+          dir
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
+        env:
+          ASSET_NAME: ${{ steps.set-asset-name.outputs.ASSET_NAME }}
         with:
           tag_name: ${{ needs.version-and-tag.outputs.tag }}
           prerelease: ${{ needs.version-and-tag.outputs.is-prerelease }}
-          files: ${{ steps.set-asset-name.outputs.ASSET_PATH }}
+          files: ${{ env.ASSET_NAME }}
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # AWS CloudFormation Language Server for Code Editors
 
+<div align="center">
+
+[![build](https://github.com/aws-cloudformation/cloudformation-languageserver/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/aws-cloudformation/cloudformation-languageserver/actions/workflows/build-and-test.yml)
+&nbsp;
+[![CodeQL](https://github.com/aws-cloudformation/cloudformation-languageserver/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main)](https://github.com/aws-cloudformation/cloudformation-languageserver/actions/workflows/github-code-scanning/codeql)
+
+</div>
+
 A LSP server implementation that provides intelligent editing support for CloudFormation templates in JSON and YAML formats.
 
 ## Features

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -312,7 +312,6 @@ module.exports = (env = {}) => {
         output: {
             clean: true,
             filename: `[name].js`,
-            chunkFilename: `${BUNDLE_NAME}-[name]-[contenthash].js`,
             path: outputPath,
             library: {
                 type: 'commonjs2',


### PR DESCRIPTION
* Fix naming for workflows
* Fix architecture for nodejs - properly use the `arch` from build matrix
* Skip linting and tests in Windows because it has issues with Line Endings (CRLF vs LF) - which breaks our template tests with line numbers
* Only use available GitHub os + arch images - https://github.com/actions/runner-images
* Make webpack only output a single standalone js (will be needed later for online downloading the server bundle)

Workflows generate https://github.com/aws-cloudformation/cloudformation-languageserver/releases/tag/v0.0.1-beta
