### PR TITLE
Modify workflow interfaces for describe call

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -14,6 +14,8 @@ import {
     CreateStackActionParams,
     CreateStackActionResult,
     GetStackActionStatusResult,
+    DescribeValidationStatusResult,
+    DescribeDeploymentStatusResult,
 } from '../stacks/actions/StackActionRequestType';
 import { ListStacksParams, ListStacksResult } from '../stacks/StackRequestType';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
@@ -106,6 +108,36 @@ export function getDeploymentStatusHandler(
             return components.deploymentWorkflowService.getStatus(params);
         } catch (error) {
             handleStackActionError(error, 'Failed to get deployment status');
+        }
+    };
+}
+
+export function describeValidationStatusHandler(
+    components: ServerComponents,
+): RequestHandler<Identifiable, DescribeValidationStatusResult, void> {
+    return (rawParams) => {
+        log.debug({ Handler: 'describeValidationStatusHandler', rawParams });
+
+        try {
+            const params = parseWithPrettyError(parseIdentifiable, rawParams);
+            return components.validationWorkflowService.describeStatus(params);
+        } catch (error) {
+            handleStackActionError(error, 'Failed to describe validation status');
+        }
+    };
+}
+
+export function describeDeploymentStatusHandler(
+    components: ServerComponents,
+): RequestHandler<Identifiable, DescribeDeploymentStatusResult, void> {
+    return (rawParams) => {
+        log.debug({ Handler: 'describeDeploymentStatusHandler', rawParams });
+
+        try {
+            const params = parseWithPrettyError(parseIdentifiable, rawParams);
+            return components.deploymentWorkflowService.describeStatus(params);
+        } catch (error) {
+            handleStackActionError(error, 'Failed to describe deployment status');
         }
     };
 }

