### PR TITLE
clone resource state

### DIFF
--- a/src/autocomplete/ResourceStateCompletionProvider.ts
+++ b/src/autocomplete/ResourceStateCompletionProvider.ts
@@ -13,6 +13,7 @@ import { CfnValue } from '../context/semantic/SemanticTypes';
 import { DocumentType } from '../document/Document';
 import { DocumentManager } from '../document/DocumentManager';
 import { ResourceStateManager } from '../resourceState/ResourceStateManager';
+import { ResourceStatePurpose } from '../resourceState/ResourceStateTypes';
 import { ResourceSchema } from '../schema/ResourceSchema';
 import { SchemaRetriever } from '../schema/SchemaRetriever';
 import { TransformersUtil } from '../schema/transformers/TransformersUtil';
@@ -25,7 +26,7 @@ import { createCompletionItem, handleSnippetJsonQuotes } from './CompletionUtils
 const log = LoggerFactory.getLogger('ResourceStateCompletionProvider');
 
 export class ResourceStateCompletionProvider implements CompletionProvider, Configurable, Closeable {
-    private readonly transformers = TransformersUtil.createTransformers();
+    private readonly transformers = TransformersUtil.createTransformers(ResourceStatePurpose.IMPORT);
     private editorSettings: EditorSettings = DefaultSettings.editor;
     private editorSettingsSubscription?: SettingsSubscription;
 

--- a/src/resourceState/ResourceStateTypes.ts
+++ b/src/resourceState/ResourceStateTypes.ts
@@ -17,8 +17,18 @@ export type ResourceSelection = {
     resourceIdentifiers: string[];
 };
 
+/*
+ * Import purpose is to move an existing resource to be managed by a stack
+ * Clone purpose is to create a new resource using the configuration of an existing resource as a reference
+ */
+export enum ResourceStatePurpose {
+    IMPORT = 'Import',
+    CLONE = 'Clone',
+}
+
 export interface ResourceStateParams extends CodeActionParams {
     resourceSelections?: ResourceSelection[];
+    purpose: ResourceStatePurpose;
 }
 
 export interface ResourceStateResult extends CodeAction {

--- a/src/schema/transformers/ReplacePrimaryIdentifierTransformer.ts
+++ b/src/schema/transformers/ReplacePrimaryIdentifierTransformer.ts
@@ -1,0 +1,43 @@
+import { ResourceSchema } from '../ResourceSchema';
+import { ResourceTemplateTransformer } from './ResourceTemplateTransformer';
+
+export class ReplacePrimaryIdentifierTransformer implements ResourceTemplateTransformer {
+    private static readonly CLONE_PLACEHOLDER = '<CLONE INPUT REQUIRED>';
+
+    transform(resourceProperties: Record<string, unknown>, schema: ResourceSchema): void {
+        if (!schema.primaryIdentifier || schema.primaryIdentifier.length === 0) {
+            return;
+        }
+
+        for (const identifierPath of schema.primaryIdentifier) {
+            this.replacePrimaryIdentifierProperty(resourceProperties, identifierPath);
+        }
+    }
+
+    private replacePrimaryIdentifierProperty(properties: Record<string, unknown>, propertyPath: string): void {
+        // Handle nested property paths like "/properties/BucketName"
+        const pathParts = propertyPath.split('/').filter((part) => part !== '' && part !== 'properties');
+
+        if (pathParts.length === 0) {
+            return;
+        }
+
+        let current = properties;
+
+        // Navigate to the parent of the target property
+        for (let i = 0; i < pathParts.length - 1; i++) {
+            const part = pathParts[i];
+            if (current[part] && typeof current[part] === 'object') {
+                current = current[part] as Record<string, unknown>;
+            } else {
+                return; // Path doesn't exist
+            }
+        }
+
+        // Replace the final property with placeholder
+        const finalProperty = pathParts[pathParts.length - 1];
+        if (finalProperty in current) {
+            current[finalProperty] = ReplacePrimaryIdentifierTransformer.CLONE_PLACEHOLDER;
+        }
+    }
+}

--- a/src/schema/transformers/TransformersUtil.ts
+++ b/src/schema/transformers/TransformersUtil.ts
@@ -1,20 +1,26 @@
+import { ResourceStatePurpose } from '../../resourceState/ResourceStateTypes';
 import { RemoveMutuallyExclusivePropertiesTransformer } from './RemoveMutuallyExclusivePropertiesTransformer';
 import { RemoveReadonlyPropertiesTransformer } from './RemoveReadonlyPropertiesTransformer';
 import { RemoveSystemTagsTransformer } from './RemoveSystemTagsTransformer';
+import { ReplacePrimaryIdentifierTransformer } from './ReplacePrimaryIdentifierTransformer';
 import type { ResourceTemplateTransformer } from './ResourceTemplateTransformer';
 
-/**
- * Utility class for managing resource template transformers
- */
 export class TransformersUtil {
-    /**
-     * Creates an array of transformers for resource template processing
-     */
-    public static createTransformers(): ResourceTemplateTransformer[] {
-        return [
-            new RemoveReadonlyPropertiesTransformer(),
-            new RemoveMutuallyExclusivePropertiesTransformer(),
-            new RemoveSystemTagsTransformer(),
-        ];
+    public static createTransformers(purpose: ResourceStatePurpose): ResourceTemplateTransformer[] {
+        if (purpose === ResourceStatePurpose.IMPORT) {
+            return [
+                new RemoveReadonlyPropertiesTransformer(),
+                new RemoveMutuallyExclusivePropertiesTransformer(),
+                new RemoveSystemTagsTransformer(),
+            ];
+        } else if (purpose === ResourceStatePurpose.CLONE) {
+            return [
+                new RemoveReadonlyPropertiesTransformer(),
+                new RemoveMutuallyExclusivePropertiesTransformer(),
+                new RemoveSystemTagsTransformer(),
+                new ReplacePrimaryIdentifierTransformer(),
+            ];
+        }
+        return [];
     }
 }

--- a/tst/unit/resourceState/MockResourceState.ts
+++ b/tst/unit/resourceState/MockResourceState.ts
@@ -1,0 +1,216 @@
+import { DateTime } from 'luxon';
+import { ResourceState } from '../../../src/resourceState/ResourceStateManager';
+
+const baseTimestamp = DateTime.now();
+
+export const MockResourceStates = {
+    'AWS::S3::Bucket': {
+        typeName: 'AWS::S3::Bucket',
+        identifier: 'my-test-bucket',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            BucketName: 'my-test-bucket',
+            VersioningConfiguration: {
+                Status: 'Enabled',
+            },
+            PublicAccessBlockConfiguration: {
+                BlockPublicAcls: true,
+                BlockPublicPolicy: true,
+            },
+        }),
+    } as ResourceState,
+
+    'AWS::EC2::Instance': {
+        typeName: 'AWS::EC2::Instance',
+        identifier: 'i-1234567890abcdef0',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            ImageId: 'ami-12345678',
+            InstanceType: 't2.micro',
+            KeyName: 'my-key-pair',
+            SecurityGroups: ['sg-12345678'],
+        }),
+    } as ResourceState,
+
+    'AWS::IAM::Role': {
+        typeName: 'AWS::IAM::Role',
+        identifier: 'MyTestRole',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            RoleName: 'MyTestRole',
+            AssumeRolePolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                    {
+                        Effect: 'Allow',
+                        Principal: { Service: 'lambda.amazonaws.com' },
+                        Action: 'sts:AssumeRole',
+                    },
+                ],
+            },
+            Description: 'Test role for Lambda',
+        }),
+    } as ResourceState,
+
+    'AWS::Lambda::Function': {
+        typeName: 'AWS::Lambda::Function',
+        identifier: 'MyTestFunction',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            FunctionName: 'MyTestFunction',
+            Runtime: 'nodejs18.x',
+            Code: {
+                ZipFile: 'exports.handler = async (event) => { return "Hello World"; };',
+            },
+            Handler: 'index.handler',
+            Role: 'arn:aws:iam::123456789012:role/lambda-role',
+        }),
+    } as ResourceState,
+
+    'AWS::EC2::VPC': {
+        typeName: 'AWS::EC2::VPC',
+        identifier: 'vpc-12345678',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            CidrBlock: '10.0.0.0/16',
+            EnableDnsHostnames: true,
+            EnableDnsSupport: true,
+            Tags: [{ Key: 'Name', Value: 'MyVPC' }],
+        }),
+    } as ResourceState,
+
+    'AWS::EC2::Subnet': {
+        typeName: 'AWS::EC2::Subnet',
+        identifier: 'subnet-12345678',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            VpcId: 'vpc-12345678',
+            CidrBlock: '10.0.1.0/24',
+            MapPublicIpOnLaunch: true,
+        }),
+    } as ResourceState,
+
+    'AWS::EC2::SecurityGroup': {
+        typeName: 'AWS::EC2::SecurityGroup',
+        identifier: 'sg-12345678',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            GroupDescription: 'Test security group',
+            VpcId: 'vpc-12345678',
+            SecurityGroupIngress: [
+                {
+                    IpProtocol: 'tcp',
+                    FromPort: 80,
+                    ToPort: 80,
+                    CidrIp: '0.0.0.0/0',
+                },
+            ],
+        }),
+    } as ResourceState,
+
+    'AWS::EC2::LaunchTemplate': {
+        typeName: 'AWS::EC2::LaunchTemplate',
+        identifier: 'lt-12345678',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            LaunchTemplateName: 'MyLaunchTemplate',
+            LaunchTemplateData: {
+                ImageId: 'ami-12345678',
+                InstanceType: 't2.micro',
+                KeyName: 'my-key-pair',
+            },
+        }),
+    } as ResourceState,
+
+    'AWS::AutoScaling::AutoScalingGroup': {
+        typeName: 'AWS::AutoScaling::AutoScalingGroup',
+        identifier: 'MyAutoScalingGroup',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            AutoScalingGroupName: 'MyAutoScalingGroup',
+            MinSize: 1,
+            MaxSize: 3,
+            DesiredCapacity: 2,
+            LaunchTemplate: {
+                LaunchTemplateId: 'lt-12345678',
+                Version: '$Latest',
+            },
+            VPCZoneIdentifier: ['subnet-12345678'],
+        }),
+    } as ResourceState,
+
+    'AWS::RDS::DBInstance': {
+        typeName: 'AWS::RDS::DBInstance',
+        identifier: 'mydbinstance',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            DBInstanceIdentifier: 'mydbinstance',
+            DBInstanceClass: 'db.t3.micro',
+            Engine: 'mysql',
+            MasterUsername: 'admin',
+            AllocatedStorage: '20',
+            VPCSecurityGroups: ['sg-12345678'],
+        }),
+    } as ResourceState,
+
+    'AWS::CloudWatch::Alarm': {
+        typeName: 'AWS::CloudWatch::Alarm',
+        identifier: 'MyTestAlarm',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            AlarmName: 'MyTestAlarm',
+            AlarmDescription: 'Test alarm for CPU utilization',
+            ComparisonOperator: 'GreaterThanThreshold',
+            EvaluationPeriods: 2,
+            MetricName: 'CPUUtilization',
+            Namespace: 'AWS/EC2',
+            Period: 300,
+            Statistic: 'Average',
+        }),
+    } as ResourceState,
+
+    'AWS::SNS::Topic': {
+        typeName: 'AWS::SNS::Topic',
+        identifier: 'arn:aws:sns:us-east-1:123456789012:MyTestTopic',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            TopicName: 'MyTestTopic',
+            DisplayName: 'My Test Topic',
+            Subscription: [
+                {
+                    Protocol: 'email',
+                    Endpoint: 'test@example.com',
+                },
+            ],
+        }),
+    } as ResourceState,
+
+    'AWS::SSM::Parameter': {
+        typeName: 'AWS::SSM::Parameter',
+        identifier: '/myapp/config/database-url',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            Name: '/myapp/config/database-url',
+            Type: 'String',
+            Value: 'mysql://localhost:3306/myapp',
+            Description: 'Database connection URL',
+        }),
+    } as ResourceState,
+};
+
+export function createMockResourceState(resourceType: string): ResourceState {
+    const mockState = MockResourceStates[resourceType as keyof typeof MockResourceStates];
+    if (!mockState) {
+        throw new Error(`No mock resource state defined for ${resourceType}`);
+    }
+    return structuredClone(mockState);
+}
+
+// Helper function to get parsed properties for testing
+export function getMockResourceProperties(resourceType: string): any {
+    const mockState = MockResourceStates[resourceType as keyof typeof MockResourceStates];
+    if (!mockState) {
+        throw new Error(`No mock resource state defined for ${resourceType}`);
+    }
+    return JSON.parse(mockState.properties);
+}

