### PR TITLE
code lens for managed resources, dry run and deployment

### DIFF
--- a/src/codeLens/ManagedResourceCodeLens.ts
+++ b/src/codeLens/ManagedResourceCodeLens.ts
@@ -1,0 +1,71 @@
+import { CodeLens, Position, Range } from 'vscode-languageserver';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { TopLevelSection } from '../context/ContextType';
+import { getEntityMap } from '../context/SectionContextBuilder';
+import { Resource } from '../context/semantic/Entity';
+import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
+import { ServerComponents } from '../server/ServerComponents';
+
+const MANAGED_RESOURCE_CONSTANTS = {
+    COMMAND_TITLE: 'Open Stack Template',
+    COMMAND_NAME: 'aws.cloudformation.api.openStackTemplate',
+    STACK_NAME_REGEX: /^\s*"?StackName"?\s*:/,
+} as const;
+
+export class ManagedResourceCodeLens {
+    constructor(private readonly syntaxTreeManager: SyntaxTreeManager) {}
+
+    getCodeLenses(uri: string, document: TextDocument): CodeLens[] {
+        const lenses: CodeLens[] = [];
+
+        const syntaxTree = this.syntaxTreeManager.getSyntaxTree(uri);
+        if (!syntaxTree) {
+            return lenses;
+        }
+
+        const resourcesMap = getEntityMap(syntaxTree, TopLevelSection.Resources);
+        if (!resourcesMap) {
+            return lenses;
+        }
+
+        const text = document.getText();
+        const lines = text.split('\n');
+
+        for (const [, resourceContext] of resourcesMap) {
+            const resource = resourceContext.entity as Resource;
+            const metadata = resource.Metadata;
+
+            if (
+                metadata?.ManagedByStack === true &&
+                typeof metadata.StackName === 'string' &&
+                typeof metadata.PrimaryIdentifier === 'string'
+            ) {
+                const stackName = metadata.StackName;
+                const primaryIdentifier = metadata.PrimaryIdentifier;
+
+                const startRow = resourceContext.startPosition.row;
+                const endRow = resourceContext.endPosition.row;
+
+                for (let i = startRow; i <= endRow && i < lines.length; i++) {
+                    if (MANAGED_RESOURCE_CONSTANTS.STACK_NAME_REGEX.test(lines[i])) {
+                        lenses.push({
+                            range: Range.create(Position.create(i, 0), Position.create(i, 0)),
+                            command: {
+                                title: MANAGED_RESOURCE_CONSTANTS.COMMAND_TITLE,
+                                command: MANAGED_RESOURCE_CONSTANTS.COMMAND_NAME,
+                                arguments: [stackName, primaryIdentifier],
+                            },
+                        });
+                        break;
+                    }
+                }
+            }
+        }
+
+        return lenses;
+    }
+
+    static create(components: ServerComponents): ManagedResourceCodeLens {
+        return new ManagedResourceCodeLens(components.syntaxTreeManager);
+    }
+}

--- a/src/codeLens/StackActionsCodeLens.ts
+++ b/src/codeLens/StackActionsCodeLens.ts
@@ -1,0 +1,34 @@
+import { CodeLens, Position, Range } from 'vscode-languageserver';
+
+const STACK_ACTION_TITLES = {
+    DRY_RUN: 'Dry Run Deployment',
+    DEPLOY: 'Deploy',
+} as const;
+
+const STACK_ACTION_COMMANDS = {
+    VALIDATE: 'aws.cloudformation.api.validateTemplate',
+    DEPLOY: 'aws.cloudformation.api.deployTemplate',
+} as const;
+
+export function getStackActionsCodeLenses(uri: string): CodeLens[] {
+    const range = Range.create(Position.create(0, 0), Position.create(0, 0));
+
+    return [
+        {
+            range,
+            command: {
+                title: STACK_ACTION_TITLES.DRY_RUN,
+                command: STACK_ACTION_COMMANDS.VALIDATE,
+                arguments: [uri],
+            },
+        },
+        {
+            range,
+            command: {
+                title: STACK_ACTION_TITLES.DEPLOY,
+                command: STACK_ACTION_COMMANDS.DEPLOY,
+                arguments: [uri],
+            },
+        },
+    ];
+}

