### PR TITLE
paginate resource and stack list

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -1,4 +1,4 @@
-import { ResponseError, ErrorCodes, RequestHandler } from 'vscode-languageserver';
+import { ErrorCodes, RequestHandler, ResponseError } from 'vscode-languageserver';
 import { TopLevelSection } from '../context/ContextType';
 import { getEntityMap } from '../context/SectionContextBuilder';
 import { Parameter, Resource } from '../context/semantic/Entity';
@@ -8,15 +8,15 @@ import { ServerComponents } from '../server/ServerComponents';
 import { analyzeCapabilities } from '../stacks/actions/CapabilityAnalyzer';
 import { parseStackActionParams, parseTemplateUriParams } from '../stacks/actions/StackActionParser';
 import {
-    GetCapabilitiesResult,
-    TemplateUri,
-    GetParametersResult,
     CreateStackActionParams,
     CreateStackActionResult,
-    GetStackActionStatusResult,
-    DescribeValidationStatusResult,
     DescribeDeploymentStatusResult,
+    DescribeValidationStatusResult,
+    GetCapabilitiesResult,
+    GetParametersResult,
+    GetStackActionStatusResult,
     GetTemplateResourcesResult,
+    TemplateUri,
 } from '../stacks/actions/StackActionRequestType';
 import { ListStacksParams, ListStacksResult } from '../stacks/StackRequestType';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
@@ -239,10 +239,14 @@ export function listStacksHandler(
             if (params.statusToInclude?.length && params.statusToExclude?.length) {
                 throw new Error('Cannot specify both statusToInclude and statusToExclude');
             }
-            return { stacks: await components.cfnService.listStacks(params.statusToInclude, params.statusToExclude) };
+            return await components.stackManager.listStacks(
+                params.statusToInclude,
+                params.statusToExclude,
+                params.loadMore,
+            );
         } catch (error) {
             log.error({ error: extractErrorMessage(error) }, 'Error listing stacks');
-            return { stacks: [] };
+            return { stacks: [], nextToken: undefined };
         }
     };
 }

--- a/src/protocol/LspResourceHandlers.ts
+++ b/src/protocol/LspResourceHandlers.ts
@@ -1,4 +1,5 @@
 import { Connection, ServerRequestHandler } from 'vscode-languageserver';
