### PR TITLE
add autocomplete for deletion policy resource attribute

### DIFF
--- a/src/autocomplete/ResourcePropertyCompletionProvider.ts
+++ b/src/autocomplete/ResourcePropertyCompletionProvider.ts
@@ -4,6 +4,11 @@ import {
     CREATION_POLICY_SCHEMA,
     CreationPolicyPropertySchema,
 } from '../artifacts/resourceAttributes/CreationPolicyPropertyDocs';
+import {
+    deletionPolicyValueDocsMap,
+    DELETION_POLICY_VALUES,
+    supportsSnapshot,
+} from '../artifacts/resourceAttributes/DeletionPolicyPropertyDocs';
 import { Context } from '../context/Context';
 import { ResourceAttribute, TopLevelSection, ResourceAttributesSet } from '../context/ContextType';
 import { Resource } from '../context/semantic/Entity';
@@ -341,6 +346,9 @@ export class ResourcePropertyCompletionProvider implements CompletionProvider {
             case ResourceAttribute.CreationPolicy: {
                 return this.getCreationPolicyCompletions(propertyPath, resource.Type, context, existingProperties);
             }
+            case ResourceAttribute.DeletionPolicy: {
+                return this.getDeletionPolicyCompletions(resource.Type, context);
+            }
             //TODO: add other resource attributes
             default: {
                 return [];
@@ -384,6 +392,24 @@ export class ResourcePropertyCompletionProvider implements CompletionProvider {
             resourceType,
             context,
             existingProperties,
+        );
+    }
+
+    private getDeletionPolicyCompletions(resourceType: string, context: Context): CompletionItem[] {
+        if (!context.isValue()) {
+            return [];
+        }
+
+        return DELETION_POLICY_VALUES.filter((value) => value !== 'Snapshot' || supportsSnapshot(resourceType)).map(
+            (value, index) => {
+                const documentation = deletionPolicyValueDocsMap.get(value);
+                return createCompletionItem(value, CompletionItemKind.EnumMember, {
+                    sortText: `${index}`,
+                    documentation: documentation ? createMarkupContent(documentation) : undefined,
+                    data: { type: 'simple' },
+                    context: context,
+                });
+            },
         );
     }
 

--- a/tst/e2e/autocomplete/Autocomplete.test.ts
+++ b/tst/e2e/autocomplete/Autocomplete.test.ts
@@ -1029,18 +1029,25 @@ Resources:
           Value: !Sub "\${EnvironmentName}-database"
         - Key: Environment
           Value: !Ref EnvironmentName
-    DeletionPolicy: !If [IsProduction, S]`,
+    DeletionPolicy: `,
                         position: { line: 279, character: 28 },
+                        description: 'Suggest DeletionPolicy options',
+                        verification: {
+                            position: { line: 286, character: 20 },
+                            expectation: CompletionExpectationBuilder.create()
+                                .expectContainsItems(['Delete', 'Retain', 'RetainExceptOnCreate', 'Snapshot'])
+                                .build(),
+                        },
+                    },
+                    {
+                        action: 'type',
+                        content: `!If [IsProduction, S]`,
+                        position: { line: 286, character: 20 },
                         description: 'Suggest DeletionPolicy option Snapshot for resources that support snapshot',
                         verification: {
                             position: { line: 286, character: 40 },
                             expectation: CompletionExpectationBuilder.create()
                                 .expectContainsItems(['Snapshot'])
-                                .todo(
-                                    `feature to suggest Resource attribute values
-                                 some values (Snapshot) are based on resource type; see docs below
-                                 https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-deletionpolicy.html#aws-attribute-deletionpolicy-options`,
-                                )
                                 .build(),
                         },
                     },
@@ -1051,7 +1058,22 @@ Resources:
                     },
                     {
                         action: 'type',
-                        content: `napshot, Delete]
+                        content: `napshot, D]`,
+                        position: { line: 286, character: 40 },
+                        description: 'Suggest DeletionPolicy option Delete',
+                        verification: {
+                            position: { line: 286, character: 50 },
+                            expectation: CompletionExpectationBuilder.create().expectContainsItems(['Delete']).build(),
+                        },
+                    },
+                    {
+                        action: 'delete',
+                        range: { start: { line: 286, character: 50 }, end: { line: 286, character: 51 } },
+                        description: 'remove ]',
+                    },
+                    {
+                        action: 'type',
+                        content: `elete]
     UpdateReplacePolicy: !If [IsProduction, Snapshot, Delete]
 
   DatabaseSecurityGroup:
@@ -1091,7 +1113,7 @@ Resources:
         Variables:
           ENVIRONMENT: !Ref EnvironmentName
           DATABASE_ENDPOINT: !GetAtt Database.`,
-                        position: { line: 286, character: 40 },
+                        position: { line: 286, character: 50 },
                         description: 'Suggest readonly properties of Resource as Fn::GetAtt value',
                         verification: {
                             position: { line: 325, character: 46 },


### PR DESCRIPTION
- adds autocomplete for the [deletion policy](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-deletionpolicy.html) resource attribute


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
