### PR TITLE
set deletion policy to retain on resource state import

### DIFF
--- a/src/resourceState/ResourceStateImporter.ts
+++ b/src/resourceState/ResourceStateImporter.ts
@@ -16,6 +16,7 @@ import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { extractErrorMessage } from '../utils/Errors';
 import { ResourceStateManager } from './ResourceStateManager';
 import {
+    DeletionPolicyOnImport,
     ResourceIdentifier,
     ResourceSelection,
     ResourceStateParams,
@@ -130,6 +131,8 @@ export class ResourceStateImporter {
                         fetchedResourceStates.push({
                             [logicalId]: {
                                 Type: resourceType,
+                                DeletionPolicy:
+                                    purpose === ResourceStatePurpose.IMPORT ? DeletionPolicyOnImport : undefined,
                                 Properties: this.applyTransformations(resourceState.properties, schema, purpose),
                                 Metadata: await this.createMetadata(resourceIdentifier, purpose),
                             },

--- a/src/resourceState/ResourceStateTypes.ts
+++ b/src/resourceState/ResourceStateTypes.ts
@@ -75,9 +75,12 @@ export const RefreshResourceListRequest = new RequestType<RefreshResourcesParams
     'aws/cfn/resources/refresh',
 );
 
+export const DeletionPolicyOnImport = 'Retain';
+
 export interface ResourceTemplateFormat {
     [key: string]: {
         Type: string;
+        DeletionPolicy: string | undefined;
         Properties: Record<string, string>;
         Metadata: {
             PrimaryIdentifier: string;

--- a/tst/unit/resourceState/StateImportExpectation.ts
+++ b/tst/unit/resourceState/StateImportExpectation.ts
@@ -1,4 +1,5 @@
 import { DocumentType } from '../../../src/document/Document';
+import { DeletionPolicyOnImport } from '../../../src/resourceState/ResourceStateTypes';
 import { getMockResourceProperties } from './MockResourceState';
 
 export interface TestScenario {
@@ -141,6 +142,7 @@ export function getImportExpectation(scenario: TestScenario, resourceType: strin
             return `,
     "${logicalName}": {
       "Type": "${resourceType}",
+      "DeletionPolicy": "${DeletionPolicyOnImport}",
       "Properties": ${formatPropertiesForJson(properties)},
       "Metadata": {
         "PrimaryIdentifier": "${identifier}",
@@ -153,6 +155,7 @@ export function getImportExpectation(scenario: TestScenario, resourceType: strin
   "Resources": {
     "${logicalName}": {
       "Type": "${resourceType}",
+      "DeletionPolicy": "${DeletionPolicyOnImport}",
       "Properties": ${formatPropertiesForJson(properties)},
       "Metadata": {
         "PrimaryIdentifier": "${identifier}",
@@ -167,6 +170,7 @@ export function getImportExpectation(scenario: TestScenario, resourceType: strin
             return `
   ${logicalName}:
     Type: ${resourceType}
+    DeletionPolicy: ${DeletionPolicyOnImport}
     Properties:
 ${formatPropertiesForYaml(properties)}
     Metadata:
@@ -178,6 +182,7 @@ ${formatPropertiesForYaml(properties)}
 Resources:
   ${logicalName}:
     Type: ${resourceType}
+    DeletionPolicy: ${DeletionPolicyOnImport}
     Properties:
 ${formatPropertiesForYaml(properties)}
     Metadata:


### PR DESCRIPTION
*Description of changes:*

When importing existing resources into a CloudFormation stack using a change set, each resource intended for import must have a DeletionPolicy attribute defined in the template. This requirement is in place to ensure safe and controlled resource management during the import process.
Why DeletionPolicy is required for import:
- **Safety and Reversibility:**
The DeletionPolicy, typically set to Retain, ensures that if the import operation fails or needs to be rolled back, the existing resource is not inadvertently deleted by CloudFormation. This provides a crucial safety net during the import process, which involves mapping existing resources to logical IDs in your CloudFormation template.
- **Preventing Accidental Deletion:**
Without a specified DeletionPolicy, CloudFormation's default behavior is to delete resources when they are removed from a stack or when the stack itself is deleted. During an import, CloudFormation needs to understand how to handle the resource if it were to be removed or if the stack were to be deleted after the import. The DeletionPolicy explicitly defines this behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