--- a/src/handlers/CodeLensHandler.ts
+++ b/src/handlers/CodeLensHandler.ts
@@ -1,0 +1,31 @@
+import { CodeLens, CodeLensParams } from 'vscode-languageserver';
+import { ServerRequestHandler } from 'vscode-languageserver/lib/common/server';
+import { getStackActionsCodeLenses } from '../codeLens/StackActionsCodeLens';
+import { ServerComponents } from '../server/ServerComponents';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+
+const log = LoggerFactory.getLogger('CodeLensHandler');
+
+export function codeLensHandler(
+    components: ServerComponents,
+): ServerRequestHandler<CodeLensParams, CodeLens[], never, void> {
+    return (params, _token, _workDoneProgress, _resultProgress) => {
+        log.debug({
+            Handler: 'CodeLens',
+            Document: params.textDocument.uri,
+        });
+
+        const document = components.documents.documents.get(params.textDocument.uri);
+        if (!document) {
+            return [];
+        }
+
+        const stackActions = getStackActionsCodeLenses(params.textDocument.uri);
+        const managedResourceActions = components.managedResourceCodeLens.getCodeLenses(
+            params.textDocument.uri,
+            document,
+        );
+
+        return [...stackActions, ...managedResourceActions];
+    };
+}

--- a/src/handlers/ResourceHandler.ts
+++ b/src/handlers/ResourceHandler.ts
@@ -1,4 +1,8 @@
+import { randomUUID } from 'crypto';
 import { ServerRequestHandler } from 'vscode-languageserver';