+import { RequestHandler } from 'vscode-languageserver/node';
 import {
     ResourceTypesResult,
     ResourceTypesRequest,
@@ -13,13 +14,16 @@ import {
     RefreshResourcesResult,
     StackMgmtInfoRequest,
     ResourceIdentifier,
+    SearchResourceRequest,
+    SearchResourceParams,
+    SearchResourceResult,
 } from '../resourceState/ResourceStateTypes';
 import { ResourceStackManagementResult } from '../resourceState/StackManagementInfoProvider';
 
 export class LspResourceHandlers {
     constructor(private readonly connection: Connection) {}
 
-    onListResources(handler: ServerRequestHandler<ListResourcesParams, ListResourcesResult, never, void>) {
+    onListResources(handler: RequestHandler<ListResourcesParams, ListResourcesResult, void>) {
         this.connection.onRequest(ListResourcesRequest.method, handler);
     }
 
@@ -37,5 +41,9 @@ export class LspResourceHandlers {
 
     onStackMgmtInfo(handler: ServerRequestHandler<ResourceIdentifier, ResourceStackManagementResult, never, void>) {
         this.connection.onRequest(StackMgmtInfoRequest.method, handler);
+    }
+
+    onSearchResource(handler: ServerRequestHandler<SearchResourceParams, SearchResourceResult, never, void>) {
+        this.connection.onRequest(SearchResourceRequest.method, handler);
     }
 }

--- a/src/resourceState/ResourceStateTypes.ts
+++ b/src/resourceState/ResourceStateTypes.ts
@@ -46,13 +46,19 @@ export type ResourceType = string;
 
 export type ResourceIdentifier = string;
 
+export type ResourceRequest = {
+    resourceType: string;
+    nextToken?: string;
+};
+
 export type ListResourcesParams = {
-    resourceTypes?: string[];
+    resources?: ResourceRequest[];
 };
 
 export type ResourceSummary = {
     typeName: string;
     resourceIdentifiers: string[];
+    nextToken?: string;
 };
 
 export type ListResourcesResult = {
@@ -64,13 +70,27 @@ export const ListResourcesRequest = new RequestType<ListResourcesParams, ListRes
 );
 
 export type RefreshResourcesParams = {
-    resourceTypes: string[];
+    resources: ResourceRequest[];
 };
 
 export type RefreshResourcesResult = {
     resources: ResourceSummary[];
     refreshFailed: boolean;
 };
+
+export type SearchResourceParams = {
+    resourceType: string;
+    identifier: string;
+};
+
+export type SearchResourceResult = {
+    found: boolean;
+    resource?: ResourceSummary;
+};
+
+export const SearchResourceRequest = new RequestType<SearchResourceParams, SearchResourceResult, void>(
+    'aws/cfn/resources/search',
+);
 
 export const RefreshResourceListRequest = new RequestType<RefreshResourcesParams, RefreshResourcesResult, void>(
     'aws/cfn/resources/refresh',

--- a/src/server/CfnLspProviders.ts
+++ b/src/server/CfnLspProviders.ts
@@ -19,6 +19,7 @@ import {
 import { StackActionWorkflow } from '../stacks/actions/StackActionWorkflowType';
 import { ValidationWorkflow } from '../stacks/actions/ValidationWorkflow';
 import { ValidationWorkflowV2 } from '../stacks/actions/ValidationWorkflowV2';
+import { StackManager } from '../stacks/StackManager';
 import { localCfnClientExists } from '../utils/ClientUtil';
 import { Closeable, closeSafely } from '../utils/Closeable';
 import { Configurable, Configurables } from '../utils/Configurable';
@@ -28,6 +29,7 @@ import { CfnInfraCore } from './CfnInfraCore';
 export class CfnLspProviders implements Configurables, Closeable {
     // Business logic
     readonly stackManagementInfoProvider: StackManagementInfoProvider;
+    readonly stackManager: StackManager;
     readonly validationWorkflowService: StackActionWorkflow<DescribeValidationStatusResult>;
     readonly deploymentWorkflowService: StackActionWorkflow<DescribeDeploymentStatusResult>;
     readonly resourceStateManager: ResourceStateManager;
@@ -49,6 +51,7 @@ export class CfnLspProviders implements Configurables, Closeable {
     constructor(core: CfnInfraCore, external: CfnExternal, overrides: Partial<CfnLspProviders> = {}) {
         this.stackManagementInfoProvider =
             overrides.stackManagementInfoProvider ?? new StackManagementInfoProvider(external.cfnService);
+        this.stackManager = overrides.stackManager ?? new StackManager(external.cfnService);
         this.validationWorkflowService =
             overrides.validationWorkflowService ??
             (localCfnClientExists()

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -23,6 +23,7 @@ import {
     getResourceTypesHandler,
     importResourceStateHandler,
     refreshResourceListHandler,
+    searchResourceHandler,
     getStackMgmtInfo,
 } from '../handlers/ResourceHandler';
 import {
@@ -112,6 +113,7 @@ export class CfnServer {
 
         this.lsp.resourceHandlers.onListResources(listResourcesHandler(this.components));
         this.lsp.resourceHandlers.onRefreshResourceList(refreshResourceListHandler(this.components));
+        this.lsp.resourceHandlers.onSearchResource(searchResourceHandler(this.components));
         this.lsp.resourceHandlers.onGetResourceTypes(getResourceTypesHandler(this.components));
         this.lsp.resourceHandlers.onResourceStateImport(importResourceStateHandler(this.components));
         this.lsp.resourceHandlers.onStackMgmtInfo(getStackMgmtInfo(this.components));

--- a/src/stacks/StackManager.ts
+++ b/src/stacks/StackManager.ts
@@ -1,0 +1,56 @@
+import { StackStatus, StackSummary } from '@aws-sdk/client-cloudformation';
+import equal from 'fast-deep-equal';
+import { CfnService } from '../services/CfnService';
+
+export class StackManager {
+    private readonly stacksCache: Map<string, StackSummary> = new Map();
+    private nextToken?: string;
+    private statusToInclude?: StackStatus[];
+    private statusToExclude?: StackStatus[];
+
+    constructor(private readonly cfnService: CfnService) {}
+
+    public async listStacks(
+        statusToInclude?: StackStatus[],
+        statusToExclude?: StackStatus[],
+        loadMore?: boolean,
+    ): Promise<{ stacks: StackSummary[]; nextToken?: string }> {
+        // If filters changed or initial load, clear cache
+        if (!loadMore || this.filtersChanged(statusToInclude, statusToExclude)) {
+            this.stacksCache.clear();
+            this.nextToken = undefined;
+            this.statusToInclude = statusToInclude;
+            this.statusToExclude = statusToExclude;
+        }
+
+        const response = await this.cfnService.listStacks(
+            statusToInclude,
+            statusToExclude,
+            loadMore ? this.nextToken : undefined,
+        );
+
+        for (const stackSummary of response.stacks) {
+            if (stackSummary.StackId) {
+                this.stacksCache.set(stackSummary.StackId, stackSummary);
+            }
+        }
+
+        // Update nextToken
+        this.nextToken = response.nextToken;
+
+        // Return all cached stacks
+        return {
+            stacks: [...this.stacksCache.values()],
+            nextToken: this.nextToken,
+        };
+    }
+
+    private filtersChanged(statusToInclude?: StackStatus[], statusToExclude?: StackStatus[]): boolean {
+        return !equal(this.statusToInclude, statusToInclude) || !equal(this.statusToExclude, statusToExclude);
+    }
+
+    public clearCache(): void {
+        this.stacksCache.clear();
+        this.nextToken = undefined;
+    }
+}

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -4,10 +4,12 @@ import { RequestType } from 'vscode-languageserver-protocol';
 export type ListStacksParams = {
     statusToInclude?: StackStatus[];
     statusToExclude?: StackStatus[];
+    loadMore?: boolean;
 };
 
 export type ListStacksResult = {
     stacks: StackSummary[];
+    nextToken?: string;
 };
 
 export const ListStacksRequest = new RequestType<ListStacksParams, ListStacksResult, void>('aws/cfn/stacks');

--- a/src/stacks/actions/DeploymentWorkflow.ts
+++ b/src/stacks/actions/DeploymentWorkflow.ts
@@ -1,4 +1,4 @@
-import { ChangeSetType } from '@aws-sdk/client-cloudformation';
+import { ChangeSetType, StackEvent } from '@aws-sdk/client-cloudformation';
 import { DateTime } from 'luxon';
 import { DocumentManager } from '../../document/DocumentManager';
 import { Identifiable } from '../../protocol/LspTypes';
@@ -205,13 +205,30 @@ export class DeploymentWorkflow implements StackActionWorkflow<DescribeDeploymen
         stackName: string,
     ): Promise<void> {
         try {
-            const stackEventsResponse = await this.cfnService.describeStackEvents(
-                { StackName: stackName },
-                existingWorkflow.id,
-            );
+            // Fetch all events for the workflow
+            let nextToken: string | undefined;
+            const allEvents: StackEvent[] = [];
+            do {
+                const stackEventsResponse = await this.cfnService.describeStackEvents(
+                    { StackName: stackName },
+                    { nextToken },
+                );
+
+                const events = stackEventsResponse.StackEvents ?? [];
+                const matchingEvents = events.filter((event) => event.ClientRequestToken === existingWorkflow.id);
+
+                allEvents.push(...matchingEvents);
+
+                // Stop if no more events match the client request token
+                if (matchingEvents.length === 0) {
+                    break;
+                }
+
+                nextToken = stackEventsResponse.NextToken;
+            } while (nextToken);
 
             const deploymentEvents: DeploymentEvent[] =
-                stackEventsResponse.StackEvents?.map((event) => ({
+                allEvents.map((event) => ({
                     LogicalResourceId: event.LogicalResourceId,
                     ResourceType: event.ResourceType,
                     Timestamp: event.Timestamp ? DateTime.fromJSDate(event.Timestamp) : undefined,

--- a/src/stacks/actions/StackActionOperations.ts
+++ b/src/stacks/actions/StackActionOperations.ts
@@ -82,6 +82,7 @@ export async function waitForChangeSetValidation(
                 state: StackActionState.SUCCESSFUL,
                 changes: mapChangesToStackChanges(response.Changes),
                 failureReason: result.reason ? String(result.reason) : undefined,
+                nextToken: response.NextToken,
             };
         } else {
             logger.warn(

--- a/src/stacks/actions/StackActionWorkflowType.ts
+++ b/src/stacks/actions/StackActionWorkflowType.ts
@@ -31,6 +31,7 @@ export type ValidationWaitForResult = {
     phase: StackActionPhase;
     changes?: StackChange[];
     failureReason?: string;
+    nextToken?: string;
 };
 
 export type DeploymentWaitForResult = {

--- a/tst/unit/handlers/StackHandler.test.ts
+++ b/tst/unit/handlers/StackHandler.test.ts
@@ -288,8 +288,8 @@ describe('StackActionHandler', () => {
             ];
 
             const mockComponents = {
-                cfnService: {
-                    listStacks: vi.fn().mockResolvedValue(mockStacks),
+                stackManager: {
+                    listStacks: vi.fn().mockResolvedValue({ stacks: mockStacks, nextToken: undefined }),
                 },
             } as any;
 
@@ -301,7 +301,7 @@ describe('StackActionHandler', () => {
 
         it('should return empty array on error', async () => {
             const mockComponents = {
-                cfnService: {
+                stackManager: {
                     listStacks: vi.fn().mockRejectedValue(new Error('API Error')),
                 },
             } as any;
@@ -312,11 +312,11 @@ describe('StackActionHandler', () => {
             expect(result.stacks).toEqual([]);
         });
 
-        it('should pass statusToInclude to cfnService', async () => {
+        it('should pass statusToInclude to stackManager', async () => {
             const mockStacks: StackSummary[] = [];
             const mockComponents = {
-                cfnService: {
-                    listStacks: vi.fn().mockResolvedValue(mockStacks),
+                stackManager: {
+                    listStacks: vi.fn().mockResolvedValue({ stacks: mockStacks, nextToken: undefined }),
                 },
             } as any;
 
@@ -327,14 +327,18 @@ describe('StackActionHandler', () => {
             const handler = listStacksHandler(mockComponents);
             await handler(paramsWithInclude, mockToken);
 
-            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith([StackStatus.CREATE_COMPLETE], undefined);
+            expect(mockComponents.stackManager.listStacks).toHaveBeenCalledWith(
+                [StackStatus.CREATE_COMPLETE],
+                undefined,
+                undefined,
+            );
         });
 
-        it('should pass statusToExclude to cfnService', async () => {
+        it('should pass statusToExclude to stackManager', async () => {
             const mockStacks: StackSummary[] = [];
             const mockComponents = {
-                cfnService: {
-                    listStacks: vi.fn().mockResolvedValue(mockStacks),
+                stackManager: {
+                    listStacks: vi.fn().mockResolvedValue({ stacks: mockStacks, nextToken: undefined }),
                 },
             } as any;
 
@@ -345,12 +349,16 @@ describe('StackActionHandler', () => {
             const handler = listStacksHandler(mockComponents);
             await handler(paramsWithExclude, mockToken);
 
-            expect(mockComponents.cfnService.listStacks).toHaveBeenCalledWith(undefined, [StackStatus.DELETE_COMPLETE]);
+            expect(mockComponents.stackManager.listStacks).toHaveBeenCalledWith(
+                undefined,
+                [StackStatus.DELETE_COMPLETE],
+                undefined,
+            );
         });
 
         it('should return empty array when both statusToInclude and statusToExclude are provided', async () => {
             const mockComponents = {
-                cfnService: {
+                stackManager: {
                     listStacks: vi.fn(),
                 },
             } as any;
@@ -364,7 +372,7 @@ describe('StackActionHandler', () => {
             const result = (await handler(paramsWithBoth, mockToken)) as ListStacksResult;
 
             expect(result.stacks).toEqual([]);
-            expect(mockComponents.cfnService.listStacks).not.toHaveBeenCalled();
+            expect(mockComponents.stackManager.listStacks).not.toHaveBeenCalled();
         });
     });
 

--- a/tst/unit/services/CfnService.test.ts
+++ b/tst/unit/services/CfnService.test.ts
@@ -95,7 +95,10 @@ describe('CfnService', () => {
             cloudFormationMock.on(ListStacksCommand).resolves(MOCK_RESPONSES.LIST_STACKS);
 
             const result = await service.listStacks();
-            expect(result).toEqual(MOCK_RESPONSES.LIST_STACKS.StackSummaries);
+            expect(result).toEqual({
+                stacks: MOCK_RESPONSES.LIST_STACKS.StackSummaries,
+                nextToken: undefined,
+            });
         });
 
         it('should throw CloudFormationServiceException when API call fails', async () => {
@@ -332,7 +335,7 @@ describe('CfnService', () => {
                 {
                     StackName: TEST_CONSTANTS.STACK_NAME,
                 },
-                'test-token',
+                { nextToken: 'test-token' },
             );
 
             expect(result).toEqual(MOCK_RESPONSES.DESCRIBE_STACK_EVENTS);
@@ -363,35 +366,20 @@ describe('CfnService', () => {
                 ],
                 NextToken: 'token1',
             };
-            const page2 = {
-                ...MOCK_RESPONSES.DESCRIBE_STACK_EVENTS,
-                StackEvents: [
-                    {
-                        StackId: TEST_CONSTANTS.STACK_ID,
-                        EventId: 'event-3',
-                        StackName: TEST_CONSTANTS.STACK_NAME,
-                        LogicalResourceId: 'Resource3',
-                        ResourceStatus: 'CREATE_COMPLETE' as const,
-                        Timestamp: new Date('2023-01-01T00:02:00Z'),
-                        ClientRequestToken: 'test-token',
-                    },
-                ],
-                NextToken: undefined,
-            };
 
-            cloudFormationMock.on(DescribeStackEventsCommand).resolvesOnce(page1).resolvesOnce(page2);
+            cloudFormationMock.on(DescribeStackEventsCommand).resolvesOnce(page1);
 
             const result = await service.describeStackEvents(
                 {
                     StackName: TEST_CONSTANTS.STACK_NAME,
                 },
-                'test-token',
+                { nextToken: undefined },
             );
 
-            expect(result.StackEvents).toHaveLength(3);
+            expect(result.StackEvents).toHaveLength(2);
             expect(result.StackEvents?.[0].EventId).toBe('event-1');
-            expect(result.StackEvents?.[2].EventId).toBe('event-3');
-            expect(result.NextToken).toBeUndefined();
+            expect(result.StackEvents?.[1].EventId).toBe('event-2');
+            expect(result.NextToken).toBe('token1');
         });
 
         it('should stop pagination when clientToken no longer matches', async () => {
@@ -419,74 +407,21 @@ describe('CfnService', () => {
                 ],
                 NextToken: 'token1',
             };
-            const page2 = {
-                ...MOCK_RESPONSES.DESCRIBE_STACK_EVENTS,
-                StackEvents: [
-                    {
-                        StackId: TEST_CONSTANTS.STACK_ID,
-                        EventId: 'event-3',
-                        StackName: TEST_CONSTANTS.STACK_NAME,
-                        LogicalResourceId: 'Resource3',
-                        ResourceStatus: 'CREATE_COMPLETE' as const,
-                        Timestamp: new Date('2023-01-01T00:02:00Z'),
-                        ClientRequestToken: 'test-token',
-                    },
-                    {
-                        StackId: TEST_CONSTANTS.STACK_ID,
-                        EventId: 'event-4',
-                        StackName: TEST_CONSTANTS.STACK_NAME,
-                        LogicalResourceId: 'Resource4',
-                        ResourceStatus: 'CREATE_COMPLETE' as const,
-                        Timestamp: new Date('2023-01-01T00:03:00Z'),
-                        ClientRequestToken: 'different-token',
-                    },
-                ],
-                NextToken: 'token2',
-            };
-            const page3 = {
-                ...MOCK_RESPONSES.DESCRIBE_STACK_EVENTS,
-                StackEvents: [
-                    {
-                        StackId: TEST_CONSTANTS.STACK_ID,
-                        EventId: 'event-5',
-                        StackName: TEST_CONSTANTS.STACK_NAME,
-                        LogicalResourceId: 'Resource5',
-                        ResourceStatus: 'CREATE_COMPLETE' as const,
-                        Timestamp: new Date('2023-01-01T00:04:00Z'),
-                        ClientRequestToken: 'different-token',
-                    },
-                    {
-                        StackId: TEST_CONSTANTS.STACK_ID,
-                        EventId: 'event-6',
-                        StackName: TEST_CONSTANTS.STACK_NAME,
-                        LogicalResourceId: 'Resource6',
-                        ResourceStatus: 'CREATE_COMPLETE' as const,
-                        Timestamp: new Date('2023-01-01T00:05:00Z'),
-                        ClientRequestToken: 'different-token',
-                    },
-                ],
-                NextToken: undefined,
-            };
 
-            cloudFormationMock
-                .on(DescribeStackEventsCommand)
-                .resolvesOnce(page1)
-                .resolvesOnce(page2)
-                .resolvesOnce(page3);
+            cloudFormationMock.on(DescribeStackEventsCommand).resolvesOnce(page1);
 
             const result = await service.describeStackEvents(
                 {
                     StackName: TEST_CONSTANTS.STACK_NAME,
                 },
-                'test-token',
+                { nextToken: undefined },
             );
 
-            expect(result.StackEvents).toHaveLength(3); // Only events with matching token (event-1, event-2, event-3)
+            expect(result.StackEvents).toHaveLength(2);
             expect(result.StackEvents?.[0].EventId).toBe('event-1');
             expect(result.StackEvents?.[1].EventId).toBe('event-2');
-            expect(result.StackEvents?.[2].EventId).toBe('event-3');
-            expect(result.NextToken).toBeUndefined();
-            expect(cloudFormationMock.commandCalls(DescribeStackEventsCommand)).toHaveLength(3); // Should have made 3 calls
+            expect(result.NextToken).toBe('token1');
+            expect(cloudFormationMock.commandCalls(DescribeStackEventsCommand)).toHaveLength(1);
         });
 
         it('should throw StackNotFoundException when API call fails', async () => {
@@ -498,7 +433,7 @@ describe('CfnService', () => {
                     {
                         StackName: TEST_CONSTANTS.STACK_NAME,
                     },
-                    'test-token',
+                    { nextToken: 'test-token' },
                 ),
             ).rejects.toThrow(error);
         });

--- a/tst/unit/stackActions/DeploymentWorkflow.test.ts
+++ b/tst/unit/stackActions/DeploymentWorkflow.test.ts
@@ -239,22 +239,29 @@ describe('DeploymentWorkflow', () => {
 
             mockCfnService.executeChangeSet = vi.fn().mockResolvedValue({});
 
-            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({
-                StackEvents: [
-                    {
-                        LogicalResourceId: 'MyBucket',
-                        ResourceType: 'AWS::S3::Bucket',
-                        Timestamp: new Date('2023-01-01T10:00:00Z'),
-                        ResourceStatus: 'CREATE_COMPLETE',
-                        ResourceStatusReason: 'Resource creation completed successfully',
-                    },
-                    {
-                        LogicalResourceId: 'MyRole',
-                        ResourceType: 'AWS::IAM::Role',
-                        Timestamp: new Date('2023-01-01T10:01:00Z'),
-                        ResourceStatus: 'CREATE_COMPLETE',
-                    },
-                ],
+            mockCfnService.describeStackEvents = vi.fn().mockImplementation((_params, options) => {
+                if (options?.nextToken) {
+                    return Promise.resolve({ StackEvents: [] });
+                }
+                return Promise.resolve({
+                    StackEvents: [
+                        {
+                            LogicalResourceId: 'MyBucket',
+                            ResourceType: 'AWS::S3::Bucket',
+                            Timestamp: new Date('2023-01-01T10:00:00Z'),
+                            ResourceStatus: 'CREATE_COMPLETE',
+                            ResourceStatusReason: 'Resource creation completed successfully',
+                            ClientRequestToken: 'test-workflow-id',
+                        },
+                        {
+                            LogicalResourceId: 'MyRole',
+                            ResourceType: 'AWS::IAM::Role',
+                            Timestamp: new Date('2023-01-01T10:01:00Z'),
+                            ResourceStatus: 'CREATE_COMPLETE',
+                            ClientRequestToken: 'test-workflow-id',
+                        },
+                    ],
+                });
             });
 
             (processChangeSet as any).mockResolvedValue('test-changeset');

--- a/tst/unit/stackActions/DeploymentWorkflowv2.test.ts
+++ b/tst/unit/stackActions/DeploymentWorkflowv2.test.ts
@@ -76,22 +76,29 @@ describe('DeploymentWorkflow', () => {
 
             mockCfnServiceV2.executeChangeSet = vi.fn().mockResolvedValue({});
 
-            mockCfnServiceV2.describeStackEvents = vi.fn().mockResolvedValue({
-                StackEvents: [
-                    {
-                        LogicalResourceId: 'MyBucket',
-                        ResourceType: 'AWS::S3::Bucket',
-                        Timestamp: new Date('2023-01-01T10:00:00Z'),
-                        ResourceStatus: 'CREATE_COMPLETE',
-                        ResourceStatusReason: 'Resource creation completed successfully',
-                    },
-                    {
-                        LogicalResourceId: 'MyRole',
-                        ResourceType: 'AWS::IAM::Role',
-                        Timestamp: new Date('2023-01-01T10:01:00Z'),
-                        ResourceStatus: 'CREATE_COMPLETE',
-                    },
-                ],
+            mockCfnServiceV2.describeStackEvents = vi.fn().mockImplementation((_params, options) => {
+                if (options?.nextToken) {
+                    return Promise.resolve({ StackEvents: [] });
+                }
+                return Promise.resolve({
+                    StackEvents: [
+                        {
+                            LogicalResourceId: 'MyBucket',
+                            ResourceType: 'AWS::S3::Bucket',
+                            Timestamp: new Date('2023-01-01T10:00:00Z'),
+                            ResourceStatus: 'CREATE_COMPLETE',
+                            ResourceStatusReason: 'Resource creation completed successfully',
+                            ClientRequestToken: 'test-workflow-id',
+                        },
+                        {
+                            LogicalResourceId: 'MyRole',
+                            ResourceType: 'AWS::IAM::Role',
+                            Timestamp: new Date('2023-01-01T10:01:00Z'),
+                            ResourceStatus: 'CREATE_COMPLETE',
+                            ClientRequestToken: 'test-workflow-id',
+                        },
+                    ],
+                });
             });
 
             (processChangeSet as any).mockResolvedValue('test-changeset');

--- a/tst/unit/stacks/StackManager.test.ts
+++ b/tst/unit/stacks/StackManager.test.ts
@@ -1,0 +1,137 @@
+import { StackStatus, StackSummary } from '@aws-sdk/client-cloudformation';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CfnService } from '../../../src/services/CfnService';
+import { StackManager } from '../../../src/stacks/StackManager';
+
+describe('StackManager', () => {
+    let stackManager: StackManager;
+    let mockCfnService: CfnService;
+
+    const createStackSummary = (id: string, name: string): StackSummary => ({
+        StackId: id,
+        StackName: name,
+        StackStatus: StackStatus.CREATE_COMPLETE,
+        CreationTime: new Date(),
+    });
+
+    beforeEach(() => {
+        mockCfnService = {
+            listStacks: vi.fn(),
+        } as any;
+        stackManager = new StackManager(mockCfnService);
+        vi.clearAllMocks();
+    });
+
+    describe('listStacks', () => {
+        it('should fetch and cache stacks on initial load', async () => {
+            const stacks = [createStackSummary('stack-1', 'Stack1'), createStackSummary('stack-2', 'Stack2')];
+            mockCfnService.listStacks = vi.fn().mockResolvedValue({ stacks, nextToken: 'token-1' });
+
+            const result = await stackManager.listStacks();
+
+            expect(mockCfnService.listStacks).toHaveBeenCalledWith(undefined, undefined, undefined);
+            expect(result.stacks).toHaveLength(2);
+            expect(result.nextToken).toBe('token-1');
+        });
+
+        it('should append stacks when loadMore is true', async () => {
+            const firstPage = [createStackSummary('stack-1', 'Stack1')];
+            const secondPage = [createStackSummary('stack-2', 'Stack2')];
+
+            mockCfnService.listStacks = vi
+                .fn()
+                .mockResolvedValueOnce({ stacks: firstPage, nextToken: 'token-1' })
+                .mockResolvedValueOnce({ stacks: secondPage, nextToken: undefined });
+
+            const firstResult = await stackManager.listStacks();
+            expect(firstResult.stacks).toHaveLength(1);
+            expect(firstResult.nextToken).toBe('token-1');
+
+            const secondResult = await stackManager.listStacks(undefined, undefined, true);
+            expect(secondResult.stacks).toHaveLength(2);
+            expect(secondResult.nextToken).toBeUndefined();
+            expect(mockCfnService.listStacks).toHaveBeenCalledWith(undefined, undefined, 'token-1');
+        });
+
+        it('should clear cache when filters change', async () => {
+            const firstStacks = [createStackSummary('stack-1', 'Stack1')];
+            const secondStacks = [createStackSummary('stack-2', 'Stack2')];
+
+            mockCfnService.listStacks = vi
+                .fn()
+                .mockResolvedValueOnce({ stacks: firstStacks, nextToken: undefined })
+                .mockResolvedValueOnce({ stacks: secondStacks, nextToken: undefined });
+
+            await stackManager.listStacks([StackStatus.CREATE_COMPLETE]);
+            const result = await stackManager.listStacks([StackStatus.UPDATE_COMPLETE], undefined, true);
+
+            expect(result.stacks).toHaveLength(1);
+            expect(result.stacks[0].StackId).toBe('stack-2');
+        });
+
+        it('should pass statusToInclude filter to CfnService', async () => {
+            mockCfnService.listStacks = vi.fn().mockResolvedValue({ stacks: [], nextToken: undefined });
+
+            await stackManager.listStacks([StackStatus.CREATE_COMPLETE, StackStatus.UPDATE_COMPLETE]);
+
+            expect(mockCfnService.listStacks).toHaveBeenCalledWith(
+                [StackStatus.CREATE_COMPLETE, StackStatus.UPDATE_COMPLETE],
+                undefined,
+                undefined,
+            );
+        });
+
+        it('should pass statusToExclude filter to CfnService', async () => {
+            mockCfnService.listStacks = vi.fn().mockResolvedValue({ stacks: [], nextToken: undefined });
+
+            await stackManager.listStacks(undefined, [StackStatus.DELETE_COMPLETE]);
+
+            expect(mockCfnService.listStacks).toHaveBeenCalledWith(undefined, [StackStatus.DELETE_COMPLETE], undefined);
+        });
+
+        it('should handle stacks without StackId', async () => {
+            const stacks = [
+                createStackSummary('stack-1', 'Stack1'),
+                { StackName: 'Stack2', StackStatus: StackStatus.CREATE_COMPLETE } as StackSummary,
+            ];
+            mockCfnService.listStacks = vi.fn().mockResolvedValue({ stacks, nextToken: undefined });
+
+            const result = await stackManager.listStacks();
+
+            expect(result.stacks).toHaveLength(1);
+            expect(result.stacks[0].StackId).toBe('stack-1');
+        });
+
+        it('should deduplicate stacks by StackId when loading more', async () => {
+            const stack1 = createStackSummary('stack-1', 'Stack1');
+            const stack1Updated = { ...stack1, StackStatus: StackStatus.UPDATE_COMPLETE };
+
+            mockCfnService.listStacks = vi
+                .fn()
+                .mockResolvedValueOnce({ stacks: [stack1], nextToken: 'token-1' })
+                .mockResolvedValueOnce({ stacks: [stack1Updated], nextToken: undefined });
+
+            await stackManager.listStacks();
+            const result = await stackManager.listStacks(undefined, undefined, true);
+
+            expect(result.stacks).toHaveLength(1);
+            expect(result.stacks[0].StackStatus).toBe(StackStatus.UPDATE_COMPLETE);
+        });
+    });
+
+    describe('clearCache', () => {
+        it('should clear cache and nextToken', async () => {
+            const stacks = [createStackSummary('stack-1', 'Stack1')];
+            mockCfnService.listStacks = vi.fn().mockResolvedValue({ stacks, nextToken: 'token-1' });
+
+            await stackManager.listStacks();
+            stackManager.clearCache();
+
+            mockCfnService.listStacks = vi.fn().mockResolvedValue({ stacks: [], nextToken: undefined });
+            const result = await stackManager.listStacks(undefined, undefined, true);
+
+            expect(result.stacks).toHaveLength(0);
+            expect(mockCfnService.listStacks).toHaveBeenCalledWith(undefined, undefined, undefined);
+        });
+    });
+});

--- a/tst/utils/MockServerComponents.ts
+++ b/tst/utils/MockServerComponents.ts
@@ -55,6 +55,7 @@ import { DefaultSettings, Settings } from '../../src/settings/Settings';
 import { SettingsManager } from '../../src/settings/SettingsManager';
 import { DeploymentWorkflow } from '../../src/stacks/actions/DeploymentWorkflow';
 import { ValidationWorkflow } from '../../src/stacks/actions/ValidationWorkflow';
+import { StackManager } from '../../src/stacks/StackManager';
 import { ClientMessage } from '../../src/telemetry/ClientMessage';
 import { Closeable } from '../../src/utils/Closeable';
 import { Configurables } from '../../src/utils/Configurable';
@@ -362,6 +363,7 @@ export function createMockComponents(o: Partial<CfnLspServerComponentsType> = {}
     const providers: MockLspProviders = {
         stackManagementInfoProvider:
             overrides.stackManagementInfoProvider ?? stubInterface<StackManagementInfoProvider>(),
+        stackManager: overrides.stackManager ?? stubInterface<StackManager>(),
         validationWorkflowService: overrides.validationWorkflowService ?? createMockValidationWorkflowService(),
         deploymentWorkflowService: overrides.deploymentWorkflowService ?? createMockDeploymentWorkflowService(),
         resourceStateManager: overrides.resourceStateManager ?? createMockResourceStateManager(),


### PR DESCRIPTION
# Server-Side Pagination for CloudFormation LSP

## Summary
Implements server-side pagination for stacks and resources, improving performance when working with large AWS accounts.

## Key Changes

### New: StackManager
- Manages stack caching with `Map<stackId, StackSummary>`
- Server tracks `nextToken`; client sends `loadMore` boolean
- Clears cache when filters change

### Enhanced: ResourceStateManager
- New `searchResourceByIdentifier()` method for finding specific resources and adding to cache
- Appends pages to cache while maintaining pagination state

### Refactored: CfnService
- Changed list stacks from do-while fetch all behavior to retrieving first page only
- Moved stack events pagination to DeploymentWorkflow

### Protocol Updates
- `ListStacksParams`: Uses `loadMore` boolean instead of `nextToken`
- `SearchResourceRequest`: New protocol for resource search

## Files Changed
**New:** `StackManager.ts`, `StackManager.test.ts`  
**Modified:** `CfnService.ts`, `ResourceStateManager.ts`, `ResourceStateTypes.ts`, `StackHandler.ts`, `ResourceHandler.ts`, `CfnLspProviders.ts`, `CfnServer.ts`, `DeploymentWorkflow.ts`

## Notes
- AWS CloudControl `MaxResults` is non-functional (marked "Reserved")
- CloudFormation `ListStacks` has no default page size

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
