### PR TITLE
fetch and manage stack events

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -12,6 +12,8 @@ import {
     parseListStackResourcesParams,
     parseStackActionParams,
     parseTemplateUriParams,
+    parseGetStackEventsParams,
+    parseClearStackEventsParams,
 } from '../stacks/actions/StackActionParser';
 import {
     TemplateUri,
@@ -34,6 +36,9 @@ import {
     ListChangeSetResult,
     ListStackResourcesParams,
     ListStackResourcesResult,
+    GetStackEventsParams,
+    GetStackEventsResult,
+    ClearStackEventsParams,
 } from '../stacks/StackRequestType';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { extractErrorMessage } from '../utils/Errors';
@@ -348,6 +353,36 @@ export function listStackResourcesHandler(
         } catch (error) {
             log.error({ error: extractErrorMessage(error) }, 'Error listing stack resources');
             return { resources: [] };
+        }
+    };
+}
+
+export function getStackEventsHandler(
+    components: ServerComponents,
+): RequestHandler<GetStackEventsParams, GetStackEventsResult, void> {
+    return async (rawParams): Promise<GetStackEventsResult> => {
+        try {
+            const params = parseWithPrettyError(parseGetStackEventsParams, rawParams);
+            if (params.refresh) {
+                const events = await components.stackEventManager.refresh(params.stackName);
+                return { events, nextToken: undefined };
+            }
+            return await components.stackEventManager.fetchEvents(params.stackName, params.nextToken);
+        } catch (error) {
+            handleStackActionError(error, 'Failed to get stack events');
+        }
+    };
+}
+
+export function clearStackEventsHandler(
+    components: ServerComponents,
+): RequestHandler<ClearStackEventsParams, void, void> {
+    return (rawParams): void => {
+        try {
+            parseWithPrettyError(parseClearStackEventsParams, rawParams);
+            components.stackEventManager.clear();
+        } catch (error) {
+            handleStackActionError(error, 'Failed to clear stack events');
         }
     };
 }

--- a/src/protocol/LspStackHandlers.ts
+++ b/src/protocol/LspStackHandlers.ts
@@ -40,6 +40,11 @@ import {
     ListChangeSetParams,
     ListChangeSetResult,
     ListChangeSetRequest,
+    GetStackEventsParams,
+    GetStackEventsResult,
+    GetStackEventsRequest,
+    ClearStackEventsParams,
+    ClearStackEventsRequest,
 } from '../stacks/StackRequestType';
 import { Identifiable } from './LspTypes';
 
@@ -108,5 +113,13 @@ export class LspStackHandlers {
 
     onDescribeChangeSetDeletionStatus(handler: RequestHandler<Identifiable, DescribeDeletionStatusResult, void>) {
         this.connection.onRequest(DescribeChangeSetDeletionStatusRequest.method, handler);
+    }
+
+    onGetStackEvents(handler: RequestHandler<GetStackEventsParams, GetStackEventsResult, void>) {
+        this.connection.onRequest(GetStackEventsRequest.method, handler);
+    }
+
+    onClearStackEvents(handler: RequestHandler<ClearStackEventsParams, void, void>) {
+        this.connection.onRequest(ClearStackEventsRequest.method, handler);
     }
 }

