### PR TITLE
Switch IAM errors from popup to a log

### DIFF
--- a/src/auth/AwsCredentials.ts
+++ b/src/auth/AwsCredentials.ts
@@ -157,10 +157,7 @@ export class AwsCredentials {
                 newRegion = profile.region;
             }
         } catch (error) {
-            void this.clientMessage.showMessageNotification(
-                MessageType.Error,
-                `Failed to update IAM profile: ${extractErrorMessage(error)}`,
-            );
+            this.logger.error(`Failed to update IAM profile: ${extractErrorMessage(error)}`);
         } finally {
             this.profileName = newProfileName;
             this.settingsManager.updateProfileSettings(newProfileName, newRegion);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Switch IAM errors from popup to a log.  When switching to the AWS toolkit we will rely on popups from the AWS toolkit but we still want to log this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