+import { RequestHandler } from 'vscode-languageserver/node';
+import { TopLevelSection } from '../context/ContextType';
+import { getEntityMap } from '../context/SectionContextBuilder';
 import {
     ResourceTypesResult,
     ListResourcesParams,
@@ -12,6 +16,7 @@ import {
 } from '../resourceState/ResourceStateTypes';
 import { ResourceStackManagementResult } from '../resourceState/StackManagementInfoProvider';
 import { ServerComponents } from '../server/ServerComponents';
+import { GetStackTemplateParams, GetStackTemplateResult } from '../stacks/StackRequestType';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { extractErrorMessage } from '../utils/Errors';
 
@@ -94,5 +99,65 @@ export function getStackMgmtInfo(
 ): ServerRequestHandler<ResourceIdentifier, ResourceStackManagementResult, never, void> {
     return async (id) => {
         return await components.stackManagementInfoProvider.getResourceManagementState(id);
+    };
+}
+
+export function getManagedResourceStackTemplateHandler(
+    components: ServerComponents,
+): RequestHandler<GetStackTemplateParams, GetStackTemplateResult | undefined, void> {
+    return async (params, _token) => {
+        try {
+            const template = await components.cfnService.getTemplate({ StackName: params.stackName });
+            if (!template) {
+                return;
+            }
+
+            let lineNumber: number | undefined;
+
+            if (params.primaryIdentifier) {
+                const resources = await components.cfnService.describeStackResources({ StackName: params.stackName });
+                const resource = resources.StackResources?.find(
+                    (r) => r.PhysicalResourceId === params.primaryIdentifier,
+                );
+
+                if (!resource?.LogicalResourceId) {
+                    throw new Error(
+                        `Resource with PhysicalResourceId ${params.primaryIdentifier} not found in stack ${params.stackName}`,
+                    );
+                }
+
+                const logicalId = resource.LogicalResourceId;
+                const tempUri = `temp://${randomUUID()}.template`;
+
+                try {
+                    components.syntaxTreeManager.add(tempUri, template);
+
+                    const syntaxTree = components.syntaxTreeManager.getSyntaxTree(tempUri);
+                    if (syntaxTree) {
+                        const resourcesMap = getEntityMap(syntaxTree, TopLevelSection.Resources);
+                        const resourceContext = resourcesMap?.get(logicalId);
+                        if (resourceContext) {
+                            lineNumber = resourceContext.startPosition.row;
+                        }
+                    }
+                } finally {
+                    components.syntaxTreeManager.deleteSyntaxTree(tempUri);
+                }
+            }
+
+            return {
+                templateBody: template,
+                lineNumber,
+            };
+        } catch (error) {
+            log.error({
+                Handler: 'GetManagedResourceStackTemplateHandler',
+                StackName: params.stackName,
+                ErrorMessage: error instanceof Error ? error.message : String(error),
+                ErrorStack: error instanceof Error ? error.stack : undefined,
+                Error: error,
+            });
+            throw error;
+        }
     };
 }

--- a/src/protocol/LspHandlers.ts
+++ b/src/protocol/LspHandlers.ts
@@ -19,6 +19,8 @@ import {
     CodeActionParams,
     CodeAction,
     Command,
+    CodeLens,
+    CodeLensParams,
 } from 'vscode-languageserver/node';
 import {
     CompletionList,
@@ -128,5 +130,9 @@ export class LspHandlers {
 
     onDidChangeConfiguration(handler: NotificationHandler<DidChangeConfigurationParams>) {
         this.connection.onDidChangeConfiguration(handler);
+    }
+
+    onCodeLens(handler: ServerRequestHandler<CodeLensParams, CodeLens[], never, void>) {
+        this.connection.onCodeLens(handler);
     }
 }

--- a/src/protocol/LspStackHandlers.ts
+++ b/src/protocol/LspStackHandlers.ts
@@ -15,7 +15,14 @@ import {
     GetParametersResult,
     GetCapabilitiesResult,
 } from '../stacks/actions/StackActionRequestType';
-import { ListStacksParams, ListStacksRequest, ListStacksResult } from '../stacks/StackRequestType';
+import {
+    ListStacksParams,
+    ListStacksResult,
+    ListStacksRequest,
+    GetStackTemplateParams,
+    GetStackTemplateResult,
+    GetStackTemplateRequest,
+} from '../stacks/StackRequestType';
 import { Identifiable } from './LspTypes';
 
 export class LspStackHandlers {
@@ -47,5 +54,9 @@ export class LspStackHandlers {
 
     onListStacks(handler: RequestHandler<ListStacksParams, ListStacksResult, void>) {
         this.connection.onRequest(ListStacksRequest.method, handler);
+    }
+
+    onGetStackTemplate(handler: RequestHandler<GetStackTemplateParams, GetStackTemplateResult | undefined, void>) {
+        this.connection.onRequest(GetStackTemplateRequest.method, handler);
     }
 }

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -8,6 +8,7 @@ import {
     ssoTokenChangedHandler,
 } from '../handlers/AuthHandler';
 import { codeActionHandler } from '../handlers/CodeActionHandler';
+import { codeLensHandler } from '../handlers/CodeLensHandler';
 import { completionHandler } from '../handlers/CompletionHandler';
 import { configurationHandler } from '../handlers/ConfigurationHandler';
 import { definitionHandler } from '../handlers/DefinitionHandler';
@@ -18,6 +19,7 @@ import { hoverHandler } from '../handlers/HoverHandler';
 import { initializedHandler } from '../handlers/Initialize';
 import { inlineCompletionHandler } from '../handlers/InlineCompletionHandler';
 import {
+    getManagedResourceStackTemplateHandler,
     listResourcesHandler,
     getResourceTypesHandler,
     importResourceStateHandler,
@@ -63,6 +65,7 @@ export class CfnServer {
         this.features.handlers.onDefinition(definitionHandler(this.components));
         this.features.handlers.onDocumentSymbol(documentSymbolHandler(this.components));
         this.features.handlers.onDidChangeConfiguration(configurationHandler(this.components));
+        this.features.handlers.onCodeLens(codeLensHandler(this.components));
 
         this.features.authHandlers.onIamCredentialsUpdate(iamCredentialsUpdateHandler(this.components));
         this.features.authHandlers.onBearerCredentialsUpdate(bearerCredentialsUpdateHandler(this.components));
@@ -77,6 +80,7 @@ export class CfnServer {
         this.features.stackHandlers.onGetValidationStatus(getValidationStatusHandler(this.components));
         this.features.stackHandlers.onGetDeploymentStatus(getDeploymentStatusHandler(this.components));
         this.features.stackHandlers.onListStacks(listStacksHandler(this.components));
+        this.features.stackHandlers.onGetStackTemplate(getManagedResourceStackTemplateHandler(this.components));
 
         this.features.resourceHandlers.onListResources(listResourcesHandler(this.components));
         this.features.resourceHandlers.onRefreshResourceList(refreshResourceListHandler(this.components));

--- a/src/server/ServerComponents.ts
+++ b/src/server/ServerComponents.ts
@@ -2,6 +2,7 @@ import { CfnAI } from '../ai/CfnAI';
 import { AwsCredentials } from '../auth/AwsCredentials';
 import { CompletionRouter } from '../autocomplete/CompletionRouter';
 import { InlineCompletionRouter } from '../autocomplete/InlineCompletionRouter';
+import { ManagedResourceCodeLens } from '../codeLens/ManagedResourceCodeLens';
 import { ContextManager } from '../context/ContextManager';
 import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
 import { DataStoreFactoryProvider, MultiDataStoreFactoryProvider } from '../datastore/DataStore';
@@ -92,6 +93,7 @@ export class ServerComponents {
     readonly definitionProvider: DefinitionProvider;
     readonly codeActionService: CodeActionService;
     readonly documentSymbolRouter: DocumentSymbolRouter;
+    readonly managedResourceCodeLens: ManagedResourceCodeLens;
 
     // AI
     readonly cfnAI: CfnAI;
@@ -145,6 +147,7 @@ export class ServerComponents {
         this.definitionProvider = overrides.definitionProvider ?? DefinitionProvider.create(this);
         this.codeActionService = overrides.codeActionService ?? CodeActionService.create(this);
         this.documentSymbolRouter = overrides.documentSymbolRouter ?? DocumentSymbolRouter.create(this);
+        this.managedResourceCodeLens = overrides.managedResourceCodeLens ?? ManagedResourceCodeLens.create(this);
 
         this.cfnAI = overrides.cfnAI ?? CfnAI.create(this);
 

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -46,6 +46,7 @@ import {
     waitUntilStackUpdateComplete,
     waitUntilStackCreateComplete,
     DescribeChangeSetCommandOutput,
+    GetTemplateCommand,
 } from '@aws-sdk/client-cloudformation';
 import { WaiterConfiguration, WaiterResult } from '@smithy/util-waiter';
 import { ServerComponents } from '../server/ServerComponents';
@@ -105,6 +106,11 @@ export class CfnService {
         NextToken?: string;
     }): Promise<DescribeStacksCommandOutput> {
         return await this.withClient((client) => client.send(new DescribeStacksCommand(params ?? {})));
+    }
+
+    public async getTemplate(params: { StackName: string }): Promise<string | undefined> {
+        const response = await this.withClient((client) => client.send(new GetTemplateCommand(params)));
+        return response.TemplateBody;
     }
 
     public async createChangeSet(params: {

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -11,3 +11,17 @@ export type ListStacksResult = {
 };
 
 export const ListStacksRequest = new RequestType<ListStacksParams, ListStacksResult, void>('aws/cfn/stacks');
+
+export type GetStackTemplateParams = {
+    stackName: string;
+    primaryIdentifier?: string;
+};
+
+export type GetStackTemplateResult = {
+    templateBody: string;
+    lineNumber?: number;
+};
+
+export const GetStackTemplateRequest = new RequestType<GetStackTemplateParams, GetStackTemplateResult, void>(
+    'aws/cfn/stack/template',
+);

--- a/tst/unit/codeLens/ManagedResourceCodeLens.test.ts
+++ b/tst/unit/codeLens/ManagedResourceCodeLens.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { ManagedResourceCodeLens } from '../../../src/codeLens/ManagedResourceCodeLens';
+import { getEntityMap } from '../../../src/context/SectionContextBuilder';
+import { createMockSyntaxTreeManager } from '../../utils/MockServerComponents';
+
+// Mock the SectionContextBuilder module
+vi.mock('../../../src/context/SectionContextBuilder', () => ({
+    getEntityMap: vi.fn(),
+}));
+
+describe('ManagedResourceCodeLens', () => {
+    let mockSyntaxTreeManager: ReturnType<typeof createMockSyntaxTreeManager>;
+    let codeLens: ManagedResourceCodeLens;
+    let mockGetEntityMap: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockSyntaxTreeManager = createMockSyntaxTreeManager();
+        codeLens = new ManagedResourceCodeLens(mockSyntaxTreeManager);
+        mockGetEntityMap = vi.mocked(getEntityMap);
+    });
+
+    it('should return empty array when syntax tree is not found', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({} as any);
+
+        const document = TextDocument.create(
+            'file:///test.yaml',
+            'yaml',
+            1,
+            'Resources:\n  Bucket:\n    Type: AWS::S3::Bucket',
+        );
+        const result = codeLens.getCodeLenses('file:///test.yaml', document);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should return empty array when no resources found', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({} as any);
+        mockGetEntityMap.mockReturnValue(undefined);
+
+        const document = TextDocument.create('file:///test.yaml', 'yaml', 1, 'AWSTemplateFormatVersion: "2010-09-09"');
+        const result = codeLens.getCodeLenses('file:///test.yaml', document);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should return code lens for managed resource with boolean ManagedByStack', () => {
+        const yamlContent = `Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      ManagedByStack: true
+      StackName: test-stack
+      PrimaryIdentifier: bucket-id`;
+
+        const document = TextDocument.create('file:///test.yaml', 'yaml', 1, yamlContent);
+
+        const mockResourceContext = {
+            entity: {
+                Metadata: {
+                    ManagedByStack: true,
+                    StackName: 'test-stack',
+                    PrimaryIdentifier: 'bucket-id',
+                },
+            },
+            startPosition: { row: 1 },
+            endPosition: { row: 6 },
+        };
+
+        mockSyntaxTreeManager.getSyntaxTree.returns({} as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', mockResourceContext]]));
+
+        const result = codeLens.getCodeLenses('file:///test.yaml', document);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].command?.title).toBe('Open Stack Template');
+        expect(result[0].command?.command).toBe('aws.cloudformation.api.openStackTemplate');
+        expect(result[0].command?.arguments).toEqual(['test-stack', 'bucket-id']);
+    });
+
+    it('should not return code lens for resource with string ManagedByStack', () => {
+        const yamlContent = `Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      ManagedByStack: "true"
+      StackName: test-stack
+      PrimaryIdentifier: bucket-id`;
+
+        const document = TextDocument.create('file:///test.yaml', 'yaml', 1, yamlContent);
+
+        const mockResourceContext = {
+            entity: {
+                Metadata: {
+                    ManagedByStack: 'true', // string instead of boolean
+                    StackName: 'test-stack',
+                    PrimaryIdentifier: 'bucket-id',
+                },
+            },
+            startPosition: { row: 1 },
+            endPosition: { row: 6 },
+        };
+
+        mockSyntaxTreeManager.getSyntaxTree.returns({} as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', mockResourceContext]]));
+
+        const result = codeLens.getCodeLenses('file:///test.yaml', document);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should not return code lens when missing required metadata fields', () => {
+        const yamlContent = `Resources:
+  Bucket:
+    Type: AWS::S3::Bucket
+    Metadata:
+      ManagedByStack: true
+      StackName: test-stack`;
+
+        const document = TextDocument.create('file:///test.yaml', 'yaml', 1, yamlContent);
+
+        const mockResourceContext = {
+            entity: {
+                Metadata: {
+                    ManagedByStack: true,
+                    StackName: 'test-stack',
+                    // Missing PrimaryIdentifier
+                },
+            },
+            startPosition: { row: 1 },
+            endPosition: { row: 5 },
+        };
+
+        mockSyntaxTreeManager.getSyntaxTree.returns({} as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', mockResourceContext]]));
+
+        const result = codeLens.getCodeLenses('file:///test.yaml', document);
+
+        expect(result).toEqual([]);
+    });
+});

--- a/tst/unit/handlers/CodeLensHandler.test.ts
+++ b/tst/unit/handlers/CodeLensHandler.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CodeLensParams, CancellationToken } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { codeLensHandler } from '../../../src/handlers/CodeLensHandler';
+import { createMockComponents } from '../../utils/MockServerComponents';
+
+describe('CodeLensHandler', () => {
+    let mockComponents: ReturnType<typeof createMockComponents>;
+    let handler: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockComponents = createMockComponents();
+        handler = codeLensHandler(mockComponents);
+    });
+
+    it('should return empty array when document is not found', async () => {
+        // Mock documents.documents.get to return undefined
+        const mockDocuments = {
+            get: vi.fn().mockReturnValue(undefined),
+        };
+        (mockComponents.documents as any).documents = mockDocuments;
+
+        const params: CodeLensParams = {
+            textDocument: { uri: 'file:///test.yaml' },
+        };
+
+        const result = await handler(params, CancellationToken.None);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should return stack actions and managed resource code lenses', async () => {
+        const document = TextDocument.create(
+            'file:///test.yaml',
+            'yaml',
+            1,
+            'Resources:\n  Bucket:\n    Type: AWS::S3::Bucket',
+        );
+
+        // Mock documents.documents.get to return the document
+        const mockDocuments = {
+            get: vi.fn().mockReturnValue(document),
+        };
+        (mockComponents.documents as any).documents = mockDocuments;
+
+        mockComponents.managedResourceCodeLens.getCodeLenses.returns([
+            {
+                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } },
+                command: {
+                    title: 'Open Stack Template',
+                    command: 'aws.cloudformation.api.openStackTemplate',
+                    arguments: ['test-stack', 'bucket-id'],
+                },
+            },
+        ]);
+
+        const params: CodeLensParams = {
+            textDocument: { uri: 'file:///test.yaml' },
+        };
+
+        const result = await handler(params, CancellationToken.None);
+
+        expect(result).toHaveLength(3); // 2 stack actions + 1 managed resource
+        expect(result[0].command?.title).toBe('Dry Run Deployment');
+        expect(result[1].command?.title).toBe('Deploy');
+        expect(result[2].command?.title).toBe('Open Stack Template');
+    });
+
+    it('should pass correct arguments to stack action commands', async () => {
+        const document = TextDocument.create(
+            'file:///test.yaml',
+            'yaml',
+            1,
+            'Resources:\n  Bucket:\n    Type: AWS::S3::Bucket',
+        );
+
+        // Mock documents.documents.get to return the document
+        const mockDocuments = {
+            get: vi.fn().mockReturnValue(document),
+        };
+        (mockComponents.documents as any).documents = mockDocuments;
+
+        mockComponents.managedResourceCodeLens.getCodeLenses.returns([]);
+
+        const params: CodeLensParams = {
+            textDocument: { uri: 'file:///test.yaml' },
+        };
+
+        const result = await handler(params, CancellationToken.None);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].command?.arguments).toEqual(['file:///test.yaml']);
+        expect(result[1].command?.arguments).toEqual(['file:///test.yaml']);
+    });
+});

