### PR TITLE
paginate aws sdk api calls instead of fetching all

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -1,4 +1,4 @@
-import { ResponseError, ErrorCodes, RequestHandler } from 'vscode-languageserver';
+import { ErrorCodes, RequestHandler, ResponseError } from 'vscode-languageserver';
 import { TopLevelSection } from '../context/ContextType';
 import { getEntityMap } from '../context/SectionContextBuilder';
 import { Parameter, Resource } from '../context/semantic/Entity';
@@ -8,15 +8,15 @@ import { ServerComponents } from '../server/ServerComponents';
 import { analyzeCapabilities } from '../stacks/actions/CapabilityAnalyzer';
 import { parseStackActionParams, parseTemplateUriParams } from '../stacks/actions/StackActionParser';
 import {
-    GetCapabilitiesResult,
-    TemplateUri,
-    GetParametersResult,
     CreateStackActionParams,
     CreateStackActionResult,
-    GetStackActionStatusResult,
-    DescribeValidationStatusResult,
     DescribeDeploymentStatusResult,
+    DescribeValidationStatusResult,
+    GetCapabilitiesResult,
+    GetParametersResult,
+    GetStackActionStatusResult,
     GetTemplateResourcesResult,
+    TemplateUri,
 } from '../stacks/actions/StackActionRequestType';
 import { ListStacksParams, ListStacksResult } from '../stacks/StackRequestType';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
@@ -239,10 +239,12 @@ export function listStacksHandler(
             if (params.statusToInclude?.length && params.statusToExclude?.length) {
                 throw new Error('Cannot specify both statusToInclude and statusToExclude');
             }
-            return { stacks: await components.cfnService.listStacks(params.statusToInclude, params.statusToExclude) };
+            return await components.cfnService.listStacks(params.statusToInclude, params.statusToExclude, {
+                nextToken: params.nextToken,
+            });
         } catch (error) {
             log.error({ error: extractErrorMessage(error) }, 'Error listing stacks');
-            return { stacks: [] };
+            return { stacks: [], nextToken: undefined };
         }
     };
 }

--- a/src/services/IacGeneratorService.ts
+++ b/src/services/IacGeneratorService.ts
@@ -41,39 +41,38 @@ export class IacGeneratorService {
         });
     }
 
