### PR TITLE
improved duplicate code with parameter extraction

### DIFF
--- a/src/services/extractToParameter/LiteralValueDetector.ts
+++ b/src/services/extractToParameter/LiteralValueDetector.ts
@@ -85,30 +85,14 @@ export class LiteralValueDetector {
     }
 
     private isJsonIntrinsicFunction(node: SyntaxNode): boolean {
-        if (!node?.children) {
-            return false;
-        }
-
-        const pairs = node.children.filter((child) => child.type === 'pair');
-        if (pairs.length !== 1) {
-            return false;
-        }
-
-        const pair = pairs[0];
-        if (!pair?.children || pair.children.length < 2) {
-            return false;
-        }
-
-        const keyNode = pair.children[0];
-        if (keyNode?.type !== 'string' || !keyNode.text) {
-            return false;
-        }
-
-        const keyText = this.removeQuotes(keyNode.text);
-        return this.isIntrinsicFunctionName(keyText);
+        return this.isJsonFunctionOfType(node, this.isIntrinsicFunctionName.bind(this));
     }
 
     private isJsonReferenceFunction(node: SyntaxNode): boolean {
+        return this.isJsonFunctionOfType(node, this.isReferenceFunctionName.bind(this));
+    }
+
+    private isJsonFunctionOfType(node: SyntaxNode, validationFn: (name: string) => boolean): boolean {
         if (!node?.children) {
             return false;
         }
@@ -129,7 +113,7 @@ export class LiteralValueDetector {
         }
 
         const keyText = this.removeQuotes(keyNode.text);
-        return this.isReferenceFunctionName(keyText);
+        return validationFn(keyText);
     }
 
     private isYamlIntrinsicTag(tagText: string): boolean {

--- a/src/services/extractToParameter/WorkspaceEditBuilder.ts
+++ b/src/services/extractToParameter/WorkspaceEditBuilder.ts
@@ -129,13 +129,7 @@ export class WorkspaceEditBuilder {
         pos1: { line: number; character: number },
         pos2: { line: number; character: number },
     ): boolean {
-        if (pos1.line < pos2.line) {
-            return true;
-        }
-        if (pos1.line > pos2.line) {
-            return false;
-        }
-        return pos1.character < pos2.character;
+        return this.comparePositions(pos1, pos2, false);
     }
 
     /**
@@ -146,13 +140,21 @@ export class WorkspaceEditBuilder {
         pos1: { line: number; character: number },
         pos2: { line: number; character: number },
     ): boolean {
+        return this.comparePositions(pos1, pos2, true);
+    }
+
+    private comparePositions(
+        pos1: { line: number; character: number },
+        pos2: { line: number; character: number },
+        allowEqual: boolean,
+    ): boolean {
         if (pos1.line < pos2.line) {
             return true;
         }
         if (pos1.line > pos2.line) {
             return false;
         }
-        return pos1.character <= pos2.character;
+        return allowEqual ? pos1.character <= pos2.character : pos1.character < pos2.character;
     }
 
     /**


### PR DESCRIPTION
- removed code duplication found from ```npm run check:duplicates``` in ExtractToParameterProvider, LiteralValueDetector, and WorkspaceEditBuilder

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