--- a/tst/unit/handlers/ResourceHandler.test.ts
+++ b/tst/unit/handlers/ResourceHandler.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CancellationToken } from 'vscode-languageserver-protocol';
+import { getEntityMap } from '../../../src/context/SectionContextBuilder';
+import { getManagedResourceStackTemplateHandler } from '../../../src/handlers/ResourceHandler';
+import { GetStackTemplateParams } from '../../../src/stacks/StackRequestType';
+import { createMockComponents } from '../../utils/MockServerComponents';
+
+// Mock the SectionContextBuilder module
+vi.mock('../../../src/context/SectionContextBuilder', () => ({
+    getEntityMap: vi.fn(),
+}));
+
+describe('ResourceHandler - getManagedResourceStackTemplateHandler', () => {
+    let mockComponents: ReturnType<typeof createMockComponents>;
+    let handler: any;
+    let mockGetEntityMap: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockComponents = createMockComponents();
+        handler = getManagedResourceStackTemplateHandler(mockComponents);
+        mockGetEntityMap = vi.mocked(getEntityMap);
+    });
+
+    it('should return template without line number when no primaryIdentifier provided', async () => {
+        const templateBody = '{"Resources": {"Bucket": {"Type": "AWS::S3::Bucket"}}}';
+        mockComponents.cfnService.getTemplate.resolves(templateBody);
+
+        const params: GetStackTemplateParams = {
+            stackName: 'test-stack',
+        };
+
+        const result = await handler(params, CancellationToken.None);
+
+        expect(result).toEqual({
+            templateBody,
+            lineNumber: undefined,
+        });
+        expect(mockComponents.cfnService.getTemplate.calledWith({ StackName: 'test-stack' })).toBe(true);
+    });
+
+    it('should return undefined when template not found', async () => {
+        mockComponents.cfnService.getTemplate.resolves(undefined);
+
+        const params: GetStackTemplateParams = {
+            stackName: 'test-stack',
+        };
+
+        const result = await handler(params, CancellationToken.None);
+
+        expect(result).toBeUndefined();
+    });
+
+    it('should return template with line number when resource found', async () => {
+        const templateBody = `Resources:
+  DeploymentBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: test-bucket`;
+
+        mockComponents.cfnService.getTemplate.resolves(templateBody);
+        mockComponents.cfnService.describeStackResources.resolves({
+            $metadata: {},
+            StackResources: [
+                {
+                    LogicalResourceId: 'DeploymentBucket',
+                    PhysicalResourceId: 'bucket-physical-id',
+                    ResourceType: 'AWS::S3::Bucket',
+                    Timestamp: new Date(),
+                    ResourceStatus: 'CREATE_COMPLETE',
+                },
+            ],
+        });
+
+        const mockResourceContext = {
+            startPosition: { row: 1 },
+        };
+
+        mockComponents.syntaxTreeManager.getSyntaxTree.returns({} as any);
+        mockGetEntityMap.mockReturnValue(new Map([['DeploymentBucket', mockResourceContext]]));
+
+        const params: GetStackTemplateParams = {
+            stackName: 'test-stack',
+            primaryIdentifier: 'bucket-physical-id',
+        };
+
+        const result = await handler(params, CancellationToken.None);
+
+        expect(result?.templateBody).toBe(templateBody);
+        expect(result?.lineNumber).toBe(1);
+        expect(mockComponents.syntaxTreeManager.add.called).toBe(true);
+        expect(mockComponents.syntaxTreeManager.deleteSyntaxTree.called).toBe(true);
+    });
+
+    it('should throw error when resource not found in stack', async () => {
+        const templateBody = '{"Resources": {"Bucket": {"Type": "AWS::S3::Bucket"}}}';
+        mockComponents.cfnService.getTemplate.resolves(templateBody);
+        mockComponents.cfnService.describeStackResources.resolves({
+            $metadata: {},
+            StackResources: [],
+        });
+
+        const params: GetStackTemplateParams = {
+            stackName: 'test-stack',
+            primaryIdentifier: 'non-existent-id',
+        };
+
+        await expect(handler(params, CancellationToken.None)).rejects.toThrow(
+            'Resource with PhysicalResourceId non-existent-id not found in stack test-stack',
+        );
+    });
+
+    it('should handle errors and rethrow them', async () => {
+        const error = new Error('AWS API Error');
+        mockComponents.cfnService.getTemplate.rejects(error);
+
+        const params: GetStackTemplateParams = {
+            stackName: 'test-stack',
+        };
+
+        await expect(handler(params, CancellationToken.None)).rejects.toThrow('AWS API Error');
+    });
+});

