### PR TITLE
Fix percentiles for histograms, configure traces for alpha env

### DIFF
--- a/src/datastore/LMDB.ts
+++ b/src/datastore/LMDB.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 import { open, Database, RootDatabase } from 'lmdb';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
-import { Telemetry } from '../telemetry/TelemetryDecorator';
+import { Measure, Telemetry } from '../telemetry/TelemetryDecorator';
 import { pathToArtifact } from '../utils/ArtifactsDir';
 import { extractErrorMessage } from '../utils/Errors';
 import { DataStore, DataStoreFactory } from './DataStore';
@@ -18,6 +18,7 @@ export class LMDBStore implements DataStore {
         return this.store.get(key) as T | undefined;
     }
 
+    @Measure({ name: 'put' })
     put<T>(key: string, value: T): Promise<boolean> {
         return this.store.put(key, value);
     }


### PR DESCRIPTION
### Key Changes:

1. Telemetry Improvements (OTELInstrumentation.ts)
• Switched histogram aggregation from EXPLICIT_BUCKET_HISTOGRAM to EXPONENTIAL_HISTOGRAM for both duration and latency metrics
• Removed hardcoded histogram boundaries array (previously had 24 fixed buckets)
• This change fixes percentile calculations by using exponential histograms which provide better accuracy for percentile queries
• Added conditional trace exporter for alpha environment only (excludes test env)
• Imported OTLPTraceExporter to enable distributed tracing capabilities

2. Feature Flag Provider Enhancements (FeatureFlagProvider.ts)
• Moved getFromOnline() from standalone function to private class method
• Added @Measure decorator to track performance of feature flag fetching
• Improved error handling in the refresh interval with better error messages using extractErrorMessage()
• Added import for extractErrorMessage utility

3. LMDB Datastore Instrumentation (LMDB.ts)
• Added @Measure decorator to the put() method to track database write performance
• Imported Measure decorator from telemetry