### PR TITLE
add metrics to ResourceStateImporter

### DIFF
--- a/src/resourceState/ResourceStateImporter.ts
+++ b/src/resourceState/ResourceStateImporter.ts
@@ -76,7 +76,7 @@ export class ResourceStateImporter {
             purpose,
         );
 
-        this.recordResourceMetrics(resourceSelections, importResult);
+        this.recordStateFetchMetrics(resourceSelections, importResult);
 
         let warning: string | undefined;
         if (purpose === ResourceStatePurpose.IMPORT) {
@@ -90,7 +90,7 @@ export class ResourceStateImporter {
         const resourceSectionExists = resourceSection !== undefined;
 
         this.telemetry.count(`document.${document.documentType.toLowerCase()}`, 1);
-        this.telemetry.count(resourceSectionExists ? 'section.exists' : 'section.created', 1);
+        this.telemetry.countBoolean('section.create', !resourceSectionExists);
 
         const insertPosition = this.getInsertPosition(resourceSection, document);
         const docFormattedText = this.combineResourcesToDocumentFormat(
@@ -377,7 +377,7 @@ export class ResourceStateImporter {
         }
     }
 
-    private recordResourceMetrics(resourceSelections: ResourceSelection[], importResult: ResourceStateResult): void {
+    private recordStateFetchMetrics(resourceSelections: ResourceSelection[], importResult: ResourceStateResult): void {
         const totalRequested = resourceSelections.reduce((sum, sel) => sum + sel.resourceIdentifiers.length, 0);
         const succeeded = Object.values(importResult.successfulImports).flat().length;
         const failed = Object.values(importResult.failedImports).flat().length;
@@ -393,8 +393,7 @@ export class ResourceStateImporter {
         this.telemetry.count('managed.warning', 0);
         this.telemetry.count('document.json', 0);
         this.telemetry.count('document.yaml', 0);
-        this.telemetry.count('section.exists', 0);
-        this.telemetry.count('section.created', 0);
+        this.telemetry.count('section.create', 0);
         this.telemetry.count('logicalid.collision', 0);
     }
 


### PR DESCRIPTION
### Metrics Added (13 total)

#### **Method Tracking (3 metrics)**
• importResourceState.count
• importResourceState.duration
• importResourceState.fault

#### **Counters (7 metrics)**
• purpose.import - Import operations
• purpose.clone - Clone operations
• document.json - JSON documents
• document.yaml - YAML documents
• section.create - New Resources section created (0=exists, 1=created)
• managed.warning - Stack-managed resources detected
• logicalid.collision - Logical ID conflicts

#### **Histograms (3 metrics)**
• resources.requested - Batch size per operation
• resources.succeeded - Successfully processed
• resources.fault - Failed to process