--- a/tst/utils/MockServerComponents.ts
+++ b/tst/utils/MockServerComponents.ts
@@ -8,6 +8,7 @@ import { InlineCompletionRouter } from '../../src/autocomplete/InlineCompletionR
 import { ResourceEntityCompletionProvider } from '../../src/autocomplete/ResourceEntityCompletionProvider';
 import { ResourceStateCompletionProvider } from '../../src/autocomplete/ResourceStateCompletionProvider';
 import { TopLevelSectionCompletionProvider } from '../../src/autocomplete/TopLevelSectionCompletionProvider';
+import { ManagedResourceCodeLens } from '../../src/codeLens/ManagedResourceCodeLens';
 import { ContextManager } from '../../src/context/ContextManager';
 import { SyntaxTreeManager } from '../../src/context/syntaxtree/SyntaxTreeManager';
 import { DataStoreFactoryProvider, MemoryDataStoreFactoryProvider } from '../../src/datastore/DataStore';
@@ -80,6 +81,7 @@ export class MockedServerComponents extends ServerComponents {
     declare readonly definitionProvider: StubbedInstance<DefinitionProvider>;
     declare readonly codeActionService: StubbedInstance<CodeActionService>;
     declare readonly documentSymbolRouter: StubbedInstance<DocumentSymbolRouter>;
+    declare readonly managedResourceCodeLens: StubbedInstance<ManagedResourceCodeLens>;
 
     declare readonly validationWorkflowService: StubbedInstance<ValidationWorkflow>;
     declare readonly deploymentWorkflowService: StubbedInstance<DeploymentWorkflow>;
@@ -232,6 +234,10 @@ export function createMockDocumentSymbolRouter() {
     return stubInterface<DocumentSymbolRouter>();
 }
 
+export function createMockManagedResourceCodeLens() {
+    return stubInterface<ManagedResourceCodeLens>();
+}
+
 export function createMockTopLevelSectionCompletionProvider(
     syntaxTreeManager?: SyntaxTreeManager,
     documentManager?: DocumentManager,
@@ -338,6 +344,7 @@ export function createMockComponents(overrides: Partial<ServerComponents> = {}):
             definitionProvider: overrides.definitionProvider ?? createMockDefinitionProvider(),
             codeActionService: overrides.codeActionService ?? createMockCodeActionService(),
             documentSymbolRouter: overrides.documentSymbolRouter ?? createMockDocumentSymbolRouter(),
+            managedResourceCodeLens: overrides.managedResourceCodeLens ?? createMockManagedResourceCodeLens(),
             validationWorkflowService: overrides.validationWorkflowService ?? createMockValidationWorkflowService(),
             deploymentWorkflowService: overrides.deploymentWorkflowService ?? createMockDeploymentWorkflowService(),
             cfnAI: overrides.cfnAI ?? mockCfnAi(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- provide dry run deployment and deploy codelens at the top of the template
- provide open stack template code lens above stack name of imported resources which contain metadata with primaryId and stack name
- call describe stack resources and use primary id of resource to get the logical id, provide line # of logical id for client to use to reveal range

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