-    public async listResourceScanResources(scanId: string): Promise<ScannedResource[]> {
+    public async listResourceScanResources(
+        scanId: string,
+        options?: { nextToken?: string; maxResults?: number },
+    ): Promise<{ resources: ScannedResource[]; nextToken?: string }> {
         return await this.withClient(async (client) => {
             const input: ListResourceScanResourcesInput = {
                 ResourceScanId: scanId,
+                NextToken: options?.nextToken,
+                MaxResults: options?.maxResults,
             };
-            let nextToken: string | undefined;
-            const scannedResources: ScannedResource[] = [];
-            do {
-                const response = await client.send(new ListResourceScanResourcesCommand(input));
-                if (response.Resources) {
-                    scannedResources.push(...response.Resources);
-                }
-                input.NextToken = response.NextToken;
-                nextToken = response.NextToken;
-            } while (nextToken);
-            return scannedResources;
+            const response = await client.send(new ListResourceScanResourcesCommand(input));
+            return {
+                resources: response.Resources ?? [],
+                nextToken: response.NextToken,
+            };
         });
     }
 
-    public async listResourceScans(): Promise<ResourceScanSummary[]> {
+    public async listResourceScans(options?: {
+        nextToken?: string;
+        maxResults?: number;
+    }): Promise<{ scans: ResourceScanSummary[]; nextToken?: string }> {
         return await this.withClient(async (client) => {
-            const input: ListResourceScansInput = {};
-            let nextToken: string | undefined;
-            const resourceScans: ResourceScanSummary[] = [];
-            do {
-                const response = await client.send(new ListResourceScansCommand(input));
-                if (response.ResourceScanSummaries) {
-                    resourceScans.push(...response.ResourceScanSummaries);
-                }
-                input.NextToken = response.NextToken;
-                nextToken = response.NextToken;
-            } while (nextToken);
-            return resourceScans;
+            const input: ListResourceScansInput = {
+                NextToken: options?.nextToken,
+                MaxResults: options?.maxResults,
+            };
+            const response = await client.send(new ListResourceScansCommand(input));
+            return {
+                scans: response.ResourceScanSummaries ?? [],
+                nextToken: response.NextToken,
+            };
         });
     }
 

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -4,10 +4,12 @@ import { RequestType } from 'vscode-languageserver-protocol';
 export type ListStacksParams = {
     statusToInclude?: StackStatus[];
     statusToExclude?: StackStatus[];
+    nextToken?: string;
 };
 
 export type ListStacksResult = {
     stacks: StackSummary[];
+    nextToken?: string;
 };
 
 export const ListStacksRequest = new RequestType<ListStacksParams, ListStacksResult, void>('aws/cfn/stacks');

--- a/tst/unit/handlers/StackHandler.test.ts
+++ b/tst/unit/handlers/StackHandler.test.ts
@@ -289,7 +289,7 @@ describe('StackActionHandler', () => {
 
             const mockComponents = {
                 cfnService: {
-                    listStacks: vi.fn().mockResolvedValue(mockStacks),
+                    listStacks: vi.fn().mockResolvedValue({ stacks: mockStacks, nextToken: undefined }),
                 },
             } as any;
 
@@ -316,7 +316,7 @@ describe('StackActionHandler', () => {
             const mockStacks: StackSummary[] = [];
             const mockComponents = {
                 cfnService: {
-                    listStacks: vi.fn().mockResolvedValue(mockStacks),
+                    listStacks: vi.fn().mockResolvedValue({ stacks: mockStacks, nextToken: undefined }),
                 },
             } as any;
 
@@ -327,14 +327,18 @@ describe('StackActionHandler', () => {
             const handler = listStacksHandler(mockComponents);
             await handler(paramsWithInclude, mockToken);
 
-            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith([StackStatus.CREATE_COMPLETE], undefined);
+            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith(
+                [StackStatus.CREATE_COMPLETE],
+                undefined,
+                { nextToken: undefined },
+            );
         });
 
         it('should pass statusToExclude to cfnService', async () => {
             const mockStacks: StackSummary[] = [];
             const mockComponents = {
                 cfnService: {
-                    listStacks: vi.fn().mockResolvedValue(mockStacks),
+                    listStacks: vi.fn().mockResolvedValue({ stacks: mockStacks, nextToken: undefined }),
                 },
             } as any;
 
@@ -345,7 +349,11 @@ describe('StackActionHandler', () => {
             const handler = listStacksHandler(mockComponents);
             await handler(paramsWithExclude, mockToken);
 
-            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith(undefined, [StackStatus.DELETE_COMPLETE]);
+            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith(
+                undefined,
+                [StackStatus.DELETE_COMPLETE],
+                { nextToken: undefined },
+            );
         });
 
         it('should return empty array when both statusToInclude and statusToExclude are provided', async () => {

--- a/tst/unit/services/IacGeneratorService.test.ts
+++ b/tst/unit/services/IacGeneratorService.test.ts
@@ -86,7 +86,10 @@ describe('IacGeneratorService', () => {
 
             const result = await service.listResourceScanResources('scan-123');
 
-            expect(result).toEqual(mockResponse.Resources);
+            expect(result).toEqual({
+                resources: mockResponse.Resources,
+                nextToken: undefined,
+            });
         });
 
         it('should throw CloudFormationServiceException when API call fails', async () => {

--- a/tst/unit/stackActions/DeploymentWorkflow.test.ts
+++ b/tst/unit/stackActions/DeploymentWorkflow.test.ts
@@ -239,22 +239,29 @@ describe('DeploymentWorkflow', () => {
 
             mockCfnService.executeChangeSet = vi.fn().mockResolvedValue({});
 
-            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({
-                StackEvents: [
-                    {
-                        LogicalResourceId: 'MyBucket',
-                        ResourceType: 'AWS::S3::Bucket',
-                        Timestamp: new Date('2023-01-01T10:00:00Z'),
-                        ResourceStatus: 'CREATE_COMPLETE',
-                        ResourceStatusReason: 'Resource creation completed successfully',
-                    },
-                    {
-                        LogicalResourceId: 'MyRole',
-                        ResourceType: 'AWS::IAM::Role',
-                        Timestamp: new Date('2023-01-01T10:01:00Z'),
-                        ResourceStatus: 'CREATE_COMPLETE',
-                    },
-                ],
+            mockCfnService.describeStackEvents = vi.fn().mockImplementation((_params, options) => {
+                if (options?.nextToken) {
+                    return Promise.resolve({ StackEvents: [] });
+                }
+                return Promise.resolve({
+                    StackEvents: [
+                        {
+                            LogicalResourceId: 'MyBucket',
+                            ResourceType: 'AWS::S3::Bucket',
+                            Timestamp: new Date('2023-01-01T10:00:00Z'),
+                            ResourceStatus: 'CREATE_COMPLETE',
+                            ResourceStatusReason: 'Resource creation completed successfully',
+                            ClientRequestToken: 'test-workflow-id',
+                        },
+                        {
+                            LogicalResourceId: 'MyRole',
+                            ResourceType: 'AWS::IAM::Role',
+                            Timestamp: new Date('2023-01-01T10:01:00Z'),
+                            ResourceStatus: 'CREATE_COMPLETE',
+                            ClientRequestToken: 'test-workflow-id',
+                        },
+                    ],
+                });
             });
 
             (processChangeSet as any).mockResolvedValue('test-changeset');


### PR DESCRIPTION
*Description of changes:*
- change AWS SDK API calls which support pagination to return only first page and next token.
- fetch all in the workflow services for now to maintain backward functional compatibility (resource state during import, describe stack events.
  - this will be revisited and improved based on the desired user experience (search function)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
