### PR TITLE
Persist auth in memory, removing loading credentials from SDK to supp…

### DIFF
--- a/src/auth/AuthProtocol.ts
+++ b/src/auth/AuthProtocol.ts
@@ -6,6 +6,7 @@ import {
 } from 'vscode-languageserver';
 import {
     UpdateCredentialsParams,
+    UpdateCredentialsResult,
     ConnectionMetadata,
     ListProfilesParams,
     ListProfilesResult,
@@ -22,7 +23,9 @@ import {
 export const IamCredentialsUpdateRequest = Object.freeze({
     method: 'aws/credentials/iam/update' as const,
     messageDirection: MessageDirection.clientToServer,
-    type: new ProtocolRequestType<UpdateCredentialsParams, void, never, void, void>('aws/credentials/iam/update'),
+    type: new ProtocolRequestType<UpdateCredentialsParams, UpdateCredentialsResult, never, void, void>(
+        'aws/credentials/iam/update',
+    ),
 } as const);
 
 export const BearerCredentialsUpdateRequest = Object.freeze({

--- a/src/auth/AwsCredentialsParser.ts
+++ b/src/auth/AwsCredentialsParser.ts
@@ -19,11 +19,11 @@ const ProfileKindSchema = z.enum([
 ]);
 
 const IamCredentialsSchema = z.object({
-    profile: z.string().optional(),
+    profile: z.string({ message: 'Profile name is required' }),
     accessKeyId: z.string({ message: 'Access key ID is required' }),
     secretAccessKey: z.string({ message: 'Secret access key is required' }),
     sessionToken: z.string().optional(),
-    region: z.string().optional(),
+    region: z.string({ message: 'Region is required' }),
 });
 
 const BearerCredentialsSchema = z.object({

--- a/src/auth/AwsLspAuthTypes.ts
+++ b/src/auth/AwsLspAuthTypes.ts
@@ -1,12 +1,10 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 
-// Must be kept consistent with https://github.com/aws/language-server-runtimes
-export type IamCredentials = {
-    profile?: string;
-    accessKeyId: string;
-    secretAccessKey: string;
-    sessionToken?: string;
-    region?: string;
+import { AwsCredentialIdentity } from '@aws-sdk/types';
+
+export type IamCredentials = AwsCredentialIdentity & {
+    profile: string;
+    region: string;
 };
 
 export type BearerCredentials = {
@@ -26,6 +24,10 @@ export type UpdateCredentialsParams = {
     data: IamCredentials | BearerCredentials;
     metadata?: ConnectionMetadata;
     encrypted?: boolean;
+};
+
+export type UpdateCredentialsResult = {
+    success: boolean;
 };
 
 export type ProfileKind =

--- a/src/handlers/AuthHandler.ts
+++ b/src/handlers/AuthHandler.ts
@@ -1,14 +1,13 @@
 import { RequestHandler, NotificationHandler } from 'vscode-languageserver/node';
-import { UpdateCredentialsParams, SsoTokenChangedParams } from '../auth/AwsLspAuthTypes';
+import { UpdateCredentialsParams, UpdateCredentialsResult, SsoTokenChangedParams } from '../auth/AwsLspAuthTypes';
 import { ServerComponents } from '../server/ServerComponents';
 
 export function iamCredentialsUpdateHandler(
     components: ServerComponents,
-): RequestHandler<UpdateCredentialsParams, void, void> {
-    return (params: UpdateCredentialsParams) => {
-        // AwsCredentials.handleIamCredentialsUpdate already calls settingsManager.updateProfileSettings
-        // which will notify all subscribed components via the observable pattern
-        components.awsCredentials.handleIamCredentialsUpdate(params);
+): RequestHandler<UpdateCredentialsParams, UpdateCredentialsResult, void> {
+    return (params: UpdateCredentialsParams): UpdateCredentialsResult => {
+        const success = components.awsCredentials.handleIamCredentialsUpdate(params);
+        return { success };
     };
 }
 

--- a/src/protocol/LspAuthHandlers.ts
+++ b/src/protocol/LspAuthHandlers.ts
@@ -17,6 +17,7 @@ import {
     ListProfilesParams,
     SsoTokenChangedParams,
     UpdateCredentialsParams,
+    UpdateCredentialsResult,
     UpdateProfileParams,
 } from '../auth/AwsLspAuthTypes';
 
@@ -27,7 +28,7 @@ export class LspAuthHandlers {
     // ========================================
     // RECEIVE: Client → Server
     // ========================================
-    onIamCredentialsUpdate(handler: RequestHandler<UpdateCredentialsParams, void, void>) {
+    onIamCredentialsUpdate(handler: RequestHandler<UpdateCredentialsParams, UpdateCredentialsResult, void>) {
         this.connection.onRequest(IamCredentialsUpdateRequest.type, handler);
     }
 

--- a/src/server/CfnExternal.ts
+++ b/src/server/CfnExternal.ts
@@ -63,7 +63,7 @@ export class CfnExternal implements Configurables, Closeable {
     }
 
     configurables(): Configurable[] {
-        return [this.schemaTaskManager, this.schemaRetriever, this.awsClient, this.cfnLintService, this.guardService];
+        return [this.schemaTaskManager, this.schemaRetriever, this.cfnLintService, this.guardService];
     }
 
     async close() {

--- a/src/server/CfnInfraCore.ts
+++ b/src/server/CfnInfraCore.ts
@@ -51,8 +51,7 @@ export class CfnInfraCore implements Configurables, Closeable {
         this.fileContextManager = overrides.fileContextManager ?? new FileContextManager(this.documentManager);
 
         this.awsCredentials =
-            overrides.awsCredentials ??
-            new AwsCredentials(lspComponents.authHandlers, this.settingsManager, this.clientMessage);
+            overrides.awsCredentials ?? new AwsCredentials(lspComponents.authHandlers, this.settingsManager);
 
         this.diagnosticCoordinator =
             overrides.diagnosticCoordinator ?? new DiagnosticCoordinator(lspComponents.diagnostics);

--- a/src/services/AwsClient.ts
+++ b/src/services/AwsClient.ts
@@ -1,46 +1,32 @@
 import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
-import { AwsCredentialIdentity } from '@aws-sdk/types';
 import { AwsCredentials } from '../auth/AwsCredentials';
-import { SettingsConfigurable, ISettingsSubscriber, SettingsSubscription } from '../settings/ISettingsSubscriber';
-import { DefaultSettings } from '../settings/Settings';
+import { IamCredentials } from '../auth/AwsLspAuthTypes';
 import { ExtensionId, ExtensionVersion } from '../utils/ExtensionConfig';
 
-export class AwsClient implements SettingsConfigurable {
-    constructor(
-        private readonly credentialsProvider: AwsCredentials,
-        private region: string = DefaultSettings.profile.region,
-        private settingsSubscription?: SettingsSubscription,
-    ) {}
+type IamClientConfig = {
+    region: string;
+    credentials: IamCredentials;
+    customUserAgent: string;
+};
 
-    configure(settingsManager: ISettingsSubscriber): void {
-        if (this.settingsSubscription) {
-            this.settingsSubscription.unsubscribe();
-        }
-
-        this.settingsSubscription = settingsManager.subscribe('profile', (newProfile) => {
-            this.region = newProfile.region;
-        });
-    }
+export class AwsClient {
+    constructor(private readonly credentialsProvider: AwsCredentials) {}
 
     // By default, clients will retry on throttling exceptions 3 times
-    public async getCloudFormationClient() {
-        return new CloudFormationClient(await this.iamClientConfig());
+    public getCloudFormationClient() {
+        return new CloudFormationClient(this.iamClientConfig());
     }
 
-    public async getCloudControlClient() {
-        return new CloudControlClient(await this.iamClientConfig());
+    public getCloudControlClient() {
+        return new CloudControlClient(this.iamClientConfig());
     }
 
-    private async iamClientConfig(): Promise<{
-        region: string;
-        credentials: AwsCredentialIdentity;
-        customUserAgent: string;
-    }> {
-        const data = await this.credentialsProvider.getIAM();
+    private iamClientConfig(): IamClientConfig {
+        const credential = this.credentialsProvider.getIAM();
         return {
-            region: this.region,
-            credentials: data,
+            region: credential.region,
+            credentials: this.credentialsProvider.getIAM(),
             customUserAgent: `${ExtensionId}/${ExtensionVersion}`,
         };
     }

--- a/src/services/CcapiService.ts
+++ b/src/services/CcapiService.ts
@@ -12,7 +12,7 @@ export class CcapiService {
     constructor(private readonly awsClient: AwsClient) {}
 
     private async withClient<T>(request: (client: CloudControlClient) => Promise<T>): Promise<T> {
-        const client = await this.awsClient.getCloudControlClient();
+        const client = this.awsClient.getCloudControlClient();
         return await request(client);
     }
 

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -59,7 +59,7 @@ export class CfnService {
     public constructor(private readonly awsClient: AwsClient) {}
 
     protected async withClient<T>(request: (client: CloudFormationClient) => Promise<T>): Promise<T> {
-        const client = await this.awsClient.getCloudFormationClient();
+        const client = this.awsClient.getCloudFormationClient();
         return await request(client);
     }
 

--- a/src/services/IacGeneratorService.ts
+++ b/src/services/IacGeneratorService.ts
@@ -24,7 +24,7 @@ export class IacGeneratorService {
     constructor(private readonly awsClient: AwsClient) {}
 
     private async withClient<T>(request: (client: CloudFormationClient) => Promise<T>): Promise<T> {
-        const client = await this.awsClient.getCloudFormationClient();
+        const client = this.awsClient.getCloudFormationClient();
         return await request(client);
     }
 

--- a/tst/unit/handlers/AuthHandler.test.ts
+++ b/tst/unit/handlers/AuthHandler.test.ts
@@ -29,15 +29,18 @@ describe('AuthHandler', () => {
     test('iamCredentialsUpdateHandler calls handleIamCredentialsUpdate', () => {
         const params: UpdateCredentialsParams = {
             data: {
+                profile: 'test-profile',
                 accessKeyId: 'test',
                 secretAccessKey: 'test',
                 region: 'Region',
             },
         };
-        iamCredentialsUpdateHandler(mockComponents)(params, mockCancellationToken);
+        awsCredentials.handleIamCredentialsUpdate.returns(true);
+        const result = iamCredentialsUpdateHandler(mockComponents)(params, mockCancellationToken);
 
         expect(awsCredentials.handleIamCredentialsUpdate.callCount).toBe(1);
         expect(awsCredentials.handleIamCredentialsUpdate.firstCall.args[0]).toStrictEqual(params);
+        expect(result).toEqual({ success: true });
     });
 
     test('bearerCredentialsUpdateHandler calls handleBearerCredentialsUpdate', () => {


### PR DESCRIPTION
> ## Summary of PR #117: Persist Auth in Memory for SSO Support

Author: Satyaki Ghosh (@satyakigh)
Status: Open
Changes: +105 additions, -172 deletions

### Key Code Changes

1. In-Memory Credential Storage
• Removed dependency on AWS SDK credential loading (sdkIAMCredentials)
• Credentials are now stored directly in memory within AwsCredentials class
• IAM credentials stored as IamCredentials object with profile, region, and AWS credential identity
• Bearer credentials stored separately for SSO token support

2. Synchronous Credential Access
• Changed getIAM() from async to synchronous method
• Returns stored credentials directly instead of loading from SDK
• Throws error if credentials not configured (fail-fast approach)
• Added structuredClone() for immutable credential returns

3. Enhanced Type Safety
• IamCredentials now extends AwsCredentialIdentity with required profile and region fields
• Made profile and region required (not optional) in credential schema
• Added UpdateCredentialsResult type with success boolean

4. Simplified AWS Client
• Removed SettingsConfigurable implementation from AwsClient
• Eliminated async credential loading in client initialization
• CloudFormation and CloudControl clients now instantiated synchronously
• Region comes directly from stored credentials instead of settings subscription

5. Updated Request Handlers
• handleIamCredentialsUpdate() now returns boolean success status
• IAM credential update request returns UpdateCredentialsResult instead of void
• Improved error handling with explicit success/failure responses