### PR TITLE
Update API calls to support region parameters

### DIFF
--- a/src/handlers/ResourceHandler.ts
+++ b/src/handlers/ResourceHandler.ts
@@ -49,7 +49,11 @@ export function listResourcesHandler(
             const resources: ResourceSummary[] = [];
 
             for (const typeName of resourceTypes) {
-                const resourceList = await components.resourceStateManager.listResources(typeName);
+                const resourceList = await components.resourceStateManager.listResources(
+                    typeName,
+                    false,
+                    params.region,
+                );
                 if (resourceList) {
                     resources.push({
                         typeName: resourceList.typeName,
@@ -107,7 +111,7 @@ export function getManagedResourceStackTemplateHandler(
 ): RequestHandler<GetStackTemplateParams, GetStackTemplateResult | undefined, void> {
     return async (params, _token) => {
         try {
-            const template = await components.cfnService.getTemplate({ StackName: params.stackName });
+            const template = await components.cfnService.getTemplate({ StackName: params.stackName }, params.region);
             if (!template) {
                 return;
             }
@@ -115,7 +119,10 @@ export function getManagedResourceStackTemplateHandler(
             let lineNumber: number | undefined;
 
             if (params.primaryIdentifier) {
-                const resources = await components.cfnService.describeStackResources({ StackName: params.stackName });
+                const resources = await components.cfnService.describeStackResources(
+                    { StackName: params.stackName },
+                    params.region,
+                );
                 const resource = resources.StackResources?.find(
                     (r) => r.PhysicalResourceId === params.primaryIdentifier,
                 );

--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -239,7 +239,13 @@ export function listStacksHandler(
             if (params.statusToInclude?.length && params.statusToExclude?.length) {
                 throw new Error('Cannot specify both statusToInclude and statusToExclude');
             }
-            return { stacks: await components.cfnService.listStacks(params.statusToInclude, params.statusToExclude) };
+            return {
+                stacks: await components.cfnService.listStacks(
+                    params.statusToInclude,
+                    params.statusToExclude,
+                    params.region,
+                ),
+            };
         } catch (error) {
             log.error({ error: extractErrorMessage(error) }, 'Error listing stacks');
             return { stacks: [] };

--- a/src/resourceState/ResourceStateManager.ts
+++ b/src/resourceState/ResourceStateManager.ts
@@ -79,12 +79,16 @@ export class ResourceStateManager implements SettingsConfigurable, Closeable {
         return value;
     }
 
-    public async listResources(typeName: string, updateFromLive?: boolean): Promise<ResourceList | undefined> {
+    public async listResources(
+        typeName: string,
+        updateFromLive?: boolean,
+        region?: string,
+    ): Promise<ResourceList | undefined> {
         const cachedResourceList = this.resourceListMap.get(typeName);
         if (cachedResourceList && !updateFromLive) {
             return cachedResourceList;
         }
-        const resourceList = await this.retrieveResourceList(typeName);
+        const resourceList = await this.retrieveResourceList(typeName, region);
         if (!resourceList) {
             return;
         }
@@ -113,11 +117,11 @@ export class ResourceStateManager implements SettingsConfigurable, Closeable {
         return resourceIdToStateMap?.get(identifier);
     }
 
-    private async retrieveResourceList(typeName: string): Promise<ResourceList | undefined> {
+    private async retrieveResourceList(typeName: string, region?: string): Promise<ResourceList | undefined> {
         let output: ListResourcesOutput | undefined = undefined;
 
         try {
-            output = await this.ccapiService.listResources(typeName);
+            output = await this.ccapiService.listResources(typeName, region);
         } catch (error) {
             log.error(error, `CCAPI ListResource failed for type ${typeName}`);
             return;

--- a/src/resourceState/ResourceStateTypes.ts
+++ b/src/resourceState/ResourceStateTypes.ts
@@ -30,6 +30,7 @@ export enum ResourceStatePurpose {
 export interface ResourceStateParams extends CodeActionParams {
     resourceSelections?: ResourceSelection[];
     purpose: ResourceStatePurpose;
+    region?: string;
 }
 
 export interface ResourceStateResult extends CodeAction {
@@ -48,6 +49,7 @@ export type ResourceIdentifier = string;
 
 export type ListResourcesParams = {
     resourceTypes?: string[];
+    region?: string;
 };
 
 export type ResourceSummary = {

--- a/src/services/AwsClient.ts
+++ b/src/services/AwsClient.ts
@@ -24,22 +24,22 @@ export class AwsClient implements SettingsConfigurable {
     }
 
     // By default, clients will retry on throttling exceptions 3 times
-    public async getCloudFormationClient() {
-        return new CloudFormationClient(await this.iamClientConfig());
+    public async getCloudFormationClient(region?: string) {
+        return new CloudFormationClient(await this.iamClientConfig(region));
     }
 
-    public async getCloudControlClient() {
-        return new CloudControlClient(await this.iamClientConfig());
+    public async getCloudControlClient(region?: string) {
+        return new CloudControlClient(await this.iamClientConfig(region));
     }
 
-    private async iamClientConfig(): Promise<{
+    private async iamClientConfig(region?: string): Promise<{
         region: string;
         credentials: AwsCredentialIdentity;
         customUserAgent: string;
     }> {
         const data = await this.credentialsProvider.getIAM();
         return {
-            region: this.region,
+            region: region ?? this.region,
             credentials: data,
             customUserAgent: `${ExtensionId}/${ExtensionVersion}`,
         };

--- a/src/services/CcapiService.ts
+++ b/src/services/CcapiService.ts
@@ -11,12 +11,12 @@ import { AwsClient } from './AwsClient';
 export class CcapiService {
     constructor(private readonly awsClient: AwsClient) {}
 
-    private async withClient<T>(request: (client: CloudControlClient) => Promise<T>): Promise<T> {
-        const client = await this.awsClient.getCloudControlClient();
+    private async withClient<T>(request: (client: CloudControlClient) => Promise<T>, region?: string): Promise<T> {
+        const client = await this.awsClient.getCloudControlClient(region);
         return await request(client);
     }
 
-    public async listResources(typeName: string) {
+    public async listResources(typeName: string, region?: string) {
         return await this.withClient(async (client) => {
             let nextToken: string | undefined;
             const resourceList: ListResourcesOutput = {
@@ -36,16 +36,16 @@ export class CcapiService {
             } while (nextToken);
 
             return resourceList;
-        });
+        }, region);
     }
 
-    public async getResource(typeName: string, identifier: string) {
+    public async getResource(typeName: string, identifier: string, region?: string) {
         return await this.withClient(async (client) => {
             const getResourceInput: GetResourceInput = {
                 TypeName: typeName,
                 Identifier: identifier,
             };
             return await client.send(new GetResourceCommand(getResourceInput));
-        });
+        }, region);
     }
 }

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -4,6 +4,7 @@ import { RequestType } from 'vscode-languageserver-protocol';
 export type ListStacksParams = {
     statusToInclude?: StackStatus[];
     statusToExclude?: StackStatus[];
+    region?: string;
 };
 
 export type ListStacksResult = {
@@ -15,6 +16,7 @@ export const ListStacksRequest = new RequestType<ListStacksParams, ListStacksRes
 export type GetStackTemplateParams = {
     stackName: string;
     primaryIdentifier?: string;
+    region?: string;
 };
 
 export type GetStackTemplateResult = {

--- a/src/stacks/actions/StackActionRequestType.ts
+++ b/src/stacks/actions/StackActionRequestType.ts
@@ -21,6 +21,7 @@ export type CreateStackActionParams = Identifiable & {
     parameters?: Parameter[];
     capabilities?: Capability[];
     resourcesToImport?: ResourceToImport[];
+    region?: string;
 };
 
 export type CreateStackActionResult = Identifiable & {

--- a/src/stacks/actions/ValidationWorkflow.ts
+++ b/src/stacks/actions/ValidationWorkflow.ts
@@ -81,7 +81,7 @@ export class ValidationWorkflow implements StackActionWorkflow<DescribeValidatio
             state: StackActionState.IN_PROGRESS,
         });
 
-        void this.runValidationAsync(params, changeSetName, changeSetType);
+        void this.runValidationAsync(params, changeSetName, changeSetType, params.region);
 
         return {
             id: params.id,
@@ -121,6 +121,7 @@ export class ValidationWorkflow implements StackActionWorkflow<DescribeValidatio
         params: CreateStackActionParams,
         changeSetName: string,
         changeSetType: ChangeSetType,
+        region?: string,
     ): Promise<void> {
         const workflowId = params.id;
         const stackName = params.stackName;
@@ -132,7 +133,7 @@ export class ValidationWorkflow implements StackActionWorkflow<DescribeValidatio
         }
 
         try {
-            const result = await waitForChangeSetValidation(this.cfnService, changeSetName, stackName);
+            const result = await waitForChangeSetValidation(this.cfnService, changeSetName, stackName, region);
 
             const validation = this.validationManager.get(stackName);
             if (validation) {

--- a/tst/unit/handlers/StackHandler.test.ts
+++ b/tst/unit/handlers/StackHandler.test.ts
@@ -327,7 +327,11 @@ describe('StackActionHandler', () => {
             const handler = listStacksHandler(mockComponents);
             await handler(paramsWithInclude, mockToken);
 
-            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith([StackStatus.CREATE_COMPLETE], undefined);
+            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith(
+                [StackStatus.CREATE_COMPLETE],
+                undefined,
+                undefined,
+            );
         });
 
         it('should pass statusToExclude to cfnService', async () => {
@@ -345,7 +349,34 @@ describe('StackActionHandler', () => {
             const handler = listStacksHandler(mockComponents);
             await handler(paramsWithExclude, mockToken);
 
-            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith(undefined, [StackStatus.DELETE_COMPLETE]);
+            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith(
+                undefined,
+                [StackStatus.DELETE_COMPLETE],
+                undefined,
+            );
+        });
+
+        it('should pass region parameter to cfnService', async () => {
+            const mockStacks: StackSummary[] = [];
+            const mockComponents = {
+                cfnService: {
+                    listStacks: vi.fn().mockResolvedValue(mockStacks),
+                },
+            } as any;
+
+            const handler = listStacksHandler(mockComponents);
+            const paramsWithRegion: ListStacksParams = {
+                statusToInclude: [StackStatus.CREATE_COMPLETE],
+                region: 'us-west-2',
+            };
+
+            await handler(paramsWithRegion, mockToken);
+
+            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith(
+                [StackStatus.CREATE_COMPLETE],
+                undefined,
+                'us-west-2',
+            );
         });
 
         it('should return empty array when both statusToInclude and statusToExclude are provided', async () => {

--- a/tst/unit/services/CcapiService.test.ts
+++ b/tst/unit/services/CcapiService.test.ts
@@ -94,6 +94,15 @@ describe('CcapiService', () => {
         });
     });
 
+    it('should pass region parameter to AwsClient', async () => {
+        const mockResponse = { ResourceDescriptions: [], TypeName: 'AWS::S3::Bucket' };
+        cloudControlMock.on(ListResourcesCommand).resolves(mockResponse);
+
+        await service.listResources('AWS::S3::Bucket', 'ap-southeast-1');
+
+        expect(mockGetCloudControlClient).toHaveBeenCalledWith('ap-southeast-1');
+    });
+
     describe('error handling', () => {
         it('should throw error when client creation fails', async () => {
             mockGetCloudControlClient.mockImplementation(() => {

--- a/tst/unit/services/CfnService.test.ts
+++ b/tst/unit/services/CfnService.test.ts
@@ -64,6 +64,14 @@ describe('CfnService', () => {
         vi.clearAllMocks();
     });
 
+    it('should pass region parameter to AwsClient', async () => {
+        cloudFormationMock.on(ListStacksCommand).resolves({ StackSummaries: [] });
+
+        await service.listStacks(undefined, undefined, 'eu-central-1');
+
+        expect(mockGetCloudFormationClient).toHaveBeenCalledWith('eu-central-1');
+    });
+
     const createStackNotFoundError = () =>
         new StackNotFoundException({
             message: TEST_CONSTANTS.ERROR_MESSAGES.STACK_NOT_FOUND,

--- a/tst/unit/stackActions/StackActionWorkflowOperations.test.ts
+++ b/tst/unit/stackActions/StackActionWorkflowOperations.test.ts
@@ -73,14 +73,17 @@ describe('StackActionWorkflowOperations', () => {
             const result = await processChangeSet(mockCfnService, mockDocumentManager, params, 'CREATE');
 
             expect(result).toContain('AWS-CloudFormation');
-            expect(mockCfnService.createChangeSet).toHaveBeenCalledWith({
-                StackName: 'test-stack',
-                ChangeSetName: expect.stringContaining(ExtensionName.replaceAll(' ', '-')),
-                TemplateBody: 'template content',
-                Parameters: undefined,
-                Capabilities: undefined,
-                ChangeSetType: 'CREATE',
-            });
+            expect(mockCfnService.createChangeSet).toHaveBeenCalledWith(
+                {
+                    StackName: 'test-stack',
+                    ChangeSetName: expect.stringContaining(ExtensionName.replaceAll(' ', '-')),
+                    TemplateBody: 'template content',
+                    Parameters: undefined,
+                    Capabilities: undefined,
+                    ChangeSetType: 'CREATE',
+                },
+                undefined,
+            );
         });
 
         it('should throw error when document not found', async () => {
@@ -288,15 +291,22 @@ describe('StackActionWorkflowOperations', () => {
             expect(result.phase).toBe(StackActionPhase.VALIDATION_COMPLETE);
             expect(result.state).toBe(StackActionState.SUCCESSFUL);
             expect(result.changes).toBeDefined();
-            expect(mockCfnService.waitUntilChangeSetCreateComplete).toHaveBeenCalledWith({
-                ChangeSetName: 'test-changeset',
-                StackName: 'test-stack',
-            });
-            expect(mockCfnService.describeChangeSet).toHaveBeenCalledWith({
-                ChangeSetName: 'test-changeset',
-                StackName: 'test-stack',
-                IncludePropertyValues: true,
-            });
+            expect(mockCfnService.waitUntilChangeSetCreateComplete).toHaveBeenCalledWith(
+                {
+                    ChangeSetName: 'test-changeset',
+                    StackName: 'test-stack',
+                },
+                undefined,
+                undefined,
+            );
+            expect(mockCfnService.describeChangeSet).toHaveBeenCalledWith(
+                {
+                    ChangeSetName: 'test-changeset',
+                    StackName: 'test-stack',
+                    IncludePropertyValues: true,
+                },
+                undefined,
+            );
         });
 
         it('should return failed result when changeset creation fails', async () => {

--- a/tst/unit/stackActions/ValidationWorkflow.test.ts
+++ b/tst/unit/stackActions/ValidationWorkflow.test.ts
@@ -376,7 +376,12 @@ describe('ValidationWorkflow', () => {
 
             expect(result.changeSetName).toBe('changeset-123');
             expect(mockValidationManager.add).toHaveBeenCalled();
-            expect(waitForChangeSetValidation).toHaveBeenCalledWith(mockCfnService, 'changeset-123', 'test-stack');
+            expect(waitForChangeSetValidation).toHaveBeenCalledWith(
+                mockCfnService,
+                'changeset-123',
+                'test-stack',
+                undefined,
+            );
 
             const workflow = (validationWorkflow as any).workflows.get('test-id');
             expect(workflow.changes).toEqual(mockChanges);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update API calls to support region parameters.  To align with the toolkit we are separating credentials and region. Credentials are global and can be used across regions so we are allowing the customer to use the same credentials against different regions.  Region is configured on the client setup and not on the parameters of the API call so we need to separate it out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
