### PR TITLE
Add more metrics for datastores and exception metrics

### DIFF
--- a/src/utils/ArtifactsDir.ts
+++ b/src/utils/ArtifactsDir.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from 'fs';
 import { resolve, join } from 'path';
 
-const RELATIVE_ROOT_DIR = './.aws-cfn-storage';
+const RELATIVE_ROOT_DIR = '.aws-cfn-storage';
 
 /**
  * This will create artifacts in the directory where the app is executing
@@ -10,7 +10,12 @@ const RELATIVE_ROOT_DIR = './.aws-cfn-storage';
  */
 function getOrCreateAbsolutePath(artifactDir: string | undefined = undefined): string {
     const dir = resolve(__dirname);
-    const path = join(dir, RELATIVE_ROOT_DIR, artifactDir ?? '.');
+    let path: string;
+    if (artifactDir) {
+        path = join(dir, RELATIVE_ROOT_DIR, artifactDir);
+    } else {
+        path = join(dir, RELATIVE_ROOT_DIR);
+    }
 
     if (existsSync(path)) {
         return path;

--- a/src/utils/Errors.ts
+++ b/src/utils/Errors.ts
@@ -8,3 +8,31 @@ export function extractErrorMessage(error: unknown) {
 
     return toString(error);
 }
+
+/**
+ * Best effort extraction of location of exception based on stack trace
+ */
+export function extractLocationFromStack(stack?: string): {
+    'error.file'?: string;
+    'error.line'?: number;
+    'error.column'?: number;
+} {
+    if (!stack) return {};
+
+    // Match first line with file location: at ... (/path/to/file.ts:line:column)
+    const match = stack.match(/at .+\((.+):(\d+):(\d+)\)|at (.+):(\d+):(\d+)/);
+    if (!match) return {};
+
+    const fullPath = match[1] || match[4];
+    const line = parseInt(match[2] || match[5], 10); // eslint-disable-line unicorn/prefer-number-properties
+    const column = parseInt(match[3] || match[6], 10); // eslint-disable-line unicorn/prefer-number-properties
+
+    // Extract only filename without path
+    const filename = fullPath?.split('/').pop()?.split('\\').pop();
+
+    return {
+        'error.file': filename,
+        'error.line': line,
+        'error.column': column,
+    };
+}

--- a/tst/unit/schema/GetSchemaTask.test.ts
+++ b/tst/unit/schema/GetSchemaTask.test.ts
@@ -21,7 +21,7 @@ describe('GetSchemaTask', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        mockDataStore = new MemoryStore();
+        mockDataStore = new MemoryStore('TestStore');
         mockLogger = stubInterface<Logger>();
 
         // Setup Sinon stubs


### PR DESCRIPTION
PR #130: Add more metrics for datastores and exception metrics

This pull request enhances the CloudFormation Language Server's telemetry capabilities by adding comprehensive metrics tracking for datastores and improved
exception handling. Here are the key features:

Datastore Metrics:
• Added telemetry tracking to both LMDB and MemoryStore implementations
• Each datastore instance now has scoped telemetry (LMDB.{name} and MemoryStore.{name})
• Added performance measurement for put operations using measureAsync
• MemoryStore now tracks gauge metrics for store count and total entries

Exception Metrics Enhancement:
• Improved error handling with detailed location extraction from stack traces
• Added structured metrics for unhandled promise rejections and uncaught exceptions
• Enhanced error metadata including error type, origin, file location, line, and column numbers
• Added automatic metrics flushing when exceptions occur

Technical Improvements:
• Refactored telemetry decorators to use direct TelemetryService calls for better control
• Fixed artifacts directory path handling (removed leading ./)
• Added utility function extractLocationFromStack for parsing error locations from stack traces
• Updated constructor signatures to support named datastore instances