### PR TITLE
add telemetry to StackManagementInfoProvider

### DIFF
--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -55,6 +55,7 @@ import {
     waitUntilStackDeleteComplete,
 } from '@aws-sdk/client-cloudformation';
 import { WaiterConfiguration, WaiterResult } from '@smithy/util-waiter';
+import { Measure } from '../telemetry/TelemetryDecorator';
 import { AwsClient } from './AwsClient';
 
 export class CfnService {
@@ -179,6 +180,7 @@ export class CfnService {
         });
     }
 
+    @Measure({ name: 'describeStackResources' })
     public async describeStackResources(params: {
         StackName?: string;
         LogicalResourceId?: string;


### PR DESCRIPTION
### Summary
Track CloudFormation stack management queries to monitor import eligibility, API performance, and error patterns.

---

### Metrics Added (9 total)

#### **StackManagementInfoProvider.getResourceManagementState**
• .count - Total invocations
• .duration - Total method time (API + processing)
• .fault - Exceptions

#### **CfnService.describeStackResources**
• .count - API call count
• .duration - CloudFormation API latency
• .fault - API failures

#### **StackManagementInfoProvider (Business Metrics)**
• .managed - Resources in stacks (LOW expected for imports)
• .unmanaged - Import-eligible resources (HIGH expected)
• .unknown - Unexpected API responses (NEAR ZERO expected)

---

### Key Insights

Import Eligibility: unmanaged / (managed + unmanaged + unknown) → Should be >80%

Processing Overhead: getResourceManagementState.duration - describeStackResources.duration → Should be <10ms

API Health: describeStackResources.fault / describeStackResources.count → Should be <1%

---

### Implementation
• @Measure decorator on methods (emits count, duration, fault)
• API tracking at CfnService layer for reusability
• Initialize counters to 0 to prevent data gaps

### Files Changed
• src/resourceState/StackManagementInfoProvider.ts
• src/services/CfnService.ts