### PR TITLE
Support more document types, and don't throw if extension is unknown

### DIFF
--- a/src/document/Document.ts
+++ b/src/document/Document.ts
@@ -8,7 +8,7 @@ import { detectDocumentType, uriToPath } from './DocumentUtils';
 
 export class Document {
     private readonly log = LoggerFactory.getLogger(Document);
-    public readonly extension: Extension;
+    public readonly extension: string;
     public readonly documentType: DocumentType;
     public readonly cfnFileType: CloudFormationFileType;
     public readonly fileName: string;
@@ -131,17 +131,6 @@ export enum DocumentType {
     YAML = 'YAML',
     JSON = 'JSON',
 }
-
-export enum Extension {
-    YAML = 'yaml',
-    JSON = 'json',
-    YML = 'yml',
-    TXT = 'txt',
-    CFN = 'cfn',
-    TEMPLATE = 'template',
-}
-
-export const Extensions = Object.values(Extension);
 
 export enum CloudFormationFileType {
     Template = 'template',

--- a/src/document/DocumentProtocol.ts
+++ b/src/document/DocumentProtocol.ts
@@ -1,10 +1,10 @@
 import { MessageDirection, ProtocolNotificationType } from 'vscode-languageserver';
-import { CloudFormationFileType, DocumentType, Extension } from './Document';
+import { CloudFormationFileType, DocumentType } from './Document';
 
 export type DocumentMetadata = {
     uri: string;
     fileName: string;
-    ext: Extension;
+    ext: string;
     type: DocumentType;
     cfnType: CloudFormationFileType;
     languageId: string;

--- a/src/document/DocumentUtils.ts
+++ b/src/document/DocumentUtils.ts
@@ -1,6 +1,6 @@
 import { extname, parse } from 'path';
 import { Edit, Point } from 'tree-sitter';
-import { DocumentType, Extension, Extensions } from './Document';
+import { DocumentType } from './Document';
 
 export function getIndexFromPoint(content: string, point: Point): number {
     const contentInLines = content.split('\n');
@@ -56,21 +56,25 @@ export function createEdit(
     };
 }
 
-export function detectDocumentType(uri: string, content: string): { extension: Extension; type: DocumentType } {
-    let ext = extname(uri).toLowerCase();
-    if (ext.startsWith('.')) {
-        ext = ext.slice(1);
-    }
+enum Extension {
+    YAML = 'yaml',
+    JSON = 'json',
+    YML = 'yml',
+    TXT = 'txt',
+    CFN = 'cfn',
+    TEMPLATE = 'template',
+}
 
-    const extension = Extensions.find((type) => type.toString().toLowerCase() === ext);
-    if (!extension) {
-        throw new Error(`Extension ${ext} is not supported`);
+export function detectDocumentType(uri: string, content: string): { extension: string; type: DocumentType } {
+    let extension = extname(uri).toLowerCase();
+    if (extension.startsWith('.')) {
+        extension = extension.slice(1);
     }
 
     let type: DocumentType;
-    if (extension === Extension.JSON) {
+    if (extension === Extension.JSON.toLowerCase()) {
         type = DocumentType.JSON;
-    } else if (extension === Extension.YAML || extension === Extension.YML) {
+    } else if (extension === Extension.YAML.toLowerCase() || extension === Extension.YML.toLowerCase()) {
         type = DocumentType.YAML;
     } else if (content.startsWith('{') || content.startsWith('[')) {
         type = DocumentType.JSON;

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -1,6 +1,6 @@
 import { readFileSync, statSync } from 'fs';
 import { detectDocumentType, uriToPath } from '../src/document/DocumentUtils';
-import { CloudFormationFileType, DocumentType, Extension } from '../src/document/Document';
+import { CloudFormationFileType, DocumentType } from '../src/document/Document';
 import { detectCfnFileType } from '../src/document/CloudFormationDetection';
 
 export type TestPosition = {
@@ -162,7 +162,7 @@ export function generatePositions(content: string, iterations: number): TestPosi
 export type TemplateFile = {
     name: string;
     path: string;
-    extension: Extension;
+    extension: string;
     documentType: DocumentType;
     cfnFileType: CloudFormationFileType;
     content: string;

--- a/tst/unit/document/Document.test.ts
+++ b/tst/unit/document/Document.test.ts
@@ -34,14 +34,6 @@ describe('Document', () => {
 
             expect(doc.documentType).toBe(DocumentType.JSON);
         });
-
-        it('should throw error for unsupported extension', () => {
-            const textDocument = TextDocument.create('file:///test.xyz', 'xyz', 1, 'content');
-
-            expect(() => {
-                new Document(textDocument);
-            }).toThrow('Extension xyz is not supported');
-        });
     });
 
     describe('content', () => {

--- a/tst/unit/document/DocumentUtils.test.ts
+++ b/tst/unit/document/DocumentUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { DocumentType, Extension } from '../../../src/document/Document';
+import { DocumentType } from '../../../src/document/Document';
 import {
     getIndexFromPoint,
     getNewEndPosition,
@@ -129,14 +129,14 @@ describe('DocumentUtils', () => {
         it('should determine JSON type from .json extension', () => {
             const result = detectDocumentType('file:///test.json', '{}');
 
-            expect(result.extension).toBe(Extension.JSON);
+            expect(result.extension).toBe('json');
             expect(result.type).toBe(DocumentType.JSON);
         });
 
         it('should determine YAML type from .yaml extension', () => {
             const result = detectDocumentType('file:///test.yaml', 'key: value');
 
-            expect(result.extension).toBe(Extension.YAML);
+            expect(result.extension).toBe('yaml');
             expect(result.type).toBe(DocumentType.YAML);
         });
 
@@ -151,14 +151,8 @@ describe('DocumentUtils', () => {
         it('should handle case-insensitive extensions', () => {
             const result = detectDocumentType('file:///test.JSON', '{}');
 
-            expect(result.extension).toBe(Extension.JSON);
+            expect(result.extension).toBe('json');
             expect(result.type).toBe(DocumentType.JSON);
-        });
-
-        it('should throw error for unsupported extension', () => {
-            expect(() => {
-                detectDocumentType('file:///test.xyz', 'content');
-            }).toThrow('Extension xyz is not supported');
         });
 
         it('should detect JSON from array content', () => {


### PR DESCRIPTION
* Support all document extensions that the IDE decides to send to the LSP
* LSP features will only trigger if file is a template
* Don't throw an exception if extension is not supported