### PR TITLE
unused components removed from completion router

### DIFF
--- a/src/autocomplete/CompletionRouter.ts
+++ b/src/autocomplete/CompletionRouter.ts
@@ -5,11 +5,7 @@ import { IntrinsicFunction, IntrinsicsUsingConditionKeyword, TopLevelSection } f
 import { isCondition } from '../context/ContextUtils';
 import { Entity, Output, Parameter } from '../context/semantic/Entity';
 import { EntityType } from '../context/semantic/SemanticTypes';
-import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
 import { DocumentType } from '../document/Document';
-import { DocumentManager } from '../document/DocumentManager';
-import { ResourceStateManager } from '../resourceState/ResourceStateManager';
-import { SchemaRetriever } from '../schema/SchemaRetriever';
 import { Closeable, Configurable, ServerComponents } from '../server/ServerComponents';
 import { CompletionSettings, DefaultSettings, ISettingsSubscriber, SettingsSubscription } from '../settings/Settings';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
@@ -38,10 +34,6 @@ export class CompletionRouter implements Configurable, Closeable {
 
     constructor(
         private readonly contextManager: ContextManager,
-        schemaRetriever: SchemaRetriever,
-        syntaxTreeManager: SyntaxTreeManager,
-        documentManager: DocumentManager,
-        resourceStateManager: ResourceStateManager,
         private readonly completionProviderMap: Map<CompletionProviderType, CompletionProvider>,
         private readonly entityFieldCompletionProviderMap = createEntityFieldProviders(),
     ) {}
@@ -271,14 +263,7 @@ export class CompletionRouter implements Configurable, Closeable {
     }
 
     static create(components: ServerComponents) {
-        return new CompletionRouter(
-            components.contextManager,
-            components.schemaRetriever,
-            components.syntaxTreeManager,
-            components.documentManager,
-            components.resourceStateManager,
-            createCompletionProviders(components),
-        );
+        return new CompletionRouter(components.contextManager, createCompletionProviders(components));
     }
 }
 

--- a/tst/unit/autocomplete/CompletionRouter.test.ts
+++ b/tst/unit/autocomplete/CompletionRouter.test.ts
@@ -209,16 +209,12 @@ describe('CompletionRouter', () => {
             resourceStateCompletionProvider: resourceStateProvider,
             schemaRetriever: mockComponents.schemaRetriever,
         });
-        const completionProvider = createCompletionProviders(mockTestComponents);
-        const entityFieldProvider = createEntityFieldProviders();
+        const completionProviderMap = createCompletionProviders(mockTestComponents);
+        const entityFieldProviderMap = createEntityFieldProviders();
         const realCompletionRouter = new CompletionRouter(
             contextManager,
-            mockComponents.schemaRetriever,
-            syntaxTreeManager,
-            mockDocumentManager,
-            mockResourceStateManager,
-            completionProvider,
-            entityFieldProvider,
+            completionProviderMap,
+            entityFieldProviderMap,
         );
 
         function expectCompletionProvider(
@@ -228,7 +224,7 @@ describe('CompletionRouter', () => {
             entityType: EntityType,
             description: string,
         ) {
-            const conditionProvider = completionProvider.get(entityType);
+            const conditionProvider = completionProviderMap.get(entityType);
             const getCompletionsSpy = vi.spyOn(conditionProvider!, 'getCompletions');
 
             const result = realCompletionRouter.getCompletions(docPosition(uri, line, character));
@@ -243,7 +239,7 @@ describe('CompletionRouter', () => {
             uri: string,
             description: string,
         ) {
-            const intrinsicArgumentProvider = completionProvider.get('IntrinsicFunctionArgument');
+            const intrinsicArgumentProvider = completionProviderMap.get('IntrinsicFunctionArgument');
             const getCompletionsSpy = vi.spyOn(intrinsicArgumentProvider!, 'getCompletions');
 
             const result = realCompletionRouter.getCompletions(docPosition(uri, line, character));
@@ -287,7 +283,7 @@ describe('CompletionRouter', () => {
                 uri: string,
                 description: string,
             ) {
-                const conditionProvider = completionProvider.get(EntityType.Condition);
+                const conditionProvider = completionProviderMap.get(EntityType.Condition);
                 const getCompletionsSpy = vi.spyOn(conditionProvider!, 'getCompletions');
 
                 realCompletionRouter.getCompletions(docPosition(uri, line, character)) as CompletionList | undefined;
@@ -667,7 +663,7 @@ describe('CompletionRouter', () => {
                 uri: string,
                 description: string,
             ) {
-                const intrinsicArgumentProvider = completionProvider.get('IntrinsicFunctionArgument');
+                const intrinsicArgumentProvider = completionProviderMap.get('IntrinsicFunctionArgument');
                 const getCompletionsSpy = vi.spyOn(intrinsicArgumentProvider!, 'getCompletions');
 
                 const result = realCompletionRouter.getCompletions(docPosition(uri, line, character));

--- a/tst/utils/TemplateBuilder.ts
+++ b/tst/utils/TemplateBuilder.ts
@@ -17,7 +17,6 @@ import { DocumentType } from '../../src/document/Document';
 import { DocumentManager } from '../../src/document/DocumentManager';
 import { HoverRouter } from '../../src/hover/HoverRouter';
 import { SchemaRetriever } from '../../src/schema/SchemaRetriever';
-import { SettingsState } from '../../src/settings/Settings';
 import { extractErrorMessage } from '../../src/utils/Errors';
 import { expectThrow } from './Expect';
 import {
@@ -118,7 +117,6 @@ export class TemplateBuilder {
     private readonly schemaRetriever: SchemaRetriever;
     private readonly completionRouter: CompletionRouter;
     private readonly hoverRouter: HoverRouter;
-    private readonly settings: SettingsState;
     private readonly uri: string;
     private version: number = 0;
 
@@ -129,7 +127,6 @@ export class TemplateBuilder {
         this.documentManager = new DocumentManager(this.textDocuments);
         this.contextManager = new ContextManager(this.syntaxTreeManager);
         this.schemaRetriever = createMockSchemaRetriever(combinedSchemas());
-        this.settings = new SettingsState();
         const topLevelSectionProvider = new TopLevelSectionCompletionProvider(
             this.syntaxTreeManager,
             this.documentManager,
@@ -153,14 +150,7 @@ export class TemplateBuilder {
 
         const completionProviders = createCompletionProviders(mockTestComponents);
 
-        this.completionRouter = new CompletionRouter(
-            this.contextManager,
-            this.schemaRetriever,
-            this.syntaxTreeManager,
-            this.documentManager,
-            createMockResourceStateManager(),
-            completionProviders,
-        );
+        this.completionRouter = new CompletionRouter(this.contextManager, completionProviders);
         this.hoverRouter = new HoverRouter(this.contextManager, this.schemaRetriever);
         this.initialize(startingContent);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After adding a static create using server components and making few of the providers server components themselves, these components are no longer used or needed by the constructor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
