### PR TITLE
Add method to track response in a nested object

### DIFF
--- a/src/autocomplete/CompletionRouter.ts
+++ b/src/autocomplete/CompletionRouter.ts
@@ -46,7 +46,7 @@ export class CompletionRouter implements SettingsConfigurable, Closeable {
         private readonly entityFieldCompletionProviderMap = createEntityFieldProviders(),
     ) {}
 
-    @Track({ name: 'getCompletions' })
+    @Track({ name: 'getCompletions', trackObjectKey: 'items' })
     async getCompletions(params: CompletionParams) {
         if (!this.completionSettings.enabled) return;
 

--- a/src/telemetry/TelemetryService.ts
+++ b/src/telemetry/TelemetryService.ts
@@ -160,15 +160,12 @@ export class TelemetryService implements Closeable {
             this.logger.error(reason, 'Unhandled promise rejection');
 
             const location = reason instanceof Error ? extractLocationFromStack(reason.stack) : {};
-            telemetry.count(
-                'process.promise.unhandled',
-                1,
-                { unit: '1' },
-                {
+            telemetry.count('process.promise.unhandled', 1, {
+                attributes: {
                     'error.type': reason instanceof Error ? reason.name : typeof reason,
                     ...location,
                 },
-            );
+            });
 
             void this.metricsReader?.forceFlush();
         });
@@ -176,16 +173,13 @@ export class TelemetryService implements Closeable {
         process.on('uncaughtException', (error, origin) => {
             this.logger.error(error, `Uncaught exception ${origin}`);
 
-            telemetry.count(
-                'process.exception.uncaught',
-                1,
-                { unit: '1' },
-                {
+            telemetry.count('process.exception.uncaught', 1, {
+                attributes: {
                     'error.type': error.name,
                     'error.origin': origin,
                     ...extractLocationFromStack(error.stack),
                 },
-            );
+            });
 
             void this.metricsReader?.forceFlush();
         });

--- a/src/utils/TypeCheck.ts
+++ b/src/utils/TypeCheck.ts
@@ -22,27 +22,25 @@ export function typeOf(value: unknown): {
         type = 'undefined';
     } else if (value === null) {
         type = 'null';
-    } else if (typeof value === 'boolean') {
-        type = 'boolean';
-    } else if (typeof value === 'string') {
-        type = 'string';
-    } else if (typeof value === 'bigint') {
-        type = 'bigint';
-    } else if (typeof value === 'number') {
-        type = 'number';
-    } else if (typeof value === 'symbol') {
-        type = 'symbol';
-    } else if (typeof value === 'function') {
-        type = 'function';
-    }
-
-    if (type === undefined && typeof value === 'object') {
+    } else if (typeof value === 'object') {
         if (Array.isArray(value)) {
             type = 'array';
             size = value.length;
         } else {
             type = 'object';
         }
+    } else if (typeof value === 'string') {
+        type = 'string';
+    } else if (typeof value === 'number') {
+        type = 'number';
+    } else if (typeof value === 'boolean') {
+        type = 'boolean';
+    } else if (typeof value === 'bigint') {
+        type = 'bigint';
+    } else if (typeof value === 'symbol') {
+        type = 'symbol';
+    } else if (typeof value === 'function') {
+        type = 'function';
     }
 
     type ??= 'unknown';

--- a/tst/unit/telemetry/ScopedTelemetry.test.ts
+++ b/tst/unit/telemetry/ScopedTelemetry.test.ts
@@ -20,7 +20,7 @@ describe('ScopedTelemetry', () => {
         it('should increment counter', () => {
             scopedTelemetry.count('test', 5);
 
-            expect(mockMeter.createCounter).toHaveBeenCalledWith('test', undefined);
+            expect(mockMeter.createCounter).toHaveBeenCalledWith('test', { unit: '1', valueType: 0 });
         });
     });
 
@@ -42,7 +42,7 @@ describe('ScopedTelemetry', () => {
         it('should record histogram value', () => {
             scopedTelemetry.histogram('test', 100);
 
-            expect(mockMeter.createHistogram).toHaveBeenCalledWith('test', undefined);
+            expect(mockMeter.createHistogram).toHaveBeenCalledWith('test', { unit: '1', valueType: 0 });
         });
     });
 
@@ -125,6 +125,23 @@ describe('ScopedTelemetry', () => {
 
             expect(mockMeter.createCounter).toHaveBeenCalledWith('test.response.type.array', expect.any(Object));
             expect(mockMeter.createHistogram).toHaveBeenCalledWith('test.response.type.size', expect.any(Object));
+        });
+
+        it('should track object property when trackObjectKey is specified', () => {
+            const fn = vi.fn(() => ({ items: [1, 2, 3], other: 'data' }));
+
+            scopedTelemetry.trackExecution('test', fn, { trackObjectKey: 'items' });
+
+            expect(mockMeter.createCounter).toHaveBeenCalledWith('test.response.type.array', expect.any(Object));
+            expect(mockMeter.createHistogram).toHaveBeenCalledWith('test.response.type.size', expect.any(Object));
+        });
+
+        it('should track whole object when trackObjectKey not found', () => {
+            const fn = vi.fn(() => ({ data: 'value' }));
+
+            scopedTelemetry.trackExecution('test', fn, { trackObjectKey: 'missing' });
+
+            expect(mockMeter.createCounter).toHaveBeenCalledWith('test.response.type.undefined', expect.any(Object));
         });
     });
 

--- a/tst/unit/telemetry/TelemetryDecorator.test.ts
+++ b/tst/unit/telemetry/TelemetryDecorator.test.ts
@@ -58,12 +58,9 @@ describe('TelemetryDecorator', () => {
             const result = instance.syncMethod();
 
             expect(result).toBe('result');
-            expect(mockTelemetry.trackExecution).toHaveBeenCalledWith(
-                'syncMethod',
-                expect.any(Function),
-                undefined,
-                {},
-            );
+            expect(mockTelemetry.trackExecution).toHaveBeenCalledWith('syncMethod', expect.any(Function), {
+                name: 'syncMethod',
+            });
             expect(mockTelemetry.trackExecutionAsync).not.toHaveBeenCalled();
         });
 
@@ -80,12 +77,9 @@ describe('TelemetryDecorator', () => {
             const result = await instance.asyncMethod();
 
             expect(result).toBe('result');
-            expect(mockTelemetry.trackExecutionAsync).toHaveBeenCalledWith(
-                'asyncMethod',
-                expect.any(Function),
-                undefined,
-                {},
-            );
+            expect(mockTelemetry.trackExecutionAsync).toHaveBeenCalledWith('asyncMethod', expect.any(Function), {
+                name: 'asyncMethod',
+            });
             expect(mockTelemetry.trackExecution).not.toHaveBeenCalled();
         });
 
@@ -140,15 +134,12 @@ describe('TelemetryDecorator', () => {
 
             new TestClass().method();
 
-            expect(mockTelemetry.trackExecution).toHaveBeenCalledWith(
-                'customName',
-                expect.any(Function),
-                undefined,
-                {},
-            );
+            expect(mockTelemetry.trackExecution).toHaveBeenCalledWith('customName', expect.any(Function), {
+                name: 'customName',
+            });
         });
 
-        it('should pass custom attributes', () => {
+        it('should pass config with attributes', () => {
             class TestClass {
                 @Track({ name: 'method', attributes: { key: 'value' } })
                 method() {}
@@ -156,8 +147,25 @@ describe('TelemetryDecorator', () => {
 
             new TestClass().method();
 
-            expect(mockTelemetry.trackExecution).toHaveBeenCalledWith('method', expect.any(Function), undefined, {
-                key: 'value',
+            expect(mockTelemetry.trackExecution).toHaveBeenCalledWith('method', expect.any(Function), {
+                name: 'method',
+                attributes: { key: 'value' },
+            });
+        });
+
+        it('should pass config with trackObjectKey', () => {
+            class TestClass {
+                @Track({ name: 'method', trackObjectKey: 'items' })
+                method() {
+                    return { items: [1, 2, 3] };
+                }
+            }
+
+            new TestClass().method();
+
+            expect(mockTelemetry.trackExecution).toHaveBeenCalledWith('method', expect.any(Function), {
+                name: 'method',
+                trackObjectKey: 'items',
             });
         });
     });
@@ -175,7 +183,9 @@ describe('TelemetryDecorator', () => {
             const result = instance.syncMethod();
 
             expect(result).toBe('result');
-            expect(mockTelemetry.measure).toHaveBeenCalledWith('syncMethod', expect.any(Function), undefined, {});
+            expect(mockTelemetry.measure).toHaveBeenCalledWith('syncMethod', expect.any(Function), {
+                name: 'syncMethod',
+            });
             expect(mockTelemetry.measureAsync).not.toHaveBeenCalled();
         });
 
@@ -192,7 +202,9 @@ describe('TelemetryDecorator', () => {
             const result = await instance.asyncMethod();
 
             expect(result).toBe('result');
-            expect(mockTelemetry.measureAsync).toHaveBeenCalledWith('asyncMethod', expect.any(Function), undefined, {});
+            expect(mockTelemetry.measureAsync).toHaveBeenCalledWith('asyncMethod', expect.any(Function), {
+                name: 'asyncMethod',
+            });
             expect(mockTelemetry.measure).not.toHaveBeenCalled();
         });
 
@@ -231,20 +243,24 @@ describe('TelemetryDecorator', () => {
 
             new TestClass().method();
 
-            expect(mockTelemetry.measure).toHaveBeenCalledWith('customName', expect.any(Function), undefined, {});
+            expect(mockTelemetry.measure).toHaveBeenCalledWith('customName', expect.any(Function), {
+                name: 'customName',
+            });
         });
 
-        it('should pass metric options', () => {
-            const options = { unit: 'ms' };
-
+        it('should pass metric config', () => {
             class TestClass {
-                @Measure({ name: 'method', options })
+                @Measure({ name: 'method', unit: 'ms', valueType: 1 })
                 method() {}
             }
 
             new TestClass().method();
 
-            expect(mockTelemetry.measure).toHaveBeenCalledWith('method', expect.any(Function), options, {});
+            expect(mockTelemetry.measure).toHaveBeenCalledWith('method', expect.any(Function), {
+                name: 'method',
+                unit: 'ms',
+                valueType: 1,
+            });
         });
     });
 });


### PR DESCRIPTION
* Add method to track response in a nested object - completion tracking was broken
* Small optimization to how types are being detected - moved more likely items higher
* Adding default units 