--- a/src/server/CfnLspProviders.ts
+++ b/src/server/CfnLspProviders.ts
@@ -23,6 +23,7 @@ import {
 import { StackActionWorkflow } from '../stacks/actions/StackActionWorkflowType';
 import { ValidationWorkflow } from '../stacks/actions/ValidationWorkflow';
 import { ValidationWorkflowV2 } from '../stacks/actions/ValidationWorkflowV2';
+import { StackEventManager } from '../stacks/StackEventManager';
 import { StackManager } from '../stacks/StackManager';
 import { localCfnClientExists } from '../utils/ClientUtil';
 import { Closeable, closeSafely } from '../utils/Closeable';
@@ -37,6 +38,7 @@ export class CfnLspProviders implements Configurables, Closeable {
     readonly deploymentWorkflowService: StackActionWorkflow<CreateDeploymentParams, DescribeDeploymentStatusResult>;
     readonly changeSetDeletionWorkflowService: StackActionWorkflow<DeleteChangeSetParams, DescribeDeletionStatusResult>;
     readonly stackManager: StackManager;
+    readonly stackEventManager: StackEventManager;
     readonly resourceStateManager: ResourceStateManager;
     readonly resourceStateImporter: ResourceStateImporter;
     readonly relationshipSchemaService: RelationshipSchemaService;
@@ -57,6 +59,7 @@ export class CfnLspProviders implements Configurables, Closeable {
         this.stackManagementInfoProvider =
             overrides.stackManagementInfoProvider ?? new StackManagementInfoProvider(external.cfnService);
         this.stackManager = overrides.stackManager ?? new StackManager(external.cfnService);
+        this.stackEventManager = overrides.stackEventManager ?? new StackEventManager(external.cfnService);
         this.validationWorkflowService =
             overrides.validationWorkflowService ??
             (localCfnClientExists()

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -42,6 +42,8 @@ import {
     deleteChangeSetHandler,
     getChangeSetDeletionStatusHandler,
     describeChangeSetDeletionStatusHandler,
+    getStackEventsHandler,
+    clearStackEventsHandler,
 } from '../handlers/StackHandler';
 import { LspComponents } from '../protocol/LspComponents';
 import { closeSafely } from '../utils/Closeable';
@@ -122,6 +124,8 @@ export class CfnServer {
         this.lsp.stackHandlers.onListChangeSets(listChangeSetsHandler(this.components));
         this.lsp.stackHandlers.onListStackResources(listStackResourcesHandler(this.components));
         this.lsp.stackHandlers.onGetStackTemplate(getManagedResourceStackTemplateHandler(this.components));
+        this.lsp.stackHandlers.onGetStackEvents(getStackEventsHandler(this.components));
+        this.lsp.stackHandlers.onClearStackEvents(clearStackEventsHandler(this.components));
 
         this.lsp.resourceHandlers.onListResources(listResourcesHandler(this.components));
         this.lsp.resourceHandlers.onRefreshResourceList(refreshResourceListHandler(this.components));

--- a/src/stacks/StackEventManager.ts
+++ b/src/stacks/StackEventManager.ts
@@ -1,0 +1,69 @@
+import { StackEvent } from '@aws-sdk/client-cloudformation';
+import { CfnService } from '../services/CfnService';
+
+export class StackEventManager {
+    private mostRecentEventId?: string;
+    private stackName?: string;
+
+    constructor(private readonly cfnService: CfnService) {}
+
+    async fetchEvents(stackName: string, nextToken?: string): Promise<{ events: StackEvent[]; nextToken?: string }> {
+        if (this.stackName !== stackName) {
+            this.clear();
+            this.stackName = stackName;
+        }
+
+        const response = await this.cfnService.describeStackEvents({ StackName: stackName }, { nextToken });
+        const events = response.StackEvents ?? [];
+
+        if (!nextToken && events.length > 0) {
+            this.mostRecentEventId = events[0].EventId;
+        }
+
+        return { events, nextToken: response.NextToken };
+    }
+
+    async refresh(stackName: string): Promise<StackEvent[]> {
+        if (this.stackName !== stackName) {
+            const eventsResponse = await this.fetchEvents(stackName);
+            return eventsResponse.events;
+        }
+
+        const newEvents: StackEvent[] = [];
+        let token: string | undefined;
+        let pagesChecked = 0;
+        const maxPages = 5;
+
+        while (pagesChecked < maxPages) {
+            const response = await this.cfnService.describeStackEvents({ StackName: stackName }, { nextToken: token });
+            const events = response.StackEvents ?? [];
+
+            for (const event of events) {
+                if (event.EventId === this.mostRecentEventId) {
+                    if (newEvents.length > 0) {
+                        this.mostRecentEventId = newEvents[0].EventId;
+                    }
+                    return newEvents;
+                }
+
+                newEvents.push(event);
+            }
+
+            token = response.NextToken;
+            pagesChecked++;
+
+            if (!token) break;
+        }
+
+        if (newEvents.length > 0) {
+            this.mostRecentEventId = newEvents[0].EventId;
+        }
+
+        return newEvents;
+    }
+
+    clear(): void {
+        this.mostRecentEventId = undefined;
+        this.stackName = undefined;
+    }
+}

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -1,4 +1,4 @@
-import { StackSummary, StackStatus, StackResourceSummary } from '@aws-sdk/client-cloudformation';
+import { StackSummary, StackStatus, StackResourceSummary, StackEvent } from '@aws-sdk/client-cloudformation';
 import { RequestType } from 'vscode-languageserver-protocol';
 
 export type ListStacksParams = {
@@ -59,4 +59,27 @@ export type ListStackResourcesResult = {
 
 export const ListStackResourcesRequest = new RequestType<ListStackResourcesParams, ListStackResourcesResult, void>(
     'aws/cfn/stack/resources',
+);
+
+export type GetStackEventsParams = {
+    stackName: string;
+    nextToken?: string;
+    refresh?: boolean;
+};
+
+export type GetStackEventsResult = {
+    events: StackEvent[];
+    nextToken?: string;
+};
+
+export const GetStackEventsRequest = new RequestType<GetStackEventsParams, GetStackEventsResult, void>(
+    'aws/cfn/stack/events',
+);
+
+export type ClearStackEventsParams = {
+    stackName: string;
+};
+
+export const ClearStackEventsRequest = new RequestType<ClearStackEventsParams, void, void>(
+    'aws/cfn/stack/events/clear',
 );

--- a/src/stacks/actions/StackActionParser.ts
+++ b/src/stacks/actions/StackActionParser.ts
@@ -1,6 +1,6 @@
 import { Capability } from '@aws-sdk/client-cloudformation';
 import { z } from 'zod';
-import { ListStackResourcesParams } from '../StackRequestType';
+import { ListStackResourcesParams, GetStackEventsParams, ClearStackEventsParams } from '../StackRequestType';
 import {
     CreateDeploymentParams,
     CreateValidationParams,
@@ -57,6 +57,16 @@ const ListStackResourcesParamsSchema = z.object({
     maxItems: z.number().optional(),
 });
 
+const GetStackEventsParamsSchema = z.object({
+    stackName: z.string().min(1).max(128),
+    nextToken: z.string().optional(),
+    refresh: z.boolean().optional(),
+});
+
+const ClearStackEventsParamsSchema = z.object({
+    stackName: z.string().min(1).max(128),
+});
+
 export function parseStackActionParams(input: unknown): CreateValidationParams {
     return StackActionParamsSchema.parse(input);
 }
@@ -75,4 +85,12 @@ export function parseTemplateUriParams(input: unknown): TemplateUri {
 
 export function parseListStackResourcesParams(input: unknown): ListStackResourcesParams {
     return ListStackResourcesParamsSchema.parse(input);
+}
+
+export function parseGetStackEventsParams(input: unknown): GetStackEventsParams {
+    return GetStackEventsParamsSchema.parse(input);
+}
+
+export function parseClearStackEventsParams(input: unknown): ClearStackEventsParams {
+    return ClearStackEventsParamsSchema.parse(input);
 }

--- a/tst/unit/stacks/StackEventManager.test.ts
+++ b/tst/unit/stacks/StackEventManager.test.ts
@@ -1,0 +1,395 @@
+import { StackEvent, ResourceStatus } from '@aws-sdk/client-cloudformation';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CfnService } from '../../../src/services/CfnService';
+import { StackEventManager } from '../../../src/stacks/StackEventManager';
+
+describe('StackEventManager', () => {
+    let manager: StackEventManager;
+    let mockCfnService: CfnService;
+
+    const createEvent = (id: string, timestamp: Date, resourceId: string, status: ResourceStatus): StackEvent => ({
+        EventId: id,
+        StackId: 'stack-123',
+        StackName: 'TestStack',
+        LogicalResourceId: resourceId,
+        PhysicalResourceId: `physical-${resourceId}`,
+        ResourceType: 'AWS::S3::Bucket',
+        Timestamp: timestamp,
+        ResourceStatus: status,
+    });
+
+    beforeEach(() => {
+        mockCfnService = {
+            describeStackEvents: vi.fn(),
+        } as any;
+        manager = new StackEventManager(mockCfnService);
+        vi.clearAllMocks();
+    });
+
+    describe('fetchEvents', () => {
+        it('fetches initial page of events', async () => {
+            const events = [
+                createEvent('event-1', new Date('2025-01-01T10:00:00Z'), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+                createEvent('event-2', new Date('2025-01-01T09:00:00Z'), 'Bucket2', ResourceStatus.CREATE_IN_PROGRESS),
+            ];
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({
+                StackEvents: events,
+                NextToken: 'token-1',
+            });
+
+            const result = await manager.fetchEvents('TestStack');
+
+            expect(mockCfnService.describeStackEvents).toHaveBeenCalledWith(
+                { StackName: 'TestStack' },
+                { nextToken: undefined },
+            );
+            expect(result.events).toHaveLength(2);
+            expect(result.nextToken).toBe('token-1');
+        });
+
+        it('fetch next page with token', async () => {
+            const firstPage = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            const secondPage = [createEvent('event-2', new Date(), 'Bucket2', ResourceStatus.CREATE_COMPLETE)];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: firstPage, NextToken: 'token-1' })
+                .mockResolvedValueOnce({ StackEvents: secondPage, NextToken: undefined });
+
+            await manager.fetchEvents('TestStack');
+            const result = await manager.fetchEvents('TestStack', 'token-1');
+
+            expect(mockCfnService.describeStackEvents).toHaveBeenCalledWith(
+                { StackName: 'TestStack' },
+                { nextToken: 'token-1' },
+            );
+            expect(result.events).toHaveLength(1);
+            expect(result.events[0].EventId).toBe('event-2');
+        });
+
+        it('track most recent event ID on initial fetch', async () => {
+            const events = [
+                createEvent(
+                    'event-newest',
+                    new Date('2025-01-01T12:00:00Z'),
+                    'Bucket1',
+                    ResourceStatus.CREATE_COMPLETE,
+                ),
+                createEvent('event-older', new Date('2025-01-01T11:00:00Z'), 'Bucket2', ResourceStatus.CREATE_COMPLETE),
+            ];
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({ StackEvents: events });
+
+            await manager.fetchEvents('TestStack');
+
+            // Verify by calling refresh - it should look for event-newest
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({
+                StackEvents: [createEvent('event-newest', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)],
+            });
+            const refreshResult = await manager.refresh('TestStack');
+            expect(refreshResult).toHaveLength(0);
+        });
+
+        it('clear cache when switching stacks', async () => {
+            const stack1Events = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            const stack2Events = [createEvent('event-2', new Date(), 'Bucket2', ResourceStatus.CREATE_COMPLETE)];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: stack1Events })
+                .mockResolvedValueOnce({ StackEvents: stack2Events });
+
+            await manager.fetchEvents('Stack1');
+            const result = await manager.fetchEvents('Stack2');
+
+            expect(result.events).toHaveLength(1);
+            expect(result.events[0].EventId).toBe('event-2');
+        });
+
+        it('handle events without EventId', async () => {
+            const events = [
+                createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+                { StackName: 'TestStack', Timestamp: new Date() } as StackEvent,
+            ];
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({ StackEvents: events });
+
+            const result = await manager.fetchEvents('TestStack');
+
+            expect(result.events).toHaveLength(2);
+        });
+    });
+
+    describe('refresh', () => {
+        it('return empty array when no new events', async () => {
+            const initialEvents = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: initialEvents })
+                .mockResolvedValueOnce({ StackEvents: initialEvents });
+
+            await manager.fetchEvents('TestStack');
+            const newEvents = await manager.refresh('TestStack');
+
+            expect(newEvents).toHaveLength(0);
+        });
+
+        it('fetch new events since last refresh', async () => {
+            const initialEvents = [
+                createEvent('event-2', new Date('2025-01-01T10:00:00Z'), 'Bucket2', ResourceStatus.CREATE_COMPLETE),
+                createEvent('event-1', new Date('2025-01-01T09:00:00Z'), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+            ];
+            const newEvents = [
+                createEvent('event-4', new Date('2025-01-01T12:00:00Z'), 'Bucket4', ResourceStatus.UPDATE_COMPLETE),
+                createEvent('event-3', new Date('2025-01-01T11:00:00Z'), 'Bucket3', ResourceStatus.UPDATE_IN_PROGRESS),
+                createEvent('event-2', new Date('2025-01-01T10:00:00Z'), 'Bucket2', ResourceStatus.CREATE_COMPLETE),
+            ];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: initialEvents })
+                .mockResolvedValueOnce({ StackEvents: newEvents });
+
+            await manager.fetchEvents('TestStack');
+            const result = await manager.refresh('TestStack');
+
+            expect(result).toHaveLength(2);
+            expect(result[0].EventId).toBe('event-4');
+            expect(result[1].EventId).toBe('event-3');
+        });
+
+        it('exhaust up to 5 pages to find last event', async () => {
+            const initialEvents = [
+                createEvent('event-old', new Date('2025-01-01T09:00:00Z'), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+            ];
+
+            const page1 = [createEvent('event-5', new Date(), 'Bucket5', ResourceStatus.CREATE_COMPLETE)];
+            const page2 = [createEvent('event-4', new Date(), 'Bucket4', ResourceStatus.CREATE_COMPLETE)];
+            const page3 = [createEvent('event-3', new Date(), 'Bucket3', ResourceStatus.CREATE_COMPLETE)];
+            const page4 = [createEvent('event-2', new Date(), 'Bucket2', ResourceStatus.CREATE_COMPLETE)];
+            const page5 = [
+                createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+                createEvent('event-old', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+            ];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: initialEvents })
+                .mockResolvedValueOnce({ StackEvents: page1, NextToken: 'token-1' })
+                .mockResolvedValueOnce({ StackEvents: page2, NextToken: 'token-2' })
+                .mockResolvedValueOnce({ StackEvents: page3, NextToken: 'token-3' })
+                .mockResolvedValueOnce({ StackEvents: page4, NextToken: 'token-4' })
+                .mockResolvedValueOnce({ StackEvents: page5 });
+
+            await manager.fetchEvents('TestStack');
+            const result = await manager.refresh('TestStack');
+
+            expect(mockCfnService.describeStackEvents).toHaveBeenCalledTimes(6);
+            expect(result).toHaveLength(5);
+            expect(result[0].EventId).toBe('event-5');
+            expect(result[4].EventId).toBe('event-1');
+        });
+
+        it('stop after 5 pages even if last event not found', async () => {
+            const initialEvents = [createEvent('event-old', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: initialEvents })
+                .mockResolvedValueOnce({
+                    StackEvents: [createEvent('event-5', new Date(), 'Bucket5', ResourceStatus.CREATE_COMPLETE)],
+                    NextToken: 'token-1',
+                })
+                .mockResolvedValueOnce({
+                    StackEvents: [createEvent('event-4', new Date(), 'Bucket4', ResourceStatus.CREATE_COMPLETE)],
+                    NextToken: 'token-2',
+                })
+                .mockResolvedValueOnce({
+                    StackEvents: [createEvent('event-3', new Date(), 'Bucket3', ResourceStatus.CREATE_COMPLETE)],
+                    NextToken: 'token-3',
+                })
+                .mockResolvedValueOnce({
+                    StackEvents: [createEvent('event-2', new Date(), 'Bucket2', ResourceStatus.CREATE_COMPLETE)],
+                    NextToken: 'token-4',
+                })
+                .mockResolvedValueOnce({
+                    StackEvents: [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)],
+                    NextToken: 'token-5',
+                });
+
+            await manager.fetchEvents('TestStack');
+            const result = await manager.refresh('TestStack');
+
+            expect(mockCfnService.describeStackEvents).toHaveBeenCalledTimes(6);
+            expect(result).toHaveLength(5);
+        });
+
+        it('stop when no more pages available', async () => {
+            const initialEvents = [createEvent('event-old', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            const newEvents = [
+                createEvent('event-2', new Date(), 'Bucket2', ResourceStatus.CREATE_COMPLETE),
+                createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+            ];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: initialEvents })
+                .mockResolvedValueOnce({ StackEvents: newEvents, NextToken: undefined });
+
+            await manager.fetchEvents('TestStack');
+            const result = await manager.refresh('TestStack');
+
+            expect(mockCfnService.describeStackEvents).toHaveBeenCalledTimes(2);
+            expect(result).toHaveLength(2);
+        });
+
+        it('update most recent event ID after refresh', async () => {
+            const initialEvents = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            const refreshEvents = [
+                createEvent('event-2', new Date(), 'Bucket2', ResourceStatus.CREATE_COMPLETE),
+                createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+            ];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: initialEvents })
+                .mockResolvedValueOnce({ StackEvents: refreshEvents })
+                .mockResolvedValueOnce({ StackEvents: refreshEvents });
+
+            await manager.fetchEvents('TestStack');
+            await manager.refresh('TestStack');
+            const secondRefresh = await manager.refresh('TestStack');
+
+            expect(secondRefresh).toHaveLength(0);
+        });
+
+        it('fetch initial events if stack name changes', async () => {
+            const stack1Events = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            const stack2Events = [createEvent('event-2', new Date(), 'Bucket2', ResourceStatus.CREATE_COMPLETE)];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: stack1Events })
+                .mockResolvedValueOnce({ StackEvents: stack2Events });
+
+            await manager.fetchEvents('Stack1');
+            const result = await manager.refresh('Stack2');
+
+            expect(result).toHaveLength(1);
+            expect(result[0].EventId).toBe('event-2');
+        });
+    });
+
+    describe('clear', () => {
+        it('clear all cached data', async () => {
+            const events = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({ StackEvents: events });
+
+            await manager.fetchEvents('TestStack');
+            manager.clear();
+
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({ StackEvents: events });
+            const result = await manager.fetchEvents('TestStack');
+
+            expect(result.events).toHaveLength(1);
+        });
+
+        it('allow fetching events after clear', async () => {
+            const events = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({ StackEvents: events });
+
+            await manager.fetchEvents('TestStack');
+            manager.clear();
+
+            const result = await manager.fetchEvents('TestStack');
+            expect(result.events).toHaveLength(1);
+        });
+    });
+
+    describe('real-world scenarios', () => {
+        it('handle stack deployment lifecycle', async () => {
+            // Initial state: stack creating
+            const initialEvents = [
+                createEvent(
+                    'event-2',
+                    new Date('2025-01-01T10:01:00Z'),
+                    'TestStack',
+                    ResourceStatus.CREATE_IN_PROGRESS,
+                ),
+                createEvent('event-1', new Date('2025-01-01T10:00:00Z'), 'Bucket1', ResourceStatus.CREATE_IN_PROGRESS),
+            ];
+
+            // After refresh: bucket created
+            const refresh1Events = [
+                createEvent('event-3', new Date('2025-01-01T10:02:00Z'), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+                createEvent(
+                    'event-2',
+                    new Date('2025-01-01T10:01:00Z'),
+                    'TestStack',
+                    ResourceStatus.CREATE_IN_PROGRESS,
+                ),
+            ];
+
+            // After second refresh: stack complete
+            const refresh2Events = [
+                createEvent('event-4', new Date('2025-01-01T10:03:00Z'), 'TestStack', ResourceStatus.CREATE_COMPLETE),
+                createEvent('event-3', new Date('2025-01-01T10:02:00Z'), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+            ];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: initialEvents })
+                .mockResolvedValueOnce({ StackEvents: refresh1Events })
+                .mockResolvedValueOnce({ StackEvents: refresh2Events });
+
+            await manager.fetchEvents('TestStack');
+            const newEvents1 = await manager.refresh('TestStack');
+            expect(newEvents1).toHaveLength(1);
+            expect(newEvents1[0].ResourceStatus).toBe(ResourceStatus.CREATE_COMPLETE);
+
+            const newEvents2 = await manager.refresh('TestStack');
+            expect(newEvents2).toHaveLength(1);
+            expect(newEvents2[0].ResourceStatus).toBe(ResourceStatus.CREATE_COMPLETE);
+            expect(newEvents2[0].LogicalResourceId).toBe('TestStack');
+        });
+
+        it('handle pagination during active deployment', async () => {
+            const initialEvents = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+
+            // Many new events across multiple pages
+            const page1 = Array.from({ length: 50 }, (_, i) =>
+                createEvent(`event-${100 - i}`, new Date(), `Resource${100 - i}`, ResourceStatus.CREATE_COMPLETE),
+            );
+            const page2 = [
+                createEvent('event-2', new Date(), 'Bucket2', ResourceStatus.CREATE_COMPLETE),
+                createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE),
+            ];
+
+            mockCfnService.describeStackEvents = vi
+                .fn()
+                .mockResolvedValueOnce({ StackEvents: initialEvents })
+                .mockResolvedValueOnce({ StackEvents: page1, NextToken: 'token-1' })
+                .mockResolvedValueOnce({ StackEvents: page2 });
+
+            await manager.fetchEvents('TestStack');
+            const newEvents = await manager.refresh('TestStack');
+
+            expect(newEvents).toHaveLength(51);
+            expect(newEvents[0].EventId).toBe('event-100');
+            expect(newEvents[50].EventId).toBe('event-2');
+        });
+
+        it('handle view close and reopen', async () => {
+            const events = [createEvent('event-1', new Date(), 'Bucket1', ResourceStatus.CREATE_COMPLETE)];
+            mockCfnService.describeStackEvents = vi.fn().mockResolvedValue({ StackEvents: events });
+
+            // First view session
+            await manager.fetchEvents('TestStack');
+
+            // View closed
+            manager.clear();
+
+            // View reopened
+            const result = await manager.fetchEvents('TestStack');
+            expect(result.events).toHaveLength(1);
+        });
+    });
+});

