### PR TITLE
Don't suggest on `:` in yaml

### DIFF
--- a/src/context/syntaxtree/SyntaxTree.ts
+++ b/src/context/syntaxtree/SyntaxTree.ts
@@ -414,6 +414,9 @@ export abstract class SyntaxTree {
         const lastCharNode = this.tree.rootNode.namedDescendantForPosition({ row: point.row, column: lastCharIndex });
 
         if (NodeType.isNodeType(lastCharNode, YamlNodeTypes.BLOCK_MAPPING_PAIR)) {
+            if (point.column === lastCharNode.endPosition.column) {
+                return lastCharNode;
+            }
             const syntheticValue = createSyntheticNode('', point, point, lastCharNode);
             syntheticValue.type = CommonNodeTypes.SYNTHETIC_VALUE;
             syntheticValue.grammarType = CommonNodeTypes.SYNTHETIC_VALUE;

--- a/tst/unit/context/syntaxtree/SyntaxTree.test.ts
+++ b/tst/unit/context/syntaxtree/SyntaxTree.test.ts
@@ -1458,6 +1458,16 @@ Resources:
             expect(node).toBeDefined();
         });
 
+        it('should handle position exactly at end of line ending with colon', () => {
+            const template = `Resources:
+  Bucket:`;
+            const tree = createSyntaxTree(template, DocumentType.YAML);
+            // Position exactly at the end of line ending with colon
+            const node = tree.getNodeAtPosition({ line: 1, character: 9 });
+            expect(node).toBeDefined();
+            expect(node.type).toBe('block_mapping_pair');
+        });
+
         it('should return Key and Value for cursor after dash in array item', () => {
             const template = `Resources:
   Bucket:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Don't suggest on `:` in yaml when in key pair mapping.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