--- a/src/protocol/LspStackHandlers.ts
+++ b/src/protocol/LspStackHandlers.ts
@@ -6,6 +6,8 @@ import {
     GetValidationStatusRequest,
     GetCapabilitiesRequest,
     GetParametersRequest,
+    DescribeValidationStatusRequest,
+    DescribeDeploymentStatusRequest,
 } from '../stacks/actions/StackActionProtocol';
 import {
     TemplateUri,
@@ -14,6 +16,8 @@ import {
     GetStackActionStatusResult,
     GetParametersResult,
     GetCapabilitiesResult,
+    DescribeValidationStatusResult,
+    DescribeDeploymentStatusResult,
 } from '../stacks/actions/StackActionRequestType';
 import {
     ListStacksParams,
@@ -42,6 +46,14 @@ export class LspStackHandlers {
 
     onGetDeploymentStatus(handler: RequestHandler<Identifiable, GetStackActionStatusResult, void>) {
         this.connection.onRequest(GetDeploymentStatusRequest.method, handler);
+    }
+
+    onDescribeValidationStatus(handler: RequestHandler<Identifiable, DescribeValidationStatusResult, void>) {
+        this.connection.onRequest(DescribeValidationStatusRequest.method, handler);
+    }
+
+    onDescribeDeploymentStatus(handler: RequestHandler<Identifiable, DescribeDeploymentStatusResult, void>) {
+        this.connection.onRequest(DescribeDeploymentStatusRequest.method, handler);
     }
 
     onGetParameters(handler: RequestHandler<TemplateUri, GetParametersResult, void>) {

--- a/src/server/CfnLspProviders.ts
+++ b/src/server/CfnLspProviders.ts
@@ -10,6 +10,11 @@ import { ResourceStateManager } from '../resourceState/ResourceStateManager';
 import { StackManagementInfoProvider } from '../resourceState/StackManagementInfoProvider';
 import { CodeActionService } from '../services/CodeActionService';
 import { DeploymentWorkflow } from '../stacks/actions/DeploymentWorkflow';
+import {
+    DescribeDeploymentStatusResult,
+    DescribeValidationStatusResult,
+} from '../stacks/actions/StackActionRequestType';
+import { StackActionWorkflow } from '../stacks/actions/StackActionWorkflowType';
 import { ValidationWorkflow } from '../stacks/actions/ValidationWorkflow';
 import { Closeable, closeSafely } from '../utils/Closeable';
 import { Configurable, Configurables } from '../utils/Configurable';
@@ -19,8 +24,8 @@ import { CfnInfraCore } from './CfnInfraCore';
 export class CfnLspProviders implements Configurables, Closeable {
     // Business logic
     readonly stackManagementInfoProvider: StackManagementInfoProvider;
-    readonly validationWorkflowService: ValidationWorkflow;
-    readonly deploymentWorkflowService: DeploymentWorkflow;
+    readonly validationWorkflowService: StackActionWorkflow<DescribeValidationStatusResult>;
+    readonly deploymentWorkflowService: StackActionWorkflow<DescribeDeploymentStatusResult>;
     readonly resourceStateManager: ResourceStateManager;
     readonly resourceStateImporter: ResourceStateImporter;
 

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -33,6 +33,8 @@ import {
     getDeploymentStatusHandler,
     getParametersHandler,
     getCapabilitiesHandler,
+    describeValidationStatusHandler,
+    describeDeploymentStatusHandler,
 } from '../handlers/StackHandler';
 import { LspComponents } from '../protocol/LspComponents';
 import { closeSafely } from '../utils/Closeable';
@@ -101,6 +103,8 @@ export class CfnServer {
         this.lsp.stackHandlers.onCreateDeployment(createDeploymentHandler(this.components));
         this.lsp.stackHandlers.onGetValidationStatus(getValidationStatusHandler(this.components));
         this.lsp.stackHandlers.onGetDeploymentStatus(getDeploymentStatusHandler(this.components));
+        this.lsp.stackHandlers.onDescribeValidationStatus(describeValidationStatusHandler(this.components));
+        this.lsp.stackHandlers.onDescribeDeploymentStatus(describeDeploymentStatusHandler(this.components));
         this.lsp.stackHandlers.onListStacks(listStacksHandler(this.components));
         this.lsp.stackHandlers.onGetStackTemplate(getManagedResourceStackTemplateHandler(this.components));
 

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -266,6 +266,7 @@ export class CfnService {
     public async executeChangeSet(params: {
         ChangeSetName: string;
         StackName?: string;
+        ClientRequestToken: string;
     }): Promise<ExecuteChangeSetCommandOutput> {
         return await this.withClient((client) => client.send(new ExecuteChangeSetCommand(params)));
     }

--- a/src/stacks/actions/DeploymentWorkflow.ts
+++ b/src/stacks/actions/DeploymentWorkflow.ts
@@ -1,21 +1,31 @@
 import { ChangeSetType } from '@aws-sdk/client-cloudformation';
+import { DateTime } from 'luxon';
 import { DocumentManager } from '../../document/DocumentManager';
 import { Identifiable } from '../../protocol/LspTypes';
 import { CfnExternal } from '../../server/CfnExternal';
 import { CfnInfraCore } from '../../server/CfnInfraCore';
 import { CfnService } from '../../services/CfnService';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
-import { processChangeSet, waitForValidation, waitForDeployment } from './StackActionOperations';
+import { extractErrorMessage } from '../../utils/Errors';
+import {
+    processChangeSet,
+    waitForValidation,
+    waitForDeployment,
+    processWorkflowUpdates,
+} from './StackActionOperations';
 import {
     CreateStackActionParams,
     CreateStackActionResult,
     StackActionPhase,
     StackActionState,
     GetStackActionStatusResult,
+    DescribeDeploymentStatusResult,
+    DeploymentEvent,
 } from './StackActionRequestType';
 import { StackActionWorkflowState, StackActionWorkflow } from './StackActionWorkflowType';
+import { DRY_RUN_VALIDATION_NAME } from './ValidationWorkflow';
 
-export class DeploymentWorkflow implements StackActionWorkflow {
+export class DeploymentWorkflow implements StackActionWorkflow<DescribeDeploymentStatusResult> {
     private readonly workflows = new Map<string, StackActionWorkflowState>();
     private readonly log = LoggerFactory.getLogger(DeploymentWorkflow);
 
@@ -69,14 +79,28 @@ export class DeploymentWorkflow implements StackActionWorkflow {
         };
     }
 
-    private async runDeploymentAsync(
+    describeStatus(params: Identifiable): DescribeDeploymentStatusResult {
+        const workflow = this.workflows.get(params.id);
+        if (!workflow) {
+            throw new Error(`Workflow not found: ${params.id}`);
+        }
+
+        return {
+            ...this.getStatus(params),
+            ValidationDetails: workflow.validationDetails,
+            DeploymentEvents: workflow.deploymentEvents,
+            FailureReason: workflow.failureReason,
+        };
+    }
+
+    protected async runDeploymentAsync(
         workflowId: string,
         changeSetName: string,
         stackName: string,
         changeSetType: ChangeSetType,
     ): Promise<void> {
         let validationResult;
-        const existingWorkflow = this.workflows.get(workflowId);
+        let existingWorkflow = this.workflows.get(workflowId);
         if (!existingWorkflow) {
             this.log.error({ workflowId }, 'Workflow not found during async execution');
             return;
@@ -85,52 +109,115 @@ export class DeploymentWorkflow implements StackActionWorkflow {
         try {
             validationResult = await waitForValidation(this.cfnService, changeSetName, stackName);
 
-            this.workflows.set(workflowId, {
-                ...existingWorkflow,
+            existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
                 phase: validationResult.phase,
-                state: validationResult.state,
                 changes: validationResult.changes,
             });
 
             if (validationResult.state === StackActionState.FAILED) {
-                return;
-            }
+                existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
+                    state: StackActionState.FAILED,
+                    validationDetails: [
+                        {
+                            ValidationName: DRY_RUN_VALIDATION_NAME,
+                            Timestamp: DateTime.now(),
+                            Severity: 'ERROR',
+                            Message: `Validation failed with reason: ${validationResult.failureReason}`,
+                        },
+                    ],
+                });
 
-            this.workflows.set(workflowId, {
-                ...existingWorkflow,
-                phase: StackActionPhase.VALIDATION_COMPLETE,
-                state: StackActionState.IN_PROGRESS,
-                changes: validationResult.changes,
+                return;
+            } else {
+                existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
+                    validationDetails: [
+                        {
+                            ValidationName: DRY_RUN_VALIDATION_NAME,
+                            Timestamp: DateTime.now(),
+                            Severity: 'INFO',
+                            Message: 'Validation succeeded',
+                        },
+                    ],
+                });
+            }
+        } catch (error) {
+            this.log.error({ error, workflowId }, 'Deployment workflow threw exception during validation phase');
+            processWorkflowUpdates(this.workflows, existingWorkflow, {
+                phase: StackActionPhase.VALIDATION_FAILED,
+                state: StackActionState.FAILED,
+                failureReason: extractErrorMessage(error),
             });
 
+            return;
+        }
+
+        try {
             await this.cfnService.executeChangeSet({
                 StackName: stackName,
                 ChangeSetName: changeSetName,
+                ClientRequestToken: workflowId,
+            });
+        } catch (error) {
+            this.log.error({ error, workflowId }, 'Deployment workflow threw exception during deployment start phase');
+            processWorkflowUpdates(this.workflows, existingWorkflow, {
+                phase: StackActionPhase.DEPLOYMENT_FAILED,
+                state: StackActionState.FAILED,
+                failureReason: extractErrorMessage(error),
             });
 
-            this.workflows.set(workflowId, {
+            return;
+        }
+
+        try {
+            existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
                 ...existingWorkflow,
                 phase: StackActionPhase.DEPLOYMENT_IN_PROGRESS,
                 state: StackActionState.IN_PROGRESS,
-                changes: validationResult.changes,
             });
 
             const deploymentResult = await waitForDeployment(this.cfnService, stackName, changeSetType);
 
-            this.workflows.set(workflowId, {
-                ...existingWorkflow,
+            existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
                 phase: deploymentResult.phase,
                 state: deploymentResult.state,
-                changes: validationResult.changes,
             });
         } catch (error) {
-            this.log.error({ error, workflowId }, 'Deployment workflow failed');
-            this.workflows.set(workflowId, {
-                ...existingWorkflow,
-                phase: validationResult ? StackActionPhase.DEPLOYMENT_FAILED : StackActionPhase.VALIDATION_FAILED,
+            this.log.error({ error, workflowId }, 'Deployment workflow threw exception during deployment phase');
+            processWorkflowUpdates(this.workflows, existingWorkflow, {
+                phase: StackActionPhase.DEPLOYMENT_FAILED,
                 state: StackActionState.FAILED,
-                changes: validationResult?.changes,
+                failureReason: extractErrorMessage(error),
             });
+        } finally {
+            await this.processDeploymentEvents(existingWorkflow, stackName); // Even if the deployment fails, some deployment events may have occurred
+        }
+    }
+
+    private async processDeploymentEvents(
+        existingWorkflow: StackActionWorkflowState,
+        stackName: string,
+    ): Promise<void> {
+        try {
+            const stackEventsResponse = await this.cfnService.describeStackEvents(
+                { StackName: stackName },
+                existingWorkflow.id,
+            );
+
+            const deploymentEvents: DeploymentEvent[] =
+                stackEventsResponse.StackEvents?.map((event) => ({
+                    LogicalResourceId: event.LogicalResourceId,
+                    ResourceType: event.ResourceType,
+                    Timestamp: event.Timestamp ? DateTime.fromJSDate(event.Timestamp) : undefined,
+                    ResourceStatus: event.ResourceStatus,
+                    ResourceStatusReason: event.ResourceStatusReason,
+                    DetailedStatus: event.DetailedStatus,
+                })) ?? [];
+
+            processWorkflowUpdates(this.workflows, existingWorkflow, {
+                deploymentEvents: deploymentEvents,
+            });
+        } catch (error) {
+            this.log.error({ error, stackName }, 'Failed to process deployment events');
         }
     }
 

--- a/src/stacks/actions/StackActionOperations.ts
+++ b/src/stacks/actions/StackActionOperations.ts
@@ -63,7 +63,7 @@ export async function waitForValidation(
                 phase: StackActionPhase.VALIDATION_COMPLETE,
                 state: StackActionState.SUCCESSFUL,
                 changes: mapChangesToStackChanges(response.Changes),
-                reason: result.reason ? String(result.reason) : undefined,
+                failureReason: result.reason ? String(result.reason) : undefined,
             };
         } else {
             logger.warn(
@@ -73,7 +73,7 @@ export async function waitForValidation(
             return {
                 phase: StackActionPhase.VALIDATION_FAILED,
                 state: StackActionState.FAILED,
-                reason: result.reason ? String(result.reason) : undefined, // TODO: Return reason as part of LSP Response
+                failureReason: result.reason ? String(result.reason) : undefined,
             };
         }
     } catch (error) {
@@ -81,7 +81,7 @@ export async function waitForValidation(
         return {
             phase: StackActionPhase.VALIDATION_FAILED,
             state: StackActionState.FAILED,
-            reason: extractErrorMessage(error),
+            failureReason: extractErrorMessage(error),
         };
     }
 }
@@ -105,7 +105,7 @@ export async function waitForDeployment(
             return {
                 phase: StackActionPhase.DEPLOYMENT_COMPLETE,
                 state: StackActionState.SUCCESSFUL,
-                reason: result.reason ? String(result.reason) : undefined,
+                failureReason: result.reason ? String(result.reason) : undefined,
             };
         } else {
             logger.warn(
@@ -115,7 +115,7 @@ export async function waitForDeployment(
             return {
                 phase: StackActionPhase.DEPLOYMENT_FAILED,
                 state: StackActionState.FAILED,
-                reason: result.reason ? String(result.reason) : undefined, // TODO: Return reason as part of LSP Response
+                failureReason: result.reason ? String(result.reason) : undefined,
             };
         }
     } catch (error) {
@@ -123,7 +123,7 @@ export async function waitForDeployment(
         return {
             phase: StackActionPhase.DEPLOYMENT_FAILED,
             state: StackActionState.FAILED,
-            reason: extractErrorMessage(error),
+            failureReason: extractErrorMessage(error),
         };
     }
 }
@@ -213,4 +213,18 @@ export function mapChangesToStackChanges(changes?: Change[]): StackChange[] | un
               }
             : undefined,
     }));
+}
+
+export function processWorkflowUpdates(
+    workflows: Map<string, StackActionWorkflowState>,
+    existingWorkflow: StackActionWorkflowState,
+    workflowUpdates: Partial<StackActionWorkflowState>,
+): StackActionWorkflowState {
+    existingWorkflow = {
+        ...existingWorkflow,
+        ...workflowUpdates,
+    };
+    workflows.set(existingWorkflow.id, existingWorkflow);
+
+    return existingWorkflow;
 }

--- a/src/stacks/actions/StackActionProtocol.ts
+++ b/src/stacks/actions/StackActionProtocol.ts
@@ -7,6 +7,8 @@ import {
     CreateStackActionResult,
     GetStackActionStatusResult,
     GetCapabilitiesResult,
+    DescribeValidationStatusResult,
+    DescribeDeploymentStatusResult,
 } from './StackActionRequestType';
 
 export const CreateValidationRequest = new RequestType<CreateStackActionParams, CreateStackActionResult, void>(
@@ -23,6 +25,14 @@ export const GetValidationStatusRequest = new RequestType<Identifiable, GetStack
 
 export const GetDeploymentStatusRequest = new RequestType<Identifiable, GetStackActionStatusResult, void>(
     'aws/cfn/stack/deployment/status',
+);
+
+export const DescribeValidationStatusRequest = new RequestType<Identifiable, DescribeValidationStatusResult, void>(
+    'aws/cfn/stack/validation/status/describe',
+);
+
+export const DescribeDeploymentStatusRequest = new RequestType<Identifiable, DescribeDeploymentStatusResult, void>(
+    'aws/cfn/stack/deployment/status/describe',
 );
 
 export const GetParametersRequest = new RequestType<TemplateUri, GetParametersResult, void>('aws/cfn/stack/parameters');

--- a/src/stacks/actions/StackActionRequestType.ts
+++ b/src/stacks/actions/StackActionRequestType.ts
@@ -1,4 +1,11 @@
-import { Parameter, Capability, ResourceChangeDetail } from '@aws-sdk/client-cloudformation';
+import {
+    Parameter,
+    Capability,
+    ResourceChangeDetail,
+    ResourceStatus,
+    DetailedStatus,
+} from '@aws-sdk/client-cloudformation';
+import { DateTime } from 'luxon';
 import { Parameter as EntityParameter } from '../../context/semantic/Entity';
 import { Identifiable } from '../../protocol/LspTypes';
 
@@ -57,5 +64,32 @@ export enum StackActionState {
 export type GetStackActionStatusResult = Identifiable & {
     state: StackActionState;
     phase: StackActionPhase;
-    changes?: StackChange[];
+    changes?: StackChange[]; // TODO: move this property to the describe call results
+};
+
+export type ValidationDetail = {
+    ValidationName: string;
+    LogicalId?: string;
+    ResourcePropertyPath?: string;
+    Timestamp: DateTime;
+    Severity: 'INFO' | 'ERROR';
+    Message: string;
+};
+
+export type DeploymentEvent = {
+    LogicalResourceId?: string;
+    ResourceType?: string;
+    Timestamp?: DateTime;
+    ResourceStatus?: ResourceStatus;
+    ResourceStatusReason?: string;
+    DetailedStatus?: DetailedStatus;
+};
+
+export type DescribeValidationStatusResult = GetStackActionStatusResult & {
+    ValidationDetails?: ValidationDetail[];
+    FailureReason?: string;
+};
+
+export type DescribeDeploymentStatusResult = DescribeValidationStatusResult & {
+    DeploymentEvents?: DeploymentEvent[];
 };

--- a/src/stacks/actions/StackActionWorkflowType.ts
+++ b/src/stacks/actions/StackActionWorkflowType.ts
@@ -4,10 +4,12 @@ import { ExtensionName } from '../../utils/ExtensionConfig';
 import {
     CreateStackActionParams,
     CreateStackActionResult,
+    DeploymentEvent,
     GetStackActionStatusResult,
     StackActionPhase,
     StackActionState,
     StackChange,
+    ValidationDetail,
 } from './StackActionRequestType';
 
 export type StackActionWorkflowState = {
@@ -18,25 +20,29 @@ export type StackActionWorkflowState = {
     state: StackActionState;
     phase: StackActionPhase;
     changes?: StackChange[];
+    deploymentEvents?: DeploymentEvent[];
+    validationDetails?: ValidationDetail[];
     lastPolled?: number;
+    failureReason?: string;
 };
 
 export type ValidationWaitForResult = {
     state: StackActionState;
     phase: StackActionPhase;
     changes?: StackChange[];
-    reason?: string;
+    failureReason?: string;
 };
 
 export type DeploymentWaitForResult = {
     state: StackActionState;
     phase: StackActionPhase;
-    reason?: string;
+    failureReason?: string;
 };
 
 export const changeSetNamePrefix = `${ExtensionName}-${AwsEnv}`.replaceAll(' ', '-');
 
-export interface StackActionWorkflow {
+export interface StackActionWorkflow<TDescribeResult> {
     start(params: CreateStackActionParams): Promise<CreateStackActionResult>;
     getStatus(params: Identifiable): GetStackActionStatusResult;
+    describeStatus(params: Identifiable): TDescribeResult;
 }

--- a/src/stacks/actions/ValidationWorkflow.ts
+++ b/src/stacks/actions/ValidationWorkflow.ts
@@ -1,4 +1,5 @@
 import { ChangeSetType } from '@aws-sdk/client-cloudformation';
+import { DateTime } from 'luxon';
 import { SyntaxTreeManager } from '../../context/syntaxtree/SyntaxTreeManager';
 import { DocumentManager } from '../../document/DocumentManager';
 import { Identifiable } from '../../protocol/LspTypes';
@@ -7,21 +8,30 @@ import { CfnInfraCore } from '../../server/CfnInfraCore';
 import { CfnService } from '../../services/CfnService';
 import { DiagnosticCoordinator } from '../../services/DiagnosticCoordinator';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
-import { deleteStackAndChangeSet, deleteChangeSet, processChangeSet, waitForValidation } from './StackActionOperations';
+import { extractErrorMessage } from '../../utils/Errors';
+import {
+    deleteStackAndChangeSet,
+    deleteChangeSet,
+    processChangeSet,
+    waitForValidation,
+    processWorkflowUpdates,
+} from './StackActionOperations';
 import {
     CreateStackActionParams,
     CreateStackActionResult,
     StackActionPhase,
     StackActionState,
     GetStackActionStatusResult,
+    DescribeValidationStatusResult,
 } from './StackActionRequestType';
 import { StackActionWorkflowState, StackActionWorkflow } from './StackActionWorkflowType';
 import { Validation } from './Validation';
 import { ValidationManager } from './ValidationManager';
 
 export const CFN_VALIDATION_SOURCE = 'CFN Dry-Run';
+export const DRY_RUN_VALIDATION_NAME = 'Change Set Dry-Run';
 
-export class ValidationWorkflow implements StackActionWorkflow {
+export class ValidationWorkflow implements StackActionWorkflow<DescribeValidationStatusResult> {
     private readonly workflows = new Map<string, StackActionWorkflowState>();
     private readonly log = LoggerFactory.getLogger(ValidationWorkflow);
 
@@ -89,13 +99,26 @@ export class ValidationWorkflow implements StackActionWorkflow {
         };
     }
 
-    private async runValidationAsync(
+    describeStatus(params: Identifiable): DescribeValidationStatusResult {
+        const workflow = this.workflows.get(params.id);
+        if (!workflow) {
+            throw new Error(`Workflow not found: ${params.id}`);
+        }
+
+        return {
+            ...this.getStatus(params),
+            ValidationDetails: workflow.validationDetails,
+            FailureReason: workflow.failureReason,
+        };
+    }
+
+    protected async runValidationAsync(
         workflowId: string,
         changeSetName: string,
         stackName: string,
         changeSetType: ChangeSetType,
     ): Promise<void> {
-        const existingWorkflow = this.workflows.get(workflowId);
+        let existingWorkflow = this.workflows.get(workflowId);
         if (!existingWorkflow) {
             this.log.error({ workflowId }, 'Workflow not found during async execution');
             return;
@@ -112,24 +135,48 @@ export class ValidationWorkflow implements StackActionWorkflow {
                 }
             }
 
-            this.workflows.set(workflowId, {
-                ...existingWorkflow,
+            existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
                 phase: result.phase,
                 state: result.state,
                 changes: result.changes,
             });
+
+            if (result.state === StackActionState.FAILED) {
+                existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
+                    validationDetails: [
+                        {
+                            ValidationName: DRY_RUN_VALIDATION_NAME,
+                            Timestamp: DateTime.now(),
+                            Severity: 'ERROR',
+                            Message: `Validation failed with reason: ${result.failureReason}`,
+                        },
+                    ],
+                    failureReason: result.failureReason,
+                });
+            } else {
+                existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
+                    validationDetails: [
+                        {
+                            ValidationName: DRY_RUN_VALIDATION_NAME,
+                            Timestamp: DateTime.now(),
+                            Severity: 'INFO',
+                            Message: 'Validation succeeded',
+                        },
+                    ],
+                });
+            }
         } catch (error) {
-            this.log.error({ error, workflowId }, 'Validation workflow failed');
+            this.log.error({ error, workflowId }, 'Validation workflow threw exception');
 
             const validation = this.validationManager.get(stackName);
             if (validation) {
                 validation.setPhase(StackActionPhase.VALIDATION_FAILED);
             }
 
-            this.workflows.set(workflowId, {
-                ...existingWorkflow,
+            processWorkflowUpdates(this.workflows, existingWorkflow, {
                 phase: StackActionPhase.VALIDATION_FAILED,
                 state: StackActionState.FAILED,
+                failureReason: extractErrorMessage(error),
             });
         } finally {
             // Cleanup validation object to prevent memory leaks

--- a/tst/unit/handlers/StackHandler.test.ts
+++ b/tst/unit/handlers/StackHandler.test.ts
@@ -15,6 +15,8 @@ import {
     getValidationStatusHandler,
     getDeploymentStatusHandler,
     listStacksHandler,
+    describeValidationStatusHandler,
+    describeDeploymentStatusHandler,
 } from '../../../src/handlers/StackHandler';
 import { analyzeCapabilities } from '../../../src/stacks/actions/CapabilityAnalyzer';
 import {
@@ -70,7 +72,7 @@ describe('StackActionHandler', () => {
         vi.clearAllMocks();
     });
 
-    describe('stackActionParametersHandler', () => {
+    describe('getParametersHandler', () => {
         it('returns empty array when no syntax tree found', () => {
             const templateUri: TemplateUri = 'test://template.yaml';
             syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(undefined);
@@ -118,7 +120,7 @@ describe('StackActionHandler', () => {
         });
     });
 
-    describe('templateCapabilitiesHandler', () => {
+    describe('getCapabilitiesHandler', () => {
         it('should return capabilities when document is available', async () => {
             const templateUri: TemplateUri = 'test://template.yaml';
             const mockDocument = { getText: vi.fn().mockReturnValue('template content') } as unknown as Document;
@@ -143,7 +145,7 @@ describe('StackActionHandler', () => {
         });
     });
 
-    describe('templateValidationCreateHandler', () => {
+    describe('createValidationHandler', () => {
         it('should delegate to validation service', async () => {
             const mockResult = { id: 'test-id', changeSetName: 'cs-123', stackName: 'test-stack' };
             mockComponents.validationWorkflowService.start.resolves(mockResult);
@@ -177,7 +179,7 @@ describe('StackActionHandler', () => {
         });
     });
 
-    describe('stackActionDeploymentCreateHandler', () => {
+    describe('createDeploymentHandler', () => {
         it('should delegate to deployment service', async () => {
             const mockResult = { id: 'test-id', changeSetName: 'cs-123', stackName: 'test-stack' };
             mockComponents.deploymentWorkflowService.start.resolves(mockResult);
@@ -192,8 +194,8 @@ describe('StackActionHandler', () => {
         });
     });
 
-    describe('stackActionValidationStatusHandler', () => {
-        it('should delegate to validation service poll', async () => {
+    describe('getValidationStatusHandler', () => {
+        it('should delegate to validation service get', async () => {
             const mockResult = {
                 id: 'test-id',
                 status: StackActionPhase.VALIDATION_COMPLETE,
@@ -211,8 +213,8 @@ describe('StackActionHandler', () => {
         });
     });
 
-    describe('stackActionDeploymentStatusHandler', () => {
-        it('should delegate to deployment service poll', async () => {
+    describe('getDeploymentStatusHandler', () => {
+        it('should delegate to deployment service get', async () => {
             const mockResult = {
                 id: 'test-id',
                 status: StackActionPhase.DEPLOYMENT_COMPLETE,
@@ -230,7 +232,47 @@ describe('StackActionHandler', () => {
         });
     });
 
-    describe('StackQueryHandler', () => {
+    describe('describeValidationStatusHandler', () => {
+        it('should delegate to validation service describe', async () => {
+            const mockResult = {
+                id: 'test-id',
+                status: StackActionPhase.VALIDATION_COMPLETE,
+                result: StackActionState.SUCCESSFUL,
+                ValidationDetails: [],
+            };
+            mockComponents.validationWorkflowService.describeStatus.resolves(mockResult);
+
+            const handler = describeValidationStatusHandler(mockComponents);
+            const params = { id: 'test-id' };
+
+            const result = await handler(params, {} as any);
+
+            expect(mockComponents.validationWorkflowService.describeStatus.calledWith(params)).toBe(true);
+            expect(result).toEqual(mockResult);
+        });
+    });
+
+    describe('describeDeploymentStatusHandler', () => {
+        it('should delegate to deployment service describe', async () => {
+            const mockResult = {
+                id: 'test-id',
+                status: StackActionPhase.DEPLOYMENT_COMPLETE,
+                result: StackActionState.SUCCESSFUL,
+                DeploymentEvents: [],
+            };
+            mockComponents.deploymentWorkflowService.describeStatus.resolves(mockResult);
+
+            const handler = describeDeploymentStatusHandler(mockComponents);
+            const params = { id: 'test-id' };
+
+            const result = await handler(params, {} as any);
+
+            expect(mockComponents.deploymentWorkflowService.describeStatus.calledWith(params)).toBe(true);
+            expect(result).toEqual(mockResult);
+        });
+    });
+
+    describe('listStacksHandler', () => {
         const mockParams = {} as ListStacksParams;
         const mockToken = {} as CancellationToken;
 

--- a/tst/unit/protocol/LspStackHandlers.test.ts
+++ b/tst/unit/protocol/LspStackHandlers.test.ts
@@ -10,6 +10,8 @@ import {
     CreateDeploymentRequest,
     GetValidationStatusRequest,
     GetDeploymentStatusRequest,
+    DescribeValidationStatusRequest,
+    DescribeDeploymentStatusRequest,
 } from '../../../src/stacks/actions/StackActionProtocol';
 import {
     GetCapabilitiesResult,
@@ -18,6 +20,8 @@ import {
     CreateStackActionParams,
     CreateStackActionResult,
     GetStackActionStatusResult,
+    DescribeValidationStatusResult,
+    DescribeDeploymentStatusResult,
 } from '../../../src/stacks/actions/StackActionRequestType';
 
 describe('LspTemplateHandlers', () => {
@@ -45,7 +49,7 @@ describe('LspTemplateHandlers', () => {
         expect(connection.onRequest.calledWith(GetCapabilitiesRequest.method)).toBe(true);
     });
 
-    it('should register onTemplateValidate handler', () => {
+    it('should register onCreateValidation handler', () => {
         const mockHandler: RequestHandler<CreateStackActionParams, CreateStackActionResult, void> = vi.fn();
 
         stackActionHandlers.onCreateValidation(mockHandler);
@@ -53,7 +57,7 @@ describe('LspTemplateHandlers', () => {
         expect(connection.onRequest.calledWith(CreateValidationRequest.method)).toBe(true);
     });
 
-    it('should register onTemplateDeploy handler', () => {
+    it('should register onCreateDeployment handler', () => {
         const mockHandler: RequestHandler<CreateStackActionParams, CreateStackActionResult, void> = vi.fn();
 
         stackActionHandlers.onCreateDeployment(mockHandler);
@@ -61,7 +65,7 @@ describe('LspTemplateHandlers', () => {
         expect(connection.onRequest.calledWith(CreateDeploymentRequest.method)).toBe(true);
     });
 
-    it('should register onTemplateValidatePoll handler', () => {
+    it('should register onGetValidationStatus handler', () => {
         const mockHandler: RequestHandler<Identifiable, GetStackActionStatusResult, void> = vi.fn();
 
         stackActionHandlers.onGetValidationStatus(mockHandler);
@@ -69,11 +73,27 @@ describe('LspTemplateHandlers', () => {
         expect(connection.onRequest.calledWith(GetValidationStatusRequest.method)).toBe(true);
     });
 
-    it('should register onTemplateDeployPoll handler', () => {
+    it('should register onGetDeploymentStatus handler', () => {
         const mockHandler: RequestHandler<Identifiable, GetStackActionStatusResult, void> = vi.fn();
 
         stackActionHandlers.onGetDeploymentStatus(mockHandler);
 
         expect(connection.onRequest.calledWith(GetDeploymentStatusRequest.method)).toBe(true);
+    });
+
+    it('should register onDescribeValidationStatus handler', () => {
+        const mockHandler: RequestHandler<Identifiable, DescribeValidationStatusResult, void> = vi.fn();
+
+        stackActionHandlers.onDescribeValidationStatus(mockHandler);
+
+        expect(connection.onRequest.calledWith(DescribeValidationStatusRequest.method)).toBe(true);
+    });
+
+    it('should register onDescribeDeploymentStatus handler', () => {
+        const mockHandler: RequestHandler<Identifiable, DescribeDeploymentStatusResult, void> = vi.fn();
+
+        stackActionHandlers.onDescribeDeploymentStatus(mockHandler);
+
+        expect(connection.onRequest.calledWith(DescribeDeploymentStatusRequest.method)).toBe(true);
     });
 });

--- a/tst/unit/stackActions/DeploymentWorkflow.test.ts
+++ b/tst/unit/stackActions/DeploymentWorkflow.test.ts
@@ -1,13 +1,20 @@
+import { ChangeSetType } from '@aws-sdk/client-cloudformation';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DocumentManager } from '../../../src/document/DocumentManager';
 import { CfnService } from '../../../src/services/CfnService';
 import { DeploymentWorkflow } from '../../../src/stacks/actions/DeploymentWorkflow';
-import { processChangeSet } from '../../../src/stacks/actions/StackActionOperations';
+import {
+    processChangeSet,
+    waitForValidation,
+    waitForDeployment,
+    processWorkflowUpdates,
+} from '../../../src/stacks/actions/StackActionOperations';
 import {
     CreateStackActionParams,
     StackActionPhase,
     StackActionState,
 } from '../../../src/stacks/actions/StackActionRequestType';
+import { DRY_RUN_VALIDATION_NAME } from '../../../src/stacks/actions/ValidationWorkflow';
 
 vi.mock('../../../src/stacks/actions/StackActionOperations');
 
@@ -97,6 +104,239 @@ describe('DeploymentWorkflow', () => {
             const params = { id: 'nonexistent-id' };
 
             expect(() => deploymentWorkflow.getStatus(params)).toThrow('Workflow not found: nonexistent-id');
+        });
+    });
+
+    describe('describeStatus', () => {
+        it('should return workflow status with validation details and deployment events', () => {
+            const params = { id: 'test-id' };
+            const changes = [{ type: 'Resource', resourceChange: { action: 'Add', logicalResourceId: 'MyBucket' } }];
+
+            const workflow = {
+                id: 'test-id',
+                changeSetName: 'changeset-123',
+                stackName: 'test-stack',
+                phase: StackActionPhase.DEPLOYMENT_COMPLETE,
+                startTime: Date.now(),
+                state: StackActionState.SUCCESSFUL,
+                changes: changes,
+                validationDetails: [{ Timestamp: new Date(), Severity: 'INFO', Message: 'Validation succeeded' }],
+                deploymentEvents: [{ LogicalResourceId: 'MyBucket', ResourceType: 'AWS::S3::Bucket' }],
+            };
+
+            // Directly set workflow state
+            (deploymentWorkflow as any).workflows.set('test-id', workflow);
+
+            const result = deploymentWorkflow.describeStatus(params);
+
+            expect(result).toEqual({
+                phase: StackActionPhase.DEPLOYMENT_COMPLETE,
+                state: StackActionState.SUCCESSFUL,
+                changes: changes,
+                id: 'test-id',
+                ValidationDetails: workflow.validationDetails,
+                DeploymentEvents: workflow.deploymentEvents,
+            });
+        });
+
+        it('should throw error when workflow not found', () => {
+            const params = { id: 'nonexistent-id' };
+
+            expect(() => deploymentWorkflow.describeStatus(params)).toThrow('Workflow not found: nonexistent-id');
+        });
+    });
+
+    describe('full workflow execution', () => {
+        const waitForWorkflowCompletion = async (workflowId: string): Promise<void> => {
+            let attempts = 0;
+            const maxAttempts = 3;
+            while (attempts < maxAttempts) {
+                const workflow = (deploymentWorkflow as any).workflows.get(workflowId);
+                if (workflow?.state !== StackActionState.IN_PROGRESS) {
+                    return;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 50));
+                attempts++;
+            }
+        };
+
+        beforeEach(() => {
+            mockCfnService.describeStacks = vi.fn().mockRejectedValue(new Error('Stack not found'));
+
+            mockCfnService.executeChangeSet = vi.fn().mockResolvedValue({});
+
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({
+                StackEvents: [
+                    {
+                        LogicalResourceId: 'MyBucket',
+                        ResourceType: 'AWS::S3::Bucket',
+                        Timestamp: new Date('2023-01-01T10:00:00Z'),
+                        ResourceStatus: 'CREATE_COMPLETE',
+                        ResourceStatusReason: 'Resource creation completed successfully',
+                    },
+                    {
+                        LogicalResourceId: 'MyRole',
+                        ResourceType: 'AWS::IAM::Role',
+                        Timestamp: new Date('2023-01-01T10:01:00Z'),
+                        ResourceStatus: 'CREATE_COMPLETE',
+                    },
+                ],
+            });
+
+            (processChangeSet as any).mockResolvedValue('test-changeset');
+
+            (waitForValidation as any).mockResolvedValue({
+                phase: StackActionPhase.VALIDATION_COMPLETE,
+                state: StackActionState.SUCCESSFUL,
+                changes: [],
+            });
+
+            (waitForDeployment as any).mockResolvedValue({
+                phase: StackActionPhase.DEPLOYMENT_COMPLETE,
+                state: StackActionState.SUCCESSFUL,
+            });
+
+            (processWorkflowUpdates as any).mockImplementation((map: any, workflow: any, updates: any) => {
+                const updated = { ...workflow, ...updates };
+                map.set(workflow.id, updated);
+                return updated;
+            });
+        });
+
+        it('should execute full deployment workflow successfully', async () => {
+            const workflowId = 'test-workflow-id';
+            const params: CreateStackActionParams = {
+                id: workflowId,
+                stackName: 'test-stack',
+                uri: 'file://test.yaml',
+                parameters: [],
+                capabilities: [],
+            };
+
+            await deploymentWorkflow.start(params);
+            await waitForWorkflowCompletion(workflowId);
+
+            // Verify StackActionOperations method calls
+            expect(processChangeSet).toHaveBeenCalledWith(
+                mockCfnService,
+                mockDocumentManager,
+                params,
+                ChangeSetType.CREATE,
+            );
+            expect(waitForValidation).toHaveBeenCalledWith(mockCfnService, 'test-changeset', 'test-stack');
+            expect(mockCfnService.executeChangeSet).toHaveBeenCalledWith({
+                StackName: 'test-stack',
+                ChangeSetName: 'test-changeset',
+                ClientRequestToken: workflowId,
+            });
+            expect(waitForDeployment).toHaveBeenCalledWith(mockCfnService, 'test-stack', ChangeSetType.CREATE);
+
+            const workflow = (deploymentWorkflow as any).workflows.get(workflowId);
+            expect(workflow.state).toBe(StackActionState.SUCCESSFUL);
+            expect(workflow.phase).toBe(StackActionPhase.DEPLOYMENT_COMPLETE);
+            expect(workflow.validationDetails).toBeDefined();
+            expect(workflow.validationDetails).toHaveLength(1);
+            expect(workflow.validationDetails[0].Severity).toBe('INFO');
+            expect(workflow.validationDetails[0].Message).toBe('Validation succeeded');
+            expect(workflow.validationDetails[0].ValidationName).toBe(DRY_RUN_VALIDATION_NAME);
+            expect(workflow.deploymentEvents).toBeDefined();
+            expect(workflow.deploymentEvents).toHaveLength(2);
+            expect(workflow.deploymentEvents[0].LogicalResourceId).toBe('MyBucket');
+            expect(workflow.deploymentEvents[0].ResourceType).toBe('AWS::S3::Bucket');
+            expect(workflow.deploymentEvents[1].LogicalResourceId).toBe('MyRole');
+            expect(workflow.deploymentEvents[1].ResourceType).toBe('AWS::IAM::Role');
+            expect(workflow.failureReason).toBeUndefined();
+        });
+
+        it('should handle waitForValidation returning failed', async () => {
+            // Override the default mock for this test
+            (waitForValidation as any).mockResolvedValueOnce({
+                phase: StackActionPhase.VALIDATION_FAILED,
+                state: StackActionState.FAILED,
+                failureReason: 'Invalid template',
+            });
+
+            const workflowId = 'test-workflow-id';
+            const params: CreateStackActionParams = {
+                id: workflowId,
+                stackName: 'test-stack',
+                uri: 'file://test.yaml',
+                parameters: [],
+                capabilities: [],
+            };
+
+            await deploymentWorkflow.start(params);
+            await waitForWorkflowCompletion(workflowId);
+
+            const workflow = (deploymentWorkflow as any).workflows.get(workflowId);
+            expect(workflow.state).toBe(StackActionState.FAILED);
+            expect(workflow.validationDetails[0].Message).toContain('Validation failed with reason: Invalid template');
+        });
+
+        it('should handle waitForValidation throwing exception', async () => {
+            // Override the default mock for this test
+            (waitForValidation as any).mockRejectedValueOnce(new Error('Validation service error'));
+
+            const workflowId = 'test-workflow-id';
+            const params: CreateStackActionParams = {
+                id: workflowId,
+                stackName: 'test-stack',
+                uri: 'file://test.yaml',
+                parameters: [],
+                capabilities: [],
+            };
+
+            await deploymentWorkflow.start(params);
+            await waitForWorkflowCompletion(workflowId);
+
+            const workflow = (deploymentWorkflow as any).workflows.get(workflowId);
+            expect(workflow.state).toBe(StackActionState.FAILED);
+            expect(workflow.failureReason).toBe('Validation service error');
+        });
+
+        it('should handle executeChangeSet throwing exception', async () => {
+            // Override the default mock for this test
+            mockCfnService.executeChangeSet = vi.fn().mockRejectedValueOnce(new Error('Execute changeset failed'));
+
+            const workflowId = 'test-workflow-id';
+            const params: CreateStackActionParams = {
+                id: workflowId,
+                stackName: 'test-stack',
+                uri: 'file://test.yaml',
+                parameters: [],
+                capabilities: [],
+            };
+
+            await deploymentWorkflow.start(params);
+            await waitForWorkflowCompletion(workflowId);
+
+            const workflow = (deploymentWorkflow as any).workflows.get(workflowId);
+            expect(workflow.state).toBe(StackActionState.FAILED);
+            expect(workflow.phase).toBe(StackActionPhase.DEPLOYMENT_FAILED);
+            expect(workflow.failureReason).toBe('Execute changeset failed');
+        });
+
+        it('should handle processDeploymentEvents throwing exception', async () => {
+            // Override the default mock for this test
+            mockCfnService.describeStackEvents = vi.fn().mockRejectedValueOnce(new Error('Failed to get stack events'));
+
+            const workflowId = 'test-workflow-id';
+            const params: CreateStackActionParams = {
+                id: workflowId,
+                stackName: 'test-stack',
+                uri: 'file://test.yaml',
+                parameters: [],
+                capabilities: [],
+            };
+
+            await deploymentWorkflow.start(params);
+            await waitForWorkflowCompletion(workflowId);
+
+            // Workflow should still succeed even if processDeploymentEvents fails
+            const workflow = (deploymentWorkflow as any).workflows.get(workflowId);
+            expect(workflow.state).toBe(StackActionState.SUCCESSFUL);
+            expect(workflow.phase).toBe(StackActionPhase.DEPLOYMENT_COMPLETE);
+            expect(workflow.deploymentEvents).toBeUndefined();
         });
     });
 });

--- a/tst/unit/stackActions/StackActionWorkflowOperations.test.ts
+++ b/tst/unit/stackActions/StackActionWorkflowOperations.test.ts
@@ -300,7 +300,7 @@ describe('StackActionWorkflowOperations', () => {
 
             expect(result.phase).toBe(StackActionPhase.VALIDATION_FAILED);
             expect(result.state).toBe(StackActionState.FAILED);
-            expect(result.reason).toBe('Test failure');
+            expect(result.failureReason).toBe('Test failure');
         });
 
         it('should handle exceptions with error message', async () => {
@@ -310,7 +310,7 @@ describe('StackActionWorkflowOperations', () => {
 
             expect(result.phase).toBe(StackActionPhase.VALIDATION_FAILED);
             expect(result.state).toBe(StackActionState.FAILED);
-            expect(result.reason).toBe('Network error');
+            expect(result.failureReason).toBe('Network error');
         });
 
         it('should handle non-Error exceptions', async () => {
@@ -320,7 +320,7 @@ describe('StackActionWorkflowOperations', () => {
 
             expect(result.phase).toBe(StackActionPhase.VALIDATION_FAILED);
             expect(result.state).toBe(StackActionState.FAILED);
-            expect(result.reason).toBe('String error');
+            expect(result.failureReason).toBe('String error');
         });
     });
 });

--- a/tst/unit/stackActions/ValidationWorkflow.test.ts
+++ b/tst/unit/stackActions/ValidationWorkflow.test.ts
@@ -3,13 +3,19 @@ import { SyntaxTreeManager } from '../../../src/context/syntaxtree/SyntaxTreeMan
 import { DocumentManager } from '../../../src/document/DocumentManager';
 import { CfnService } from '../../../src/services/CfnService';
 import { DiagnosticCoordinator } from '../../../src/services/DiagnosticCoordinator';
-import { processChangeSet } from '../../../src/stacks/actions/StackActionOperations';
+import {
+    processChangeSet,
+    waitForValidation,
+    processWorkflowUpdates,
+    deleteStackAndChangeSet,
+    deleteChangeSet,
+} from '../../../src/stacks/actions/StackActionOperations';
 import {
     CreateStackActionParams,
     StackActionPhase,
     StackActionState,
 } from '../../../src/stacks/actions/StackActionRequestType';
-import { ValidationWorkflow } from '../../../src/stacks/actions/ValidationWorkflow';
+import { DRY_RUN_VALIDATION_NAME, ValidationWorkflow } from '../../../src/stacks/actions/ValidationWorkflow';
 
 vi.mock('../../../src/stacks/actions/StackActionOperations');
 
@@ -114,6 +120,43 @@ describe('ValidationWorkflow', () => {
         });
     });
 
+    describe('describeStatus', () => {
+        it('should return workflow status with validation details', () => {
+            const params = { id: 'test-id' };
+            const changes = [{ type: 'Resource', resourceChange: { action: 'Add', logicalResourceId: 'MyBucket' } }];
+
+            const workflow = {
+                id: 'test-id',
+                changeSetName: 'changeset-123',
+                stackName: 'test-stack',
+                phase: StackActionPhase.VALIDATION_COMPLETE,
+                startTime: Date.now(),
+                state: StackActionState.SUCCESSFUL,
+                changes: changes,
+                validationDetails: [{ Timestamp: new Date(), Severity: 'INFO', Message: 'Validation succeeded' }],
+            };
+
+            // Directly set workflow state
+            (validationWorkflow as any).workflows.set('test-id', workflow);
+
+            const result = validationWorkflow.describeStatus(params);
+
+            expect(result).toEqual({
+                phase: StackActionPhase.VALIDATION_COMPLETE,
+                state: StackActionState.SUCCESSFUL,
+                changes: changes,
+                id: 'test-id',
+                ValidationDetails: workflow.validationDetails,
+            });
+        });
+
+        it('should throw error when workflow not found', () => {
+            const params = { id: 'nonexistent-id' };
+
+            expect(() => validationWorkflow.describeStatus(params)).toThrow('Workflow not found: nonexistent-id');
+        });
+    });
+
     describe('ValidationManager integration', () => {
         let mockValidationManager: any;
 
@@ -191,6 +234,131 @@ describe('ValidationWorkflow', () => {
             // Verify the validation object has the correct stack name using getter method
             const addedValidation = mockValidationManager.add.mock.calls[0][0];
             expect(addedValidation.getStackName()).toBe(params.stackName);
+        });
+    });
+
+    describe('full workflow execution', () => {
+        const waitForWorkflowCompletion = async (workflowId: string): Promise<void> => {
+            let attempts = 0;
+            const maxAttempts = 3;
+            while (attempts < maxAttempts) {
+                const workflow = (validationWorkflow as any).workflows.get(workflowId);
+                if (workflow?.state !== StackActionState.IN_PROGRESS) {
+                    return;
+                }
+                await new Promise((resolve) => setTimeout(resolve, 50));
+                attempts++;
+            }
+        };
+
+        let mockValidationManager: any;
+
+        beforeEach(() => {
+            mockValidationManager = { add: vi.fn(), get: vi.fn(), remove: vi.fn() };
+
+            // Default to CREATE changeSetType (stack doesn't exist)
+            mockCfnService.describeStacks = vi.fn().mockRejectedValue(new Error('Stack does not exist'));
+
+            (processChangeSet as any).mockResolvedValue('changeset-123');
+
+            (waitForValidation as any).mockResolvedValue({
+                phase: StackActionPhase.VALIDATION_COMPLETE,
+                state: StackActionState.SUCCESSFUL,
+                changes: [],
+            });
+            (deleteStackAndChangeSet as any).mockResolvedValue(undefined);
+
+            (deleteChangeSet as any).mockResolvedValue(undefined);
+
+            (processWorkflowUpdates as any).mockImplementation((map: any, workflow: any, updates: any) => {
+                const updated = { ...workflow, ...updates };
+                map.set(workflow.id, updated);
+                return updated;
+            });
+
+            validationWorkflow = new ValidationWorkflow(
+                mockCfnService,
+                mockDocumentManager,
+                mockDiagnosticCoordinator,
+                mockSyntaxTreeManager,
+                mockValidationManager,
+            );
+        });
+
+        it('should handle successful validation workflow', async () => {
+            const params: CreateStackActionParams = {
+                id: 'test-id',
+                uri: 'file:///test.yaml',
+                stackName: 'test-stack',
+            };
+
+            const mockChanges = [{ resourceChange: { action: 'Add', logicalResourceId: 'TestResource' } }];
+            (waitForValidation as any).mockResolvedValueOnce({
+                phase: StackActionPhase.VALIDATION_COMPLETE,
+                state: StackActionState.SUCCESSFUL,
+                changes: mockChanges,
+            });
+
+            const result = await validationWorkflow.start(params);
+            await waitForWorkflowCompletion('test-id');
+
+            expect(result.changeSetName).toBe('changeset-123');
+            expect(mockValidationManager.add).toHaveBeenCalled();
+            expect(waitForValidation).toHaveBeenCalledWith(mockCfnService, 'changeset-123', 'test-stack');
+
+            const workflow = (validationWorkflow as any).workflows.get('test-id');
+            expect(workflow.changes).toEqual(mockChanges);
+            expect(workflow.validationDetails).toBeDefined();
+            expect(workflow.validationDetails[0].Severity).toBe('INFO');
+            expect(workflow.validationDetails[0].Message).toBe('Validation succeeded');
+            expect(workflow.validationDetails[0].ValidationName).toBe(DRY_RUN_VALIDATION_NAME);
+        });
+
+        it('should handle validation failure', async () => {
+            const params: CreateStackActionParams = {
+                id: 'test-id',
+                uri: 'file:///test.yaml',
+                stackName: 'test-stack',
+            };
+
+            (waitForValidation as any).mockResolvedValueOnce({
+                phase: StackActionPhase.VALIDATION_FAILED,
+                state: StackActionState.FAILED,
+                failureReason: 'Template validation failed',
+            });
+
+            await validationWorkflow.start(params);
+            await waitForWorkflowCompletion('test-id');
+
+            expect(mockValidationManager.add).toHaveBeenCalled();
+            expect(mockValidationManager.remove).toHaveBeenCalledWith('test-stack');
+
+            const workflow = (validationWorkflow as any).workflows.get('test-id');
+            expect(workflow.validationDetails).toBeDefined();
+            expect(workflow.validationDetails[0].Severity).toBe('ERROR');
+            expect(workflow.validationDetails[0].Message).toBe(
+                'Validation failed with reason: Template validation failed',
+            );
+        });
+
+        it('should handle validation exception', async () => {
+            const params: CreateStackActionParams = {
+                id: 'test-id',
+                uri: 'file:///test.yaml',
+                stackName: 'test-stack',
+            };
+
+            (waitForValidation as any).mockRejectedValueOnce(new Error('Validation service error'));
+
+            await validationWorkflow.start(params);
+            await waitForWorkflowCompletion('test-id');
+
+            expect(mockValidationManager.remove).toHaveBeenCalledWith('test-stack');
+            expect(deleteStackAndChangeSet).toHaveBeenCalled();
+
+            const workflow = (validationWorkflow as any).workflows.get('test-id');
+            expect(workflow.failureReason).toBeDefined();
+            expect(workflow.failureReason).toBe('Validation service error');
         });
     });
 });


### PR DESCRIPTION
*Description of changes:*

- Added describeStatus method to StackActionWorkflow
- Added generics to StackActionWorkflow, so the describeStatus typing isn't static
- Added logic for describeStatus
  - Validations are returned from describeStatus
  - Deployments are returned for describeStatus on deployment
  - Workflow failure reasons are returned for describeStatus


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