--- a/tst/utils/MockServerComponents.ts
+++ b/tst/utils/MockServerComponents.ts
@@ -56,6 +56,7 @@ import { SettingsManager } from '../../src/settings/SettingsManager';
 import { ChangeSetDeletionWorkflow } from '../../src/stacks/actions/ChangeSetDeletionWorkflow';
 import { DeploymentWorkflow } from '../../src/stacks/actions/DeploymentWorkflow';
 import { ValidationWorkflow } from '../../src/stacks/actions/ValidationWorkflow';
+import { StackEventManager } from '../../src/stacks/StackEventManager';
 import { StackManager } from '../../src/stacks/StackManager';
 import { ClientMessage } from '../../src/telemetry/ClientMessage';
 import { Closeable } from '../../src/utils/Closeable';
@@ -370,6 +371,7 @@ export function createMockComponents(o: Partial<CfnLspServerComponentsType> = {}
         stackManagementInfoProvider:
             overrides.stackManagementInfoProvider ?? stubInterface<StackManagementInfoProvider>(),
         stackManager: overrides.stackManager ?? stubInterface<StackManager>(),
+        stackEventManager: overrides.stackEventManager ?? stubInterface<StackEventManager>(),
         validationWorkflowService: overrides.validationWorkflowService ?? createMockValidationWorkflowService(),
         deploymentWorkflowService: overrides.deploymentWorkflowService ?? createMockDeploymentWorkflowService(),
         changeSetDeletionWorkflowService:


### PR DESCRIPTION
*Description of changes:*
- fetches stack events
- retrieves until last observed event up to a max of 5 pages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
