### PR TITLE
Fix deletion workflow lsp request and pagination

### DIFF
--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -38,6 +38,9 @@ import {
     describeValidationStatusHandler,
     describeDeploymentStatusHandler,
     getTemplateResourcesHandler,
+    deleteChangeSetHandler,
+    getChangeSetDeletionStatusHandler,
+    describeChangeSetDeletionStatusHandler,
 } from '../handlers/StackHandler';
 import { LspComponents } from '../protocol/LspComponents';
 import { closeSafely } from '../utils/Closeable';
@@ -109,6 +112,11 @@ export class CfnServer {
         this.lsp.stackHandlers.onGetDeploymentStatus(getDeploymentStatusHandler(this.components));
         this.lsp.stackHandlers.onDescribeValidationStatus(describeValidationStatusHandler(this.components));
         this.lsp.stackHandlers.onDescribeDeploymentStatus(describeDeploymentStatusHandler(this.components));
+        this.lsp.stackHandlers.onDeleteChangeSet(deleteChangeSetHandler(this.components));
+        this.lsp.stackHandlers.onGetChangeSetDeletionStatus(getChangeSetDeletionStatusHandler(this.components));
+        this.lsp.stackHandlers.onDescribeChangeSetDeletionStatus(
+            describeChangeSetDeletionStatusHandler(this.components),
+        );
         this.lsp.stackHandlers.onListStacks(listStacksHandler(this.components));
         this.lsp.stackHandlers.onListChangeSets(listChangeSetsHandler(this.components));
         this.lsp.stackHandlers.onGetStackTemplate(getManagedResourceStackTemplateHandler(this.components));

--- a/src/stacks/actions/ChangeSetDeletionWorkflow.ts
+++ b/src/stacks/actions/ChangeSetDeletionWorkflow.ts
@@ -193,21 +193,15 @@ export class ChangeSetDeletionWorkflow
     }
 
     private async hasMultipleChangeSets(stackName: string): Promise<boolean> {
-        let nextToken: string | undefined;
-        let changeSetCount = 0;
+        const result = await this.cfnService.listChangeSets(stackName);
 
-        do {
-            const result = await this.cfnService.listChangeSets(stackName, nextToken);
+        const changeSetCount = result.changeSets.length;
 
-            changeSetCount += result.changeSets.length ?? 0;
-
-            if (changeSetCount > 1) {
-                return true;
-            }
-
-            nextToken = result.nextToken;
-        } while (nextToken);
-
-        return false;
+        // Minimum one change set per page, if nextToken is defined there is at least two change sets
+        if (changeSetCount > 1 || result.nextToken) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }

--- a/tst/unit/stackActions/ChangeSetDeletionWorkflow.test.ts
+++ b/tst/unit/stackActions/ChangeSetDeletionWorkflow.test.ts
@@ -292,17 +292,11 @@ describe('ChangeSetDeletionWorkflow', () => {
             mockCfnService.waitUntilStackDeleteComplete = vi.fn().mockResolvedValue({
                 state: WaiterState.SUCCESS,
             });
-            // Mock pagination: first call returns 1 changeset + nextToken, second call returns 1 changeset
-            mockCfnService.listChangeSets = vi
-                .fn()
-                .mockResolvedValueOnce({
-                    changeSets: [{ ChangeSetName: 'changeset1' }],
-                    nextToken: 'token123',
-                })
-                .mockResolvedValueOnce({
-                    changeSets: [{ ChangeSetName: 'changeset3' }],
-                    nextToken: undefined,
-                });
+
+            mockCfnService.listChangeSets = vi.fn().mockResolvedValue({
+                changeSets: [{ ChangeSetName: 'changeset1' }],
+                nextToken: 'token123',
+            });
             (isStackInReview as any).mockResolvedValue(true);
             (mapChangesToStackChanges as any).mockReturnValue([]);
         });
@@ -322,7 +316,7 @@ describe('ChangeSetDeletionWorkflow', () => {
                 ChangeSetName: testChangeSetName,
             });
 
-            expect(mockCfnService.listChangeSets).toBeCalledTimes(2);
+            expect(mockCfnService.listChangeSets).toBeCalledTimes(1);
             const workflow = (deletionWorkflow as any).workflows.get(testId);
             expect(workflow.state).toBe(StackActionState.SUCCESSFUL);
             expect(workflow.phase).toBe(StackActionPhase.DELETION_COMPLETE);


### PR DESCRIPTION
*Description of changes:*
- We don't need to paginate the listChangeSets call because as soon as we get a nextToken there are at least two change sets (which means we should not remove the stack)
- Was missing CfnServer Lsp requests as well

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