--- a/tst/unit/resourceState/ResourceStateImporter.test.ts
+++ b/tst/unit/resourceState/ResourceStateImporter.test.ts
@@ -5,13 +5,19 @@ import { SyntaxTreeManager } from '../../../src/context/syntaxtree/SyntaxTreeMan
 import { DocumentType } from '../../../src/document/Document';
 import { DocumentManager } from '../../../src/document/DocumentManager';
 import { ResourceStateImporter } from '../../../src/resourceState/ResourceStateImporter';
-import { ResourceSelection, ResourceStateParams } from '../../../src/resourceState/ResourceStateTypes';
+import {
+    ResourceSelection,
+    ResourceStateParams,
+    ResourceStatePurpose,
+} from '../../../src/resourceState/ResourceStateTypes';
 import {
     createMockClientMessage,
     createMockSchemaRetriever,
     createMockStackManagementInfoProvider,
 } from '../../utils/MockServerComponents';
 import { combinedSchemas } from '../../utils/SchemaUtils';
+import { createMockResourceState, MockResourceStates } from './MockResourceState';
+import { TestScenarios, getImportExpectation, getCloneExpectation } from './StateImportExpectation';
 
 describe('ResourceStateImporter', () => {
     let mockResourceStateManager: any;
@@ -22,7 +28,8 @@ describe('ResourceStateImporter', () => {
     let importer: ResourceStateImporter;
 
     beforeEach(() => {
-        // Create a proper mock for ResourceStateManager
+        vi.clearAllMocks();
+
         mockResourceStateManager = {
             getResource: vi.fn(),
             listResources: vi.fn(),
@@ -30,7 +37,8 @@ describe('ResourceStateImporter', () => {
         };
         mockStackManagementInfoProvider.getResourceManagementState.resolves({
             physicalResourceId: '',
-            managedByStack: undefined,
+            managedByStack: true,
+            stackName: 'test-stack',
         });
 
         importer = new ResourceStateImporter(
@@ -42,32 +50,12 @@ describe('ResourceStateImporter', () => {
         );
     });
 
-    // Test data generators
-    const createS3BucketResource = (identifier: string) => ({
-        resourceType: 'AWS::S3::Bucket',
-        resourceIdentifier: identifier,
-        properties: JSON.stringify({
-            BucketName: identifier,
-            PublicAccessBlockConfiguration: {
-                BlockPublicAcls: true,
-                BlockPublicPolicy: true,
-                IgnorePublicAcls: true,
-                RestrictPublicBuckets: true,
-            },
-        }),
-        createdTimestamp: new Date(),
-        lastUpdatedTimestamp: new Date(),
-    });
-
-    // Helper to create and register a document
-    const createAndRegisterDocument = (uri: string, content: string, documentType: DocumentType) => {
+    function createAndRegisterDocument(uri: string, content: string, documentType: DocumentType): TextDocument {
         const languageId = documentType === DocumentType.JSON ? 'json' : 'yaml';
         const textDocument = TextDocument.create(uri, languageId, 1, content);
 
-        // Manually add the document to the TextDocuments collection (like TemplateBuilder does)
         (documentManager as any).documents._syncedDocuments.set(uri, textDocument);
 
-        // Add to syntax tree manager if content exists
         if (content.trim()) {
             try {
                 syntaxTreeManager.add(uri, content);
@@ -77,177 +65,131 @@ describe('ResourceStateImporter', () => {
         }
 
         return textDocument;
-    };
-
-    // Simplified test cases for debugging
-    const testCases = [
-        {
-            documentType: DocumentType.JSON,
-            hasResourcesSection: false,
-            resources: [{ type: 'single', count: 1, resourceType: 'AWS::S3::Bucket' }],
-            description: 'JSON - No resources section - Single S3 bucket',
-        },
-        {
-            documentType: DocumentType.JSON,
-            hasResourcesSection: true,
-            resources: [{ type: 'single', count: 1, resourceType: 'AWS::S3::Bucket' }],
-            description: 'JSON - With resources section - Single S3 bucket',
-        },
-        {
-            documentType: DocumentType.YAML,
-            hasResourcesSection: false,
-            resources: [{ type: 'single', count: 1, resourceType: 'AWS::S3::Bucket' }],
-            description: 'YAML - No resources section - Single S3 bucket',
-        },
-        {
-            documentType: DocumentType.YAML,
-            hasResourcesSection: true,
-            resources: [{ type: 'single', count: 1, resourceType: 'AWS::S3::Bucket' }],
-            description: 'YAML - With resources section - Single S3 bucket',
-        },
-    ];
-
-    for (const testCase of testCases) {
-        it(`${testCase.description}`, async () => {
-            const uri = `test://test-${testCase.description.replaceAll(/\s+/g, '-').toLowerCase()}.template`;
-
-            // Setup initial document content
-            let initialContent: string;
-            if (testCase.documentType === DocumentType.JSON) {
-                initialContent = testCase.hasResourcesSection
-                    ? `{
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Resources": {
-    "ExistingBucket": {
-      "Type": "AWS::S3::Bucket",
-      "Properties": {
-        "BucketName": "existing-bucket"
-      }
     }
-  }
-}`
-                    : `{
-  "AWSTemplateFormatVersion": "2010-09-09"
-}`;
-            } else {
-                initialContent = testCase.hasResourcesSection
-                    ? `AWSTemplateFormatVersion: "2010-09-09"
-Resources:
-  ExistingBucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: existing-bucket`
-                    : `AWSTemplateFormatVersion: "2010-09-09"`;
+
+    describe.each(TestScenarios)('$name', (scenario) => {
+        describe('Import functionality', () => {
+            const resourceTypes = Object.keys(MockResourceStates);
+
+            for (const resourceType of resourceTypes) {
+                it(`should import ${resourceType} with exact expected output`, async () => {
+                    const uri = `test://test-import-${resourceType.toLowerCase().replaceAll('::', '-')}-${scenario.name.toLowerCase().replaceAll(' ', '-')}.template`;
+
+                    createAndRegisterDocument(uri, scenario.initialContent, scenario.documentType);
+
+                    const mockResource = createMockResourceState(resourceType);
+                    const resourceSelections: ResourceSelection[] = [
+                        {
+                            resourceType,
+                            resourceIdentifiers: [mockResource.identifier],
+                        },
+                    ];
+
+                    mockResourceStateManager.getResource.mockResolvedValue(mockResource);
+
+                    const params: ResourceStateParams = {
+                        resourceSelections,
+                        textDocument: { uri } as any,
+                        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                        context: { diagnostics: [], only: [], triggerKind: 1 },
+                        purpose: ResourceStatePurpose.IMPORT,
+                    };
+
+                    const result = await importer.importResourceState(params);
+
+                    expect(result.edit).toBeDefined();
+                    expect(result.edit!.changes![uri]).toBeDefined();
+
+                    const textEdit = result.edit!.changes![uri][0] as TextEdit;
+                    const newText = textEdit.newText;
+
+                    const expectedText = getImportExpectation(scenario, resourceType);
+                    expect(newText).toBe(expectedText);
+
+                    expect(newText).not.toContain('<CLONE INPUT REQUIRED>');
+                    expect(result.successfulImports).toBeDefined();
+                    expect(result.failedImports).toBeDefined();
+                });
             }
-
-            // Create and register the document
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const textDocument = createAndRegisterDocument(uri, initialContent, testCase.documentType);
-
-            // Setup resource selections and mock resource state manager responses
-            const resourceSelections: ResourceSelection[] = [];
-            const identifier = 'test-bucket-1';
-
-            const mockResource = createS3BucketResource(identifier);
-
-            // Mock getResource to return the resource state correctly
-            mockResourceStateManager.getResource.mockResolvedValue(mockResource);
-
-            resourceSelections.push({
-                resourceType: 'AWS::S3::Bucket',
-                resourceIdentifiers: [identifier],
-            });
-
-            // Execute the import
-            const params: ResourceStateParams = {
-                resourceSelections,
-                textDocument: { uri },
-                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
-                context: { diagnostics: [], only: [], triggerKind: 1 },
-            };
-
-            const result = await importer.importResourceState(params);
-
-            // Basic assertions - check for edit instead of success
-            expect(result.edit).toBeDefined();
-            expect(result.edit?.changes).toBeDefined();
-
-            const changes = result.edit!.changes![uri];
-            expect(changes).toHaveLength(1);
-
-            const textEdit = changes[0];
-            const newText = textEdit.newText;
-
-            // Verify the format is valid JSON/YAML when combined with original
-            const fullContent = applyTextEdit(initialContent, textEdit);
-            if (testCase.documentType === DocumentType.JSON) {
-                expect(() => JSON.parse(fullContent)).not.toThrow();
-            } else {
-                // For YAML, just check it's not empty and has proper structure
-                expect(fullContent).toContain('AWSTemplateFormatVersion');
-                expect(fullContent).toContain('Resources');
-            }
-
-            // Verify proper comma placement and formatting for existing resources section
-            if (testCase.hasResourcesSection) {
-                if (testCase.documentType === DocumentType.JSON) {
-                    expect(newText).toMatch(/^,/); // Should start with comma
-                    expect(newText).toMatch(/^,\s*\n/); // Should have newline after comma
-                    expect(newText).not.toMatch(/^, *"[^"]+"/); // Should NOT have resource immediately after comma (same line)
-                    expect(newText).toMatch(/^,\n\s*"[^"]+"/); // Should have proper newline separation before resource
-                } else {
-                    // YAML formatting checks
-                    expect(newText).toMatch(/^\n/); // Should start with newline for YAML
-                    expect(newText).toContain('Type: AWS::S3::Bucket'); // Should contain resource type
-                }
-            } else {
-                // No existing resources section
-                if (testCase.documentType === DocumentType.JSON) {
-                    expect(newText).toContain('"Resources"'); // Should add Resources section
-                } else {
-                    expect(newText).toContain('Resources:'); // Should add Resources section
-                }
-            }
-
-            // Verify resource content is present
-            expect(newText).toContain('AWS::S3::Bucket');
-            expect(newText).toContain(identifier);
-
-            // Clean up - remove document from manager
-            (documentManager as any).documents._syncedDocuments.delete(uri);
-            syntaxTreeManager.deleteSyntaxTree(uri);
         });
-    }
 
-    // Test cases for failure scenarios
-    describe('Failure scenarios', () => {
-        it('should return failure when no resources are selected', async () => {
+        describe('Clone functionality', () => {
+            const resourceTypes = Object.keys(MockResourceStates);
+
+            for (const resourceType of resourceTypes) {
+                it(`should clone ${resourceType} with exact expected output`, async () => {
+                    const uri = `test://test-clone-${resourceType.toLowerCase().replaceAll('::', '-')}-${scenario.name.toLowerCase().replaceAll(' ', '-')}.template`;
+
+                    createAndRegisterDocument(uri, scenario.initialContent, scenario.documentType);
+
+                    const mockResource = createMockResourceState(resourceType);
+                    const resourceSelections: ResourceSelection[] = [
+                        {
+                            resourceType,
+                            resourceIdentifiers: [mockResource.identifier],
+                        },
+                    ];
+
+                    mockResourceStateManager.getResource.mockResolvedValue(mockResource);
+
+                    const params: ResourceStateParams = {
+                        resourceSelections,
+                        textDocument: { uri } as any,
+                        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                        context: { diagnostics: [], only: [], triggerKind: 1 },
+                        purpose: ResourceStatePurpose.CLONE,
+                    };
+
+                    const result = await importer.importResourceState(params);
+
+                    expect(result.edit).toBeDefined();
+                    expect(result.edit!.changes![uri]).toBeDefined();
+
+                    const textEdit = result.edit!.changes![uri][0] as TextEdit;
+                    const newText = textEdit.newText;
+
+                    const expectedText = getCloneExpectation(scenario, resourceType);
+                    expect(newText).toBe(expectedText);
+
+                    expect(result.successfulImports).toBeDefined();
+                    expect(result.failedImports).toBeDefined();
+                });
+            }
+        });
+    });
+
+    describe('Error handling', () => {
+        it('should handle no resources selected', async () => {
+            const uri = 'test://test-no-resources.template';
+            const scenario = TestScenarios[0]; // Use first scenario
+
+            createAndRegisterDocument(uri, scenario.initialContent, scenario.documentType);
+
             const params: ResourceStateParams = {
-                resourceSelections: undefined as any,
-                textDocument: { uri: 'test://test.template' },
+                resourceSelections: [],
+                textDocument: { uri } as any,
                 range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
                 context: { diagnostics: [], only: [], triggerKind: 1 },
+                purpose: ResourceStatePurpose.IMPORT,
             };
 
             const result = await importer.importResourceState(params);
 
-            expect(result.edit).toBeUndefined();
-            expect(result.title).toBe('No resources selected for import.');
+            expect(result.edit).toBeDefined();
+            expect(result.title).toBe('Resource State Import');
             expect(Object.keys(result.successfulImports)).toHaveLength(0);
             expect(Object.keys(result.failedImports)).toHaveLength(0);
         });
 
-        it('should return failure when document is not found', async () => {
+        it('should handle document not found', async () => {
+            const uri = 'test://non-existent.template';
+
             const params: ResourceStateParams = {
-                resourceSelections: [
-                    {
-                        resourceType: 'AWS::S3::Bucket',
-                        resourceIdentifiers: ['test-bucket'],
-                    },
-                ],
-                textDocument: { uri: 'test://nonexistent.template' },
+                resourceSelections: [{ resourceType: 'AWS::S3::Bucket', resourceIdentifiers: ['test-bucket'] }],
+                textDocument: { uri } as any,
                 range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
                 context: { diagnostics: [], only: [], triggerKind: 1 },
+                purpose: ResourceStatePurpose.IMPORT,
             };
 
             const result = await importer.importResourceState(params);
@@ -258,73 +200,26 @@ Resources:
             expect(Object.keys(result.failedImports)).toHaveLength(0);
         });
 
-        it('should return failure when syntax tree is not found', async () => {
+        it('should handle syntax tree not found', async () => {
             const uri = 'test://test-no-syntax-tree.template';
-            const content = '{ "AWSTemplateFormatVersion": "2010-09-09" }';
+            const scenario = TestScenarios[0]; // Use first scenario
 
-            // Create document but don't add to syntax tree manager
-            const textDocument = TextDocument.create(uri, 'json', 1, content);
-            (documentManager as any).documents._syncedDocuments.set(uri, textDocument);
+            createAndRegisterDocument(uri, scenario.initialContent, scenario.documentType);
 
             const params: ResourceStateParams = {
-                resourceSelections: [
-                    {
-                        resourceType: 'AWS::S3::Bucket',
-                        resourceIdentifiers: ['test-bucket'],
-                    },
-                ],
-                textDocument: { uri },
+                resourceSelections: [{ resourceType: 'AWS::S3::Bucket', resourceIdentifiers: ['test-bucket'] }],
+                textDocument: { uri } as any,
                 range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
                 context: { diagnostics: [], only: [], triggerKind: 1 },
+                purpose: ResourceStatePurpose.IMPORT,
             };
 
             const result = await importer.importResourceState(params);
 
-            expect(result.edit).toBeUndefined();
-            expect(result.title).toBe('Import failed. Syntax tree not found');
+            expect(result.edit).toBeDefined();
+            expect(result.title).toBe('Resource State Import');
             expect(Object.keys(result.successfulImports)).toHaveLength(0);
-            expect(Object.keys(result.failedImports)).toHaveLength(0);
-
-            // Cleanup
-            (documentManager as any).documents._syncedDocuments.delete(uri);
+            expect(Object.keys(result.failedImports)).toHaveLength(1);
         });
     });
-
-    // Helper function to apply text edit to content
-    function applyTextEdit(content: string, textEdit: TextEdit): string {
-        const lines = content.split('\n');
-        const startLine = textEdit.range.start.line;
-        const startChar = textEdit.range.start.character;
-        const endLine = textEdit.range.end.line;
-        const endChar = textEdit.range.end.character;
-
-        // Ensure we have enough lines
-        while (lines.length <= Math.max(startLine, endLine)) {
-            lines.push('');
-        }
-
-        if (startLine === endLine) {
-            const line = lines[startLine] || '';
-            lines[startLine] =
-                line.slice(0, Math.max(0, startChar)) + textEdit.newText + line.slice(Math.max(0, endChar));
-        } else {
-            const newLines = textEdit.newText.split('\n');
-            const startLineContent = lines[startLine] || '';
-            lines[startLine] = startLineContent.slice(0, Math.max(0, startChar)) + newLines[0];
-
-            for (let i = 1; i < newLines.length; i++) {
-                lines.splice(startLine + i, 0, newLines[i]);
-            }
-
-            if (newLines.length > 1) {
-                const endLineContent = lines[endLine + newLines.length - 1] || '';
-                lines[startLine + newLines.length - 1] += endLineContent.slice(Math.max(0, endChar));
-            }
-
-            // Remove the original end line and any lines in between
-            lines.splice(endLine + newLines.length - 1, endLine - startLine);
-        }
-
-        return lines.join('\n');
-    }
 });

--- a/tst/unit/resourceState/StateImportExpectation.ts
+++ b/tst/unit/resourceState/StateImportExpectation.ts
@@ -1,0 +1,284 @@
+import { DocumentType } from '../../../src/document/Document';
+import { getMockResourceProperties } from './MockResourceState';
+
+export interface TestScenario {
+    name: string;
+    documentType: DocumentType;
+    hasExistingResources: boolean;
+    initialContent: string;
+}
+
+export const TestScenarios: TestScenario[] = [
+    {
+        name: 'JSON without existing Resources',
+        documentType: DocumentType.JSON,
+        hasExistingResources: false,
+        initialContent: `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Test template"
+}`,
+    },
+    {
+        name: 'JSON with existing Resources',
+        documentType: DocumentType.JSON,
+        hasExistingResources: true,
+        initialContent: `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Test template",
+  "Resources": {
+    "ExistingResource": {
+      "Type": "AWS::S3::Bucket",
+      "Properties": {
+        "BucketName": "existing-bucket"
+      }
+    }
+  }
+}`,
+    },
+    {
+        name: 'YAML without existing Resources',
+        documentType: DocumentType.YAML,
+        hasExistingResources: false,
+        initialContent: `AWSTemplateFormatVersion: '2010-09-09'
+Description: Test template`,
+    },
+    {
+        name: 'YAML with existing Resources',
+        documentType: DocumentType.YAML,
+        hasExistingResources: true,
+        initialContent: `AWSTemplateFormatVersion: '2010-09-09'
+Description: Test template
+Resources:
+  ExistingResource:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: existing-bucket`,
+    },
+];
+
+function getResourceLogicalName(resourceType: string): string {
+    const typeMap: Record<string, string> = {
+        'AWS::S3::Bucket': 'Bucket',
+        'AWS::EC2::Instance': 'Instance',
+        'AWS::IAM::Role': 'Role',
+        'AWS::Lambda::Function': 'Function',
+        'AWS::EC2::VPC': 'VPC',
+        'AWS::EC2::Subnet': 'Subnet',
+        'AWS::EC2::SecurityGroup': 'SecurityGroup',
+        'AWS::EC2::LaunchTemplate': 'LaunchTemplate',
+        'AWS::AutoScaling::AutoScalingGroup': 'AutoScalingGroup',
+        'AWS::RDS::DBInstance': 'DBInstance',
+        'AWS::CloudWatch::Alarm': 'Alarm',
+        'AWS::SNS::Topic': 'Topic',
+        'AWS::SSM::Parameter': 'Parameter',
+    };
+    return typeMap[resourceType] || 'Resource';
+}
+
+function formatPropertiesForJson(properties: any, indent: number = 6): string {
+    const spaces = ' '.repeat(indent);
+    return JSON.stringify(properties, null, 2)
+        .split('\n')
+        .map((line, index) => (index === 0 ? line : spaces + line))
+        .join('\n');
+}
+
+function formatPropertiesForYaml(properties: any, indent: number = 6): string {
+    const spaces = ' '.repeat(indent);
+    const yamlLines: string[] = [];
+
+    function processValue(value: any, currentIndent: number): string[] {
+        const currentSpaces = ' '.repeat(currentIndent);
+
+        if (Array.isArray(value)) {
+            return value.map((item) => {
+                if (typeof item === 'object' && item !== null) {
+                    const subLines = processValue(item, currentIndent + 2);
+                    return `${currentSpaces}- ${subLines[0].trim()}\n${subLines.slice(1).join('\n')}`;
+                } else {
+                    return `${currentSpaces}- ${String(item)}`;
+                }
+            });
+        } else if (typeof value === 'object' && value !== null) {
+            const lines: string[] = [];
+            for (const [key, val] of Object.entries(value)) {
+                if (Array.isArray(val)) {
+                    lines.push(`${currentSpaces}${key}:`, ...processValue(val, currentIndent + 2));
+                } else if (typeof val === 'object' && val !== null) {
+                    lines.push(`${currentSpaces}${key}:`, ...processValue(val, currentIndent + 2));
+                } else {
+                    const formattedValue = typeof val === 'string' && /^\d+$/.test(val) ? `"${val}"` : String(val);
+                    lines.push(`${currentSpaces}${key}: ${formattedValue}`);
+                }
+            }
+            return lines;
+        } else {
+            return [`${String(value)}`];
+        }
+    }
+
+    for (const [key, value] of Object.entries(properties)) {
+        if (Array.isArray(value)) {
+            yamlLines.push(`${spaces}${key}:`, ...processValue(value, indent + 2));
+        } else if (typeof value === 'object' && value !== null) {
+            yamlLines.push(`${spaces}${key}:`, ...processValue(value, indent + 2));
+        } else {
+            const formattedValue = typeof value === 'string' && /^\d+$/.test(value) ? `"${value}"` : String(value);
+            yamlLines.push(`${spaces}${key}: ${formattedValue}`);
+        }
+    }
+
+    return yamlLines.join('\n');
+}
+
+export function getImportExpectation(scenario: TestScenario, resourceType: string): string {
+    const logicalName = getResourceLogicalName(resourceType);
+    const properties = getMockResourceProperties(resourceType);
+    const identifier = getResourceIdentifier(resourceType);
+
+    if (scenario.documentType === DocumentType.JSON) {
+        if (scenario.hasExistingResources) {
+            return `,
+    "${logicalName}": {
+      "Type": "${resourceType}",
+      "Properties": ${formatPropertiesForJson(properties)},
+      "Metadata": {
+        "PrimaryIdentifier": "${identifier}",
+        "ManagedByStack": "true",
+        "StackName": "test-stack"
+      }
+    }`;
+        } else {
+            return `,
+  "Resources": {
+    "${logicalName}": {
+      "Type": "${resourceType}",
+      "Properties": ${formatPropertiesForJson(properties)},
+      "Metadata": {
+        "PrimaryIdentifier": "${identifier}",
+        "ManagedByStack": "true",
+        "StackName": "test-stack"
+      }
+    }
+  }`;
+        }
+    } else {
+        if (scenario.hasExistingResources) {
+            return `
+  ${logicalName}:
+    Type: ${resourceType}
+    Properties:
+${formatPropertiesForYaml(properties)}
+    Metadata:
+      PrimaryIdentifier: ${identifier}
+      ManagedByStack: "true"
+      StackName: test-stack`;
+        } else {
+            return `
+Resources:
+  ${logicalName}:
+    Type: ${resourceType}
+    Properties:
+${formatPropertiesForYaml(properties)}
+    Metadata:
+      PrimaryIdentifier: ${identifier}
+      ManagedByStack: "true"
+      StackName: test-stack`;
+        }
+    }
+}
+
+export function getCloneExpectation(scenario: TestScenario, resourceType: string): string {
+    const logicalName = getResourceLogicalName(resourceType);
+    const properties = getMockResourceProperties(resourceType);
+    const identifier = getResourceIdentifier(resourceType);
+
+    // For clone, replace primary identifier properties with <CLONE INPUT REQUIRED>
+    const cloneProperties = replaceCloneProperties(properties, resourceType);
+
+    if (scenario.documentType === DocumentType.JSON) {
+        if (scenario.hasExistingResources) {
+            return `,
+    "${logicalName}": {
+      "Type": "${resourceType}",
+      "Properties": ${formatPropertiesForJson(cloneProperties)},
+      "Metadata": {
+        "PrimaryIdentifier": "<CLONE>${identifier}"
+      }
+    }`;
+        } else {
+            return `,
+  "Resources": {
+    "${logicalName}": {
+      "Type": "${resourceType}",
+      "Properties": ${formatPropertiesForJson(cloneProperties)},
+      "Metadata": {
+        "PrimaryIdentifier": "<CLONE>${identifier}"
+      }
+    }
+  }`;
+        }
+    } else {
+        if (scenario.hasExistingResources) {
+            return `
+  ${logicalName}:
+    Type: ${resourceType}
+    Properties:
+${formatPropertiesForYaml(cloneProperties)}
+    Metadata:
+      PrimaryIdentifier: <CLONE>${identifier}`;
+        } else {
+            return `
+Resources:
+  ${logicalName}:
+    Type: ${resourceType}
+    Properties:
+${formatPropertiesForYaml(cloneProperties)}
+    Metadata:
+      PrimaryIdentifier: <CLONE>${identifier}`;
+        }
+    }
+}
+
+function getResourceIdentifier(resourceType: string): string {
+    const identifierMap: Record<string, string> = {
+        'AWS::S3::Bucket': 'my-test-bucket',
+        'AWS::EC2::Instance': 'i-1234567890abcdef0',
+        'AWS::IAM::Role': 'MyTestRole',
+        'AWS::Lambda::Function': 'MyTestFunction',
+        'AWS::EC2::VPC': 'vpc-12345678',
+        'AWS::EC2::Subnet': 'subnet-12345678',
+        'AWS::EC2::SecurityGroup': 'sg-12345678',
+        'AWS::EC2::LaunchTemplate': 'lt-12345678',
+        'AWS::AutoScaling::AutoScalingGroup': 'MyAutoScalingGroup',
+        'AWS::RDS::DBInstance': 'mydbinstance',
+        'AWS::CloudWatch::Alarm': 'MyTestAlarm',
+        'AWS::SNS::Topic': 'arn:aws:sns:us-east-1:123456789012:MyTestTopic',
+        'AWS::SSM::Parameter': '/myapp/config/database-url',
+    };
+    return identifierMap[resourceType] || 'unknown';
+}
+
+function replaceCloneProperties(properties: any, resourceType: string): any {
+    const cloneProperties = structuredClone(properties);
+
+    // Replace primary identifier properties with <CLONE INPUT REQUIRED>
+    const primaryIdentifierProps: Record<string, string[]> = {
+        'AWS::S3::Bucket': ['BucketName'],
+        'AWS::IAM::Role': ['RoleName'],
+        'AWS::Lambda::Function': ['FunctionName'],
+        'AWS::AutoScaling::AutoScalingGroup': ['AutoScalingGroupName'],
+        'AWS::RDS::DBInstance': ['DBInstanceIdentifier'],
+        'AWS::CloudWatch::Alarm': ['AlarmName'],
+        'AWS::SSM::Parameter': ['Name'],
+    };
+
+    const propsToReplace = primaryIdentifierProps[resourceType] || [];
+    for (const prop of propsToReplace) {
+        if (cloneProperties[prop] !== undefined) {
+            cloneProperties[prop] = '<CLONE INPUT REQUIRED>';
+        }
+    }
+
+    return cloneProperties;
+}

--- a/tst/unit/schema/transformers/ReplacePrimaryIdentifierTransformer.test.ts
+++ b/tst/unit/schema/transformers/ReplacePrimaryIdentifierTransformer.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import { ReplacePrimaryIdentifierTransformer } from '../../../../src/schema/transformers/ReplacePrimaryIdentifierTransformer';
+import { combinedSchemas } from '../../../utils/SchemaUtils';
+
+describe('ReplacePrimaryIdentifierTransformer', () => {
+    const schemas = combinedSchemas();
+    const transformer = new ReplacePrimaryIdentifierTransformer();
+
+    // Test with all 13 available resource schemas
+    const resourceTests = [
+        {
+            typeName: 'AWS::S3::Bucket',
+            properties: {
+                BucketName: 'my-existing-bucket',
+                VersioningConfiguration: { Status: 'Enabled' },
+            },
+            expectedAfterTransform: {
+                BucketName: '<CLONE INPUT REQUIRED>',
+                VersioningConfiguration: { Status: 'Enabled' },
+            },
+        },
+        {
+            typeName: 'AWS::EC2::Instance',
+            properties: {
+                ImageId: 'ami-12345678',
+                InstanceType: 't2.micro',
+            },
+            expectedAfterTransform: {
+                // InstanceId is read-only, no replacement
+                ImageId: 'ami-12345678',
+                InstanceType: 't2.micro',
+            },
+        },
+        {
+            typeName: 'AWS::IAM::Role',
+            properties: {
+                RoleName: 'MyExistingRole',
+                AssumeRolePolicyDocument: { Version: '2012-10-17' },
+            },
+            expectedAfterTransform: {
+                RoleName: '<CLONE INPUT REQUIRED>',
+                AssumeRolePolicyDocument: { Version: '2012-10-17' },
+            },
+        },
+        {
+            typeName: 'AWS::Lambda::Function',
+            properties: {
+                FunctionName: 'MyExistingFunction',
+                Runtime: 'nodejs18.x',
+                Code: { ZipFile: 'exports.handler = async () => {}' },
+            },
+            expectedAfterTransform: {
+                FunctionName: '<CLONE INPUT REQUIRED>',
+                Runtime: 'nodejs18.x',
+                Code: { ZipFile: 'exports.handler = async () => {}' },
+            },
+        },
+        {
+            typeName: 'AWS::EC2::VPC',
+            properties: {
+                CidrBlock: '10.0.0.0/16',
+                EnableDnsHostnames: true,
+            },
+            expectedAfterTransform: {
+                // VpcId is read-only, no replacement
+                CidrBlock: '10.0.0.0/16',
+                EnableDnsHostnames: true,
+            },
+        },
+        {
+            typeName: 'AWS::EC2::Subnet',
+            properties: {
+                VpcId: 'vpc-12345678',
+                CidrBlock: '10.0.1.0/24',
+            },
+            expectedAfterTransform: {
+                // SubnetId is read-only, no replacement
+                VpcId: 'vpc-12345678',
+                CidrBlock: '10.0.1.0/24',
+            },
+        },
+        {
+            typeName: 'AWS::EC2::SecurityGroup',
+            properties: {
+                GroupDescription: 'My security group',
+                VpcId: 'vpc-12345678',
+            },
+            expectedAfterTransform: {
+                // Id is read-only, no replacement
+                GroupDescription: 'My security group',
+                VpcId: 'vpc-12345678',
+            },
+        },
+        {
+            typeName: 'AWS::EC2::LaunchTemplate',
+            properties: {
+                LaunchTemplateName: 'MyTemplate',
+                LaunchTemplateData: { ImageId: 'ami-12345678' },
+            },
+            expectedAfterTransform: {
+                // LaunchTemplateId is read-only, no replacement
+                LaunchTemplateName: 'MyTemplate',
+                LaunchTemplateData: { ImageId: 'ami-12345678' },
+            },
+        },
+        {
+            typeName: 'AWS::AutoScaling::AutoScalingGroup',
+            properties: {
+                AutoScalingGroupName: 'MyASG',
+                MinSize: 1,
+                MaxSize: 3,
+            },
+            expectedAfterTransform: {
+                AutoScalingGroupName: '<CLONE INPUT REQUIRED>',
+                MinSize: 1,
+                MaxSize: 3,
+            },
+        },
+        {
+            typeName: 'AWS::RDS::DBInstance',
+            properties: {
+                DBInstanceIdentifier: 'mydb',
+                DBInstanceClass: 'db.t3.micro',
+                Engine: 'mysql',
+            },
+            expectedAfterTransform: {
+                DBInstanceIdentifier: '<CLONE INPUT REQUIRED>',
+                DBInstanceClass: 'db.t3.micro',
+                Engine: 'mysql',
+            },
+        },
+        {
+            typeName: 'AWS::CloudWatch::Alarm',
+            properties: {
+                AlarmName: 'MyAlarm',
+                ComparisonOperator: 'GreaterThanThreshold',
+                EvaluationPeriods: 2,
+            },
+            expectedAfterTransform: {
+                AlarmName: '<CLONE INPUT REQUIRED>',
+                ComparisonOperator: 'GreaterThanThreshold',
+                EvaluationPeriods: 2,
+            },
+        },
+        {
+            typeName: 'AWS::SNS::Topic',
+            properties: {
+                TopicName: 'MyTopic',
+                DisplayName: 'My Topic',
+            },
+            expectedAfterTransform: {
+                // TopicArn is read-only, no replacement
+                TopicName: 'MyTopic',
+                DisplayName: 'My Topic',
+            },
+        },
+        {
+            typeName: 'AWS::SSM::Parameter',
+            properties: {
+                Name: '/my/parameter',
+                Type: 'String',
+                Value: 'test-value',
+            },
+            expectedAfterTransform: {
+                Name: '<CLONE INPUT REQUIRED>',
+                Type: 'String',
+                Value: 'test-value',
+            },
+        },
+    ];
+
+    for (const { typeName, properties, expectedAfterTransform } of resourceTests) {
+        it(`should replace primary identifier properties in ${typeName}`, () => {
+            const schema = schemas.schemas.get(typeName)!;
+            const resourceProperties = { ...properties };
+
+            transformer.transform(resourceProperties, schema);
+
+            expect(resourceProperties).toEqual(expectedAfterTransform);
+        });
+    }
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- import resource state remains the same functionally
- clone resource state will put a placeholder for the primary identifier and add a clone prefix to the `PrimaryIdentfier` in `Metadata`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
