### PR TITLE
export artifacts as readonly

### DIFF
--- a/src/artifacts/IntrinsicFunctionsDocs.ts
+++ b/src/artifacts/IntrinsicFunctionsDocs.ts
@@ -1,6 +1,6 @@
 import { IntrinsicFunction } from '../context/ContextType';
 
-export const intrinsicFunctionsDocsMap = getIntrinsicFunctionsDocsMap();
+export const intrinsicFunctionsDocsMap: ReadonlyMap<IntrinsicFunction, string> = getIntrinsicFunctionsDocsMap();
 
 function getIntrinsicFunctionsDocsMap(): Map<IntrinsicFunction, string> {
     const intrinsicFunctionsDocsMap = new Map<IntrinsicFunction, string>();

--- a/src/artifacts/OutputSectionFieldDocs.ts
+++ b/src/artifacts/OutputSectionFieldDocs.ts
@@ -1,4 +1,4 @@
-export const outputSectionFieldDocsMap = getOutputSectionFieldDocsMap();
+export const outputSectionFieldDocsMap: ReadonlyMap<string, string> = getOutputSectionFieldDocsMap();
 
 function getOutputSectionFieldDocsMap(): Map<string, string> {
     const outputSectionFieldDocsMap = new Map<string, string>();

--- a/src/artifacts/ParameterAttributeDocs.ts
+++ b/src/artifacts/ParameterAttributeDocs.ts
@@ -1,4 +1,4 @@
-export const parameterAttributeDocsMap = getParameterAttributeDocsMap();
+export const parameterAttributeDocsMap: ReadonlyMap<string, string> = getParameterAttributeDocsMap();
 
 function getParameterAttributeDocsMap(): Map<string, string> {
     const parameterAttributeDocsMap = new Map<string, string>();

--- a/src/artifacts/PseudoParameterDocs.ts
+++ b/src/artifacts/PseudoParameterDocs.ts
@@ -1,6 +1,6 @@
 import { PseudoParameter } from '../context/ContextType';
 
-export const pseudoParameterDocsMap = getPseudoParameterDocsMap();
+export const pseudoParameterDocsMap: ReadonlyMap<PseudoParameter, string> = getPseudoParameterDocsMap();
 
 function getPseudoParameterDocsMap(): Map<PseudoParameter, string> {
     const pseudoParameterDocsMap = new Map<PseudoParameter, string>();

--- a/src/artifacts/ResourceAttributeDocs.ts
+++ b/src/artifacts/ResourceAttributeDocs.ts
@@ -1,6 +1,6 @@
 import { ResourceAttribute } from '../context/ContextType';
 
-export const resourceAttributeDocsMap = getResourceAttributeDocsMap();
+export const resourceAttributeDocsMap: ReadonlyMap<ResourceAttribute, string> = getResourceAttributeDocsMap();
 
 function getResourceAttributeDocsMap(): Map<ResourceAttribute, string> {
     const resourceAttributeDocsMap = new Map<ResourceAttribute, string>();

--- a/src/artifacts/TemplateSectionDocs.ts
+++ b/src/artifacts/TemplateSectionDocs.ts
@@ -1,6 +1,6 @@
 import { TopLevelSection } from '../context/ContextType';
 
-export const templateSectionDocsMap = getTemplateSectionDocsMap();
+export const templateSectionDocsMap: ReadonlyMap<TopLevelSection, string> = getTemplateSectionDocsMap();
 
 function getTemplateSectionDocsMap(): Map<TopLevelSection, string> {
     const templateSectionDocsMap = new Map<TopLevelSection, string>();

--- a/src/autocomplete/IntrinsicFunctionArgumentCompletionProvider.ts
+++ b/src/autocomplete/IntrinsicFunctionArgumentCompletionProvider.ts
@@ -243,7 +243,9 @@ export class IntrinsicFunctionArgumentCompletionProvider implements CompletionPr
         return undefined;
     }
 
-    private getPseudoParametersAsCompletionItems(pseudoParameterMap: Map<PseudoParameter, string>): CompletionItem[] {
+    private getPseudoParametersAsCompletionItems(
+        pseudoParameterMap: ReadonlyMap<PseudoParameter, string>,
+    ): CompletionItem[] {
         const completionItems: CompletionItem[] = [];
         for (const [paramName, doc] of pseudoParameterMap) {
             completionItems.push(


### PR DESCRIPTION
- From [this](https://github.com/aws-cloudformation/cloudformation-languageserver/pull/46#discussion_r2412027424) feedback, export artifacts in the docs for hover as Readonly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
