### PR TITLE
refactoring related resources logicalId suggestions to be more informative

### DIFF
--- a/src/autocomplete/InlineCompletionRouter.ts
+++ b/src/autocomplete/InlineCompletionRouter.ts
@@ -1,6 +1,7 @@
 import { InlineCompletionList, InlineCompletionParams, InlineCompletionItem } from 'vscode-languageserver-protocol';
 import { Context } from '../context/Context';
 import { ContextManager } from '../context/ContextManager';
+import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
 import { DocumentManager } from '../document/DocumentManager';
 import { SchemaRetriever } from '../schema/SchemaRetriever';
 import { CfnExternal } from '../server/CfnExternal';
@@ -100,7 +101,12 @@ export class InlineCompletionRouter implements SettingsConfigurable, Closeable {
         const relationshipSchemaService = new RelationshipSchemaService();
         return new InlineCompletionRouter(
             core.contextManager,
-            createInlineCompletionProviders(core.documentManager, relationshipSchemaService, external.schemaRetriever),
+            createInlineCompletionProviders(
+                core.documentManager,
+                relationshipSchemaService,
+                external.schemaRetriever,
+                core.syntaxTreeManager,
+            ),
             core.documentManager,
         );
     }
@@ -110,12 +116,18 @@ export function createInlineCompletionProviders(
     documentManager: DocumentManager,
     relationshipSchemaService: RelationshipSchemaService,
     schemaRetriever: SchemaRetriever,
+    syntaxTreeManager: SyntaxTreeManager,
 ): Map<InlineCompletionProviderType, InlineCompletionProvider> {
     const inlineCompletionProviderMap = new Map<InlineCompletionProviderType, InlineCompletionProvider>();
 
     inlineCompletionProviderMap.set(
         'RelatedResources',
-        new RelatedResourcesInlineCompletionProvider(relationshipSchemaService, documentManager, schemaRetriever),
+        new RelatedResourcesInlineCompletionProvider(
+            relationshipSchemaService,
+            documentManager,
+            schemaRetriever,
+            syntaxTreeManager,
+        ),
     );
 
     return inlineCompletionProviderMap;

--- a/tst/unit/autocomplete/InlineCompletionRouter.test.ts
+++ b/tst/unit/autocomplete/InlineCompletionRouter.test.ts
@@ -13,6 +13,7 @@ import {
     createMockRelationshipSchemaService,
     createMockSchemaRetriever,
     createMockSettingsManager,
+    createMockSyntaxTreeManager,
 } from '../../utils/MockServerComponents';
 
 describe('InlineCompletionRouter', () => {
@@ -21,6 +22,7 @@ describe('InlineCompletionRouter', () => {
     const mockSettingsManager = createMockSettingsManager();
     const mockSchemaRetriever = createMockSchemaRetriever();
     const mockRelationshipSchemaService = createMockRelationshipSchemaService();
+    const mockSyntaxTreeManager = createMockSyntaxTreeManager();
     let router: InlineCompletionRouter;
 
     const mockParams: InlineCompletionParams = {
@@ -37,6 +39,7 @@ describe('InlineCompletionRouter', () => {
             mockDocumentManager,
             mockRelationshipSchemaService,
             mockSchemaRetriever,
+            mockSyntaxTreeManager,
         );
         router = new InlineCompletionRouter(mockContextManager, providers, mockDocumentManager);
         router.configure(mockSettingsManager);
@@ -301,6 +304,7 @@ describe('InlineCompletionRouter', () => {
             const mockCore = {
                 contextManager: mockContextManager,
                 documentManager: mockDocumentManager,
+                syntaxTreeManager: mockSyntaxTreeManager,
             } as any;
             const mockExternal = {
                 schemaRetriever: mockSchemaRetriever,


### PR DESCRIPTION
*Description of changes:*
- Small refactoring of logicalId suggestion to be like `IamRoleRelatedToLambdaFunction1`
- Replace entire document reading logical with `getEntityMap` function to get the logicalId already authored in template
- https://github.com/aws-cloudformation/cloudformation-languageserver/pull/66

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
