### PR TITLE
Fix list-stack-resource handler with pagination

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -342,9 +342,11 @@ export function listStackResourcesHandler(
             const response = await components.cfnService.listStackResources({
                 StackName: params.stackName,
                 NextToken: params.nextToken,
-                MaxItems: params.maxItems,
             });
-            return { resources: response.StackResourceSummaries ?? [] };
+            return {
+                resources: response.StackResourceSummaries ?? [],
+                nextToken: response.NextToken,
+            };
         } catch (error) {
             log.error({ error: extractErrorMessage(error) }, 'Error listing stack resources');
             return { resources: [] };

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -50,11 +50,11 @@ export const ListChangeSetRequest = new RequestType<ListChangeSetParams, ListCha
 export type ListStackResourcesParams = {
     stackName: string;
     nextToken?: string;
-    maxItems?: number;
 };
 
 export type ListStackResourcesResult = {
     resources: StackResourceSummary[];
+    nextToken?: string;
 };
 
 export const ListStackResourcesRequest = new RequestType<ListStackResourcesParams, ListStackResourcesResult, void>(

--- a/tst/unit/handlers/StackHandler.test.ts
+++ b/tst/unit/handlers/StackHandler.test.ts
@@ -467,19 +467,20 @@ describe('StackActionHandler', () => {
 
             mockComponents.cfnService.listStackResources.resolves({
                 StackResourceSummaries: mockResources,
+                NextToken: 'nextToken456',
                 $metadata: {},
             });
 
             const handler = listStackResourcesHandler(mockComponents);
-            const params = { stackName: 'test-stack', nextToken: 'token123', maxItems: 10 };
+            const params = { stackName: 'test-stack', nextToken: 'token123' };
             const result = (await handler(params, {} as any)) as ListStackResourcesResult;
 
             expect(result.resources).toEqual(mockResources);
+            expect(result.nextToken).toBe('nextToken456');
             expect(
                 mockComponents.cfnService.listStackResources.calledWith({
                     StackName: 'test-stack',
                     NextToken: 'token123',
-                    MaxItems: 10,
                 }),
             ).toBe(true);
         });
@@ -502,6 +503,7 @@ describe('StackActionHandler', () => {
             const result = (await handler(params, {} as any)) as ListStackResourcesResult;
 
             expect(result.resources).toEqual([]);
+            expect(result.nextToken).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
*Issue #, if available:*
MaxItem field does not exist in list-stack-resource API, and we did not return nextToken

*Description of changes:*
- Removed MaxItem field
- return nextToken in response so the client can send token

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
