### PR TITLE
change resource state import from CodeAction to CompletionItem with t…

### DIFF
--- a/src/resourceState/ResourceStateTypes.ts
+++ b/src/resourceState/ResourceStateTypes.ts
@@ -1,4 +1,4 @@
-import { CodeAction, CodeActionParams } from 'vscode-languageserver';
+import { CompletionItem, TextDocumentIdentifier } from 'vscode-languageserver';
 import { RequestType } from 'vscode-languageserver-protocol';
 import { ResourceStackManagementResult } from './StackManagementInfoProvider';
 
@@ -27,12 +27,14 @@ export enum ResourceStatePurpose {
     CLONE = 'Clone',
 }
 
-export interface ResourceStateParams extends CodeActionParams {
+export interface ResourceStateParams {
+    textDocument: TextDocumentIdentifier;
     resourceSelections?: ResourceSelection[];
     purpose: ResourceStatePurpose;
 }
 
-export interface ResourceStateResult extends CodeAction {
+export interface ResourceStateResult {
+    completionItem?: CompletionItem;
     successfulImports: Record<ResourceType, ResourceIdentifier[]>;
     failedImports: Record<ResourceType, ResourceIdentifier[]>;
     warning?: string;

--- a/src/schema/transformers/AddWriteOnlyRequiredPropertiesTransformer.ts
+++ b/src/schema/transformers/AddWriteOnlyRequiredPropertiesTransformer.ts
@@ -1,18 +1,18 @@
 import type { ResourceSchema } from '../ResourceSchema';
+import { PlaceholderConstants } from './PlaceholderConstants';
 import type { ResourceTemplateTransformer } from './ResourceTemplateTransformer';
 
 /**
- * Transformer that adds tabstop placeholders for required write-only properties.
+ * Transformer that adds placeholder constants for required write-only properties.
  * Only adds placeholders at the required property level, not for nested write-only children.
- * Replaces empty objects with tabstop placeholders using LSP snippet syntax.
- * Uses sequential tabstops (${1}, ${2}, etc.). The $0 final cursor position is handled by the client.
+ * Uses placeholder constants that will be replaced with tab stops later.
  */
 export class AddWriteOnlyRequiredPropertiesTransformer implements ResourceTemplateTransformer {
-    public transform(resourceProperties: Record<string, unknown>, schema: ResourceSchema): void {
+    public transform(resourceProperties: Record<string, unknown>, schema: ResourceSchema, logicalId?: string): void {
         const requiredProps = schema.required ?? [];
         const writeOnlyPaths = schema.writeOnlyProperties ?? [];
 
-        if (requiredProps.length === 0 || writeOnlyPaths.length === 0) {
+        if (requiredProps.length === 0 || writeOnlyPaths.length === 0 || !logicalId) {
             return;
         }
 
@@ -28,10 +28,12 @@ export class AddWriteOnlyRequiredPropertiesTransformer implements ResourceTempla
             }
         }
 
-        let tabstopIndex = 1;
         for (const prop of requiredWriteOnlyProps) {
             if (!(prop in resourceProperties) || this.isEmpty(resourceProperties[prop])) {
-                resourceProperties[prop] = `\${${tabstopIndex++}:update required write only property}`;
+                resourceProperties[prop] = PlaceholderConstants.createPlaceholder(
+                    PlaceholderConstants.WRITE_ONLY_REQUIRED,
+                    logicalId,
+                );
             }
         }
     }

--- a/src/schema/transformers/PlaceholderConstants.ts
+++ b/src/schema/transformers/PlaceholderConstants.ts
@@ -1,0 +1,70 @@
+/**
+ * Constants for placeholder text used during resource transformation.
+ * These will be replaced with actual snippet tab stops at the end of processing.
+ */
+export const PlaceholderConstants = {
+    /** Common prefix for all placeholders */
+    PREFIX: '__PLACEHOLDER__',
+
+    /** Placeholder purposes */
+    WRITE_ONLY_REQUIRED: 'WRITE_ONLY_REQUIRED',
+    CLONE_INPUT_REQUIRED: 'CLONE_INPUT_REQUIRED',
+
+    /** Generate placeholder text with logical ID */
+    createPlaceholder(purpose: string, logicalId: string): string {
+        return `${this.PREFIX}${purpose}__${logicalId}`;
+    },
+
+    /** Check if text contains any placeholder */
+    hasPlaceholders(text: string): boolean {
+        return text.includes(this.PREFIX);
+    },
+} as const;
+
+/**
+ * Utility to replace placeholder constants with snippet tab stops.
+ */
+export const PlaceholderReplacer = {
+    /**
+     * Replace all placeholder constants with sequential snippet tab stops.
+     * @param text The text containing placeholder constants
+     * @returns Text with tab stops (${1:...}, ${2:...}, etc.)
+     */
+    replaceWithTabStops(text: string): string {
+        let tabStopCounter = 1;
+        let result = text;
+
+        // Find all placeholders in the text
+        const placeholderRegex = /__PLACEHOLDER__(\w+)__(\w+)/g;
+        const placeholders: Array<{ match: string; purpose: string; logicalId: string }> = [];
+
+        let match;
+        while ((match = placeholderRegex.exec(text)) !== null) {
+            placeholders.push({
+                match: match[0],
+                purpose: match[1],
+                logicalId: match[2],
+            });
+        }
+
+        // Replace each placeholder sequentially using local counter
+        for (const placeholder of placeholders) {
+            const purposeText =
+                placeholder.purpose === PlaceholderConstants.WRITE_ONLY_REQUIRED
+                    ? 'write only required property'
+                    : 'enter new identifier';
+
+            const tabStopText = `\${${tabStopCounter++}:${purposeText} for ${placeholder.logicalId}}`;
+            result = result.replace(placeholder.match, tabStopText);
+        }
+
+        return result;
+    },
+
+    /**
+     * Check if text contains any placeholder constants.
+     */
+    hasPlaceholders(text: string): boolean {
+        return PlaceholderConstants.hasPlaceholders(text);
+    },
+} as const;

--- a/src/schema/transformers/ReplacePrimaryIdentifierTransformer.ts
+++ b/src/schema/transformers/ReplacePrimaryIdentifierTransformer.ts
@@ -1,20 +1,67 @@
 import { ResourceSchema } from '../ResourceSchema';
+import { PlaceholderConstants } from './PlaceholderConstants';
 import { ResourceTemplateTransformer } from './ResourceTemplateTransformer';
 
 export class ReplacePrimaryIdentifierTransformer implements ResourceTemplateTransformer {
-    private static readonly CLONE_PLACEHOLDER = '<CLONE INPUT REQUIRED>';
-
-    transform(resourceProperties: Record<string, unknown>, schema: ResourceSchema): void {
+    transform(resourceProperties: Record<string, unknown>, schema: ResourceSchema, logicalId?: string): void {
         if (!schema.primaryIdentifier || schema.primaryIdentifier.length === 0) {
             return;
         }
 
         for (const identifierPath of schema.primaryIdentifier) {
-            this.replacePrimaryIdentifierProperty(resourceProperties, identifierPath);
+            if (this.isPrimaryIdentifierRequired(identifierPath, schema)) {
+                if (logicalId) {
+                    this.replacePrimaryIdentifierProperty(resourceProperties, identifierPath, logicalId);
+                }
+            } else {
+                this.removePrimaryIdentifierProperty(resourceProperties, identifierPath);
+            }
         }
     }
 
-    private replacePrimaryIdentifierProperty(properties: Record<string, unknown>, propertyPath: string): void {
+    private isPrimaryIdentifierRequired(identifierPath: string, schema: ResourceSchema): boolean {
+        if (!schema.required || schema.required.length === 0) {
+            return false;
+        }
+
+        const pathParts = identifierPath.split('/').filter((part) => part !== '' && part !== 'properties');
+        if (pathParts.length === 0) {
+            return false;
+        }
+
+        const propertyName = pathParts[pathParts.length - 1];
+        return schema.required.includes(propertyName);
+    }
+
+    private removePrimaryIdentifierProperty(properties: Record<string, unknown>, propertyPath: string): void {
+        const pathParts = propertyPath.split('/').filter((part) => part !== '' && part !== 'properties');
+
+        if (pathParts.length === 0) {
+            return;
+        }
+
+        let current = properties;
+
+        // Navigate to the parent of the target property
+        for (let i = 0; i < pathParts.length - 1; i++) {
+            const part = pathParts[i];
+            if (current[part] && typeof current[part] === 'object') {
+                current = current[part] as Record<string, unknown>;
+            } else {
+                return; // Path doesn't exist
+            }
+        }
+
+        // Remove the final property
+        const finalProperty = pathParts[pathParts.length - 1];
+        delete current[finalProperty];
+    }
+
+    private replacePrimaryIdentifierProperty(
+        properties: Record<string, unknown>,
+        propertyPath: string,
+        logicalId: string,
+    ): void {
         // Handle nested property paths like "/properties/BucketName"
         const pathParts = propertyPath.split('/').filter((part) => part !== '' && part !== 'properties');
 
@@ -37,7 +84,10 @@ export class ReplacePrimaryIdentifierTransformer implements ResourceTemplateTran
         // Replace the final property with placeholder
         const finalProperty = pathParts[pathParts.length - 1];
         if (finalProperty in current) {
-            current[finalProperty] = ReplacePrimaryIdentifierTransformer.CLONE_PLACEHOLDER;
+            current[finalProperty] = PlaceholderConstants.createPlaceholder(
+                PlaceholderConstants.CLONE_INPUT_REQUIRED,
+                logicalId,
+            );
         }
     }
 }

--- a/src/schema/transformers/ResourceTemplateTransformer.ts
+++ b/src/schema/transformers/ResourceTemplateTransformer.ts
@@ -4,5 +4,5 @@ import { ResourceSchema } from '../ResourceSchema';
  * Interface for resource template transformers
  */
 export interface ResourceTemplateTransformer {
-    transform(resourceProperties: Record<string, unknown>, schema: ResourceSchema): void;
+    transform(resourceProperties: Record<string, unknown>, schema: ResourceSchema, logicalId?: string): void;
 }

--- a/tst/unit/resourceState/MockResourceState.ts
+++ b/tst/unit/resourceState/MockResourceState.ts
@@ -196,6 +196,40 @@ export const MockResourceStates = {
             Description: 'Database connection URL',
         }),
     } as ResourceState,
+
+    'AWS::Synthetics::Canary': {
+        typeName: 'AWS::Synthetics::Canary',
+        identifier: 'my-test-canary',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            Name: 'my-test-canary',
+            Code: {
+                Handler: 'index.handler',
+                Script: 'exports.handler = async () => {};',
+            },
+            ArtifactS3Location: 's3://my-bucket/canary-artifacts',
+            ExecutionRoleArn: 'arn:aws:iam::123456789012:role/canary-role',
+            Schedule: {
+                Expression: 'rate(5 minutes)',
+            },
+            RuntimeVersion: 'syn-nodejs-puppeteer-3.9',
+        }),
+    } as ResourceState,
+
+    'AWS::SecurityLake::SubscriberNotification': {
+        typeName: 'AWS::SecurityLake::SubscriberNotification',
+        identifier: 'arn:aws:securitylake:us-east-1:123456789012:subscriber/test-subscriber',
+        createdTimestamp: baseTimestamp,
+        properties: JSON.stringify({
+            SubscriberArn: 'arn:aws:securitylake:us-east-1:123456789012:subscriber/test-subscriber',
+            NotificationConfiguration: {
+                HttpsNotificationConfiguration: {
+                    TargetRoleArn: 'arn:aws:iam::123456789012:role/notification-role',
+                    Endpoint: 'https://example.com/webhook',
+                },
+            },
+        }),
+    } as ResourceState,
 };
 
 export function createMockResourceState(resourceType: string): ResourceState {

--- a/tst/unit/schema/transformers/PlaceholderConstants.test.ts
+++ b/tst/unit/schema/transformers/PlaceholderConstants.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { PlaceholderConstants, PlaceholderReplacer } from '../../../../src/schema/transformers/PlaceholderConstants';
+
+describe('PlaceholderConstants', () => {
+    describe('createPlaceholder', () => {
+        it('should create placeholder with correct format', () => {
+            const result = PlaceholderConstants.createPlaceholder('TEST_PURPOSE', 'MyResource');
+            expect(result).toBe('__PLACEHOLDER__TEST_PURPOSE__MyResource');
+        });
+
+        it('should create placeholder for WRITE_ONLY_REQUIRED', () => {
+            const result = PlaceholderConstants.createPlaceholder(PlaceholderConstants.WRITE_ONLY_REQUIRED, 'IAMRole');
+            expect(result).toBe('__PLACEHOLDER__WRITE_ONLY_REQUIRED__IAMRole');
+        });
+
+        it('should create placeholder for CLONE_INPUT_REQUIRED', () => {
+            const result = PlaceholderConstants.createPlaceholder(
+                PlaceholderConstants.CLONE_INPUT_REQUIRED,
+                'S3Bucket',
+            );
+            expect(result).toBe('__PLACEHOLDER__CLONE_INPUT_REQUIRED__S3Bucket');
+        });
+    });
+
+    describe('hasPlaceholders', () => {
+        it('should return true when text contains placeholder', () => {
+            const text = 'some text __PLACEHOLDER__TEST__Resource more text';
+            expect(PlaceholderConstants.hasPlaceholders(text)).toBe(true);
+        });
+
+        it('should return false when text does not contain placeholder', () => {
+            const text = 'some text without placeholder';
+            expect(PlaceholderConstants.hasPlaceholders(text)).toBe(false);
+        });
+    });
+});
+
+describe('PlaceholderReplacer', () => {
+    describe('replaceWithTabStops', () => {
+        it('should replace single WRITE_ONLY_REQUIRED placeholder', () => {
+            const input = '__PLACEHOLDER__WRITE_ONLY_REQUIRED__MyResource';
+            const result = PlaceholderReplacer.replaceWithTabStops(input);
+            expect(result).toBe('${1:write only required property for MyResource}');
+        });
+
+        it('should replace single CLONE_INPUT_REQUIRED placeholder', () => {
+            const input = '__PLACEHOLDER__CLONE_INPUT_REQUIRED__MyBucket';
+            const result = PlaceholderReplacer.replaceWithTabStops(input);
+            expect(result).toBe('${1:enter new identifier for MyBucket}');
+        });
+
+        it('should replace multiple placeholders with sequential tabstops', () => {
+            const input = `{
+  "Prop1": "__PLACEHOLDER__WRITE_ONLY_REQUIRED__Resource1",
+  "Prop2": "__PLACEHOLDER__CLONE_INPUT_REQUIRED__Resource2",
+  "Prop3": "__PLACEHOLDER__WRITE_ONLY_REQUIRED__Resource3"
+}`;
+            const result = PlaceholderReplacer.replaceWithTabStops(input);
+            expect(result).toContain('${1:write only required property for Resource1}');
+            expect(result).toContain('${2:enter new identifier for Resource2}');
+            expect(result).toContain('${3:write only required property for Resource3}');
+        });
+
+        it('should handle placeholders with underscores in purpose', () => {
+            const input = '__PLACEHOLDER__SOME_LONG_PURPOSE_NAME__MyResource';
+            const result = PlaceholderReplacer.replaceWithTabStops(input);
+            expect(result).toBe('${1:enter new identifier for MyResource}');
+        });
+
+        it('should handle placeholders with numbers in logical ID', () => {
+            const input = '__PLACEHOLDER__CLONE_INPUT_REQUIRED__Resource123';
+            const result = PlaceholderReplacer.replaceWithTabStops(input);
+            expect(result).toBe('${1:enter new identifier for Resource123}');
+        });
+
+        it('should return unchanged text when no placeholders present', () => {
+            const input = 'regular text without placeholders';
+            const result = PlaceholderReplacer.replaceWithTabStops(input);
+            expect(result).toBe(input);
+        });
+
+        it('should handle mixed content with placeholders', () => {
+            const input =
+                'Before __PLACEHOLDER__WRITE_ONLY_REQUIRED__Res1 Middle __PLACEHOLDER__CLONE_INPUT_REQUIRED__Res2 After';
+            const result = PlaceholderReplacer.replaceWithTabStops(input);
+            expect(result).toBe(
+                'Before ${1:write only required property for Res1} Middle ${2:enter new identifier for Res2} After',
+            );
+        });
+
+        it('should use independent counter for each call', () => {
+            const input1 = '__PLACEHOLDER__WRITE_ONLY_REQUIRED__Res1';
+            const input2 = '__PLACEHOLDER__CLONE_INPUT_REQUIRED__Res2';
+
+            const result1 = PlaceholderReplacer.replaceWithTabStops(input1);
+            const result2 = PlaceholderReplacer.replaceWithTabStops(input2);
+
+            expect(result1).toBe('${1:write only required property for Res1}');
+            expect(result2).toBe('${1:enter new identifier for Res2}');
+        });
+    });
+
+    describe('hasPlaceholders', () => {
+        it('should return true when text contains placeholder', () => {
+            const text = '__PLACEHOLDER__TEST__Resource';
+            expect(PlaceholderReplacer.hasPlaceholders(text)).toBe(true);
+        });
+
+        it('should return false when text does not contain placeholder', () => {
+            const text = 'no placeholder here';
+            expect(PlaceholderReplacer.hasPlaceholders(text)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
…abstop placeholders

*Description of changes:*
- change the resource state insertion from CodeAction to CompletionItem
- values required user input have tab stops with placeholder text such as:
  - `write only required property for LambdaFunction1`
- primary identifiers no longer require user input
  - i.e., no placeholder for `BucketName` when cloning `AWS::S3::Bucket`
- using EditorSettings for indentation instead of previously hardcoded indentation of '2'
- insertion of text on client side is changing from `workspace.applyEdit()` to `SnippetString` which applies auto indentation and supports tabstops
  - this necessitated many formatting changes in server side

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
