### PR TITLE
Clean up debug logs, use pino to handle exception logging

### DIFF
--- a/src/ai/CfnAI.ts
+++ b/src/ai/CfnAI.ts
@@ -7,7 +7,6 @@ import { getFilteredScannedResources, formatScannedResourcesForAI } from '../ser
 import { SettingsConfigurable, ISettingsSubscriber } from '../settings/ISettingsSubscriber';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Closeable } from '../utils/Closeable';
-import { extractErrorMessage } from '../utils/Errors';
 import { toString } from '../utils/String';
 import { Agent } from './Agent';
 import { LLMConfig } from './llm/LLMConfig';
@@ -47,7 +46,7 @@ export class CfnAI implements SettingsConfigurable, Closeable {
         try {
             return (await this.mcpTools?.getAllTools()) ?? [];
         } catch (error) {
-            logger.warn({ error: extractErrorMessage(error) }, 'Failed to get MCP tools, continuing without tools');
+            logger.warn(error, 'Failed to get MCP tools, continuing without tools');
             return [];
         }
     }
@@ -129,7 +128,7 @@ export class CfnAI implements SettingsConfigurable, Closeable {
                     logger.info('No resource scan available');
                 }
             } catch (error) {
-                logger.warn({ error: extractErrorMessage(error) }, 'Failed to get resource scan data');
+                logger.warn(error, 'Failed to get resource scan data');
             }
 
             return await agent.execute(

--- a/src/ai/McpTools.ts
+++ b/src/ai/McpTools.ts
@@ -4,7 +4,6 @@ import { SettingsConfigurable, ISettingsSubscriber, SettingsSubscription } from 
 import { DefaultSettings, ProfileSettings } from '../settings/Settings';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Closeable } from '../utils/Closeable';
-import { extractErrorMessage } from '../utils/Errors';
 
 const logger = LoggerFactory.getLogger('McpTools');
 
@@ -57,7 +56,7 @@ export class McpTools implements SettingsConfigurable, Closeable {
             await this.mcpClient.initializeConnections();
             logger.info('Initialized MCP tools');
         } catch (error) {
-            logger.error({ error: extractErrorMessage(error) }, 'Failed to initialize MCP tools');
+            logger.error(error, 'Failed to initialize MCP tools');
         }
     }
 
@@ -67,7 +66,7 @@ export class McpTools implements SettingsConfigurable, Closeable {
 
             if (this.mcpClient) {
                 await this.mcpClient.close().catch((error: unknown) => {
-                    logger.error({ error }, 'Failed to close MCP client');
+                    logger.error(error, 'Failed to close MCP client');
                 });
             }
             await this.initializeMCP();

--- a/src/ai/llm/LLMConfig.ts
+++ b/src/ai/llm/LLMConfig.ts
@@ -3,7 +3,6 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { DeepReadonly } from 'ts-essentials';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../../utils/Errors';
 import { parseWithPrettyError } from '../../utils/ZodErrorWrapper';
 import { LLMConfigType, parseLLMConfig } from './LLMTypes';
 
@@ -27,7 +26,7 @@ export class LLMConfig {
             logger.info({ provider: llmConfig.provider, model: llmConfig.model }, 'LLM configuration');
             return llmConfig;
         } catch (error) {
-            logger.error(`Failed to parse LLM config. ${extractErrorMessage(error)}`);
+            logger.error(error, `Failed to parse LLM config`);
         }
     }
 

--- a/src/auth/AwsCredentials.ts
+++ b/src/auth/AwsCredentials.ts
@@ -5,7 +5,6 @@ import { LspAuthHandlers } from '../protocol/LspAuthHandlers';
 import { DefaultSettings } from '../settings/Settings';
 import { SettingsManager } from '../settings/SettingsManager';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../utils/Errors';
 import { getRegion } from '../utils/Region';
 import { parseWithPrettyError } from '../utils/ZodErrorWrapper';
 import { UpdateCredentialsParams, IamCredentials } from './AwsLspAuthTypes';
@@ -63,7 +62,7 @@ export class AwsCredentials {
         } catch (error) {
             this.iamCredentials = undefined;
 
-            this.logger.error(`Failed to update IAM credentials: ${extractErrorMessage(error)}`);
+            this.logger.error(error, `Failed to update IAM credentials`);
             this.settingsManager.updateProfileSettings(DefaultSettings.profile.profile, DefaultSettings.profile.region);
             return false;
         }

--- a/src/autocomplete/CompletionFormatter.ts
+++ b/src/autocomplete/CompletionFormatter.ts
@@ -49,7 +49,7 @@ export class CompletionFormatter {
                 items: formattedItems,
             };
         } catch (error) {
-            CompletionFormatter.log.warn({ error }, 'Failed to adapt completions');
+            CompletionFormatter.log.warn(error, 'Failed to adapt completions');
             return completions;
         }
     }

--- a/src/autocomplete/ConditionCompletionProvider.ts
+++ b/src/autocomplete/ConditionCompletionProvider.ts
@@ -22,14 +22,6 @@ export class ConditionCompletionProvider implements CompletionProvider {
     public constructor(private readonly syntaxTreeManager: SyntaxTreeManager) {}
 
     public getCompletions(context: Context, params: CompletionParams): CompletionItem[] | undefined {
-        this.log.debug(
-            {
-                provider: 'Condition Completion',
-                position: params.position,
-            },
-            'Processing condition completion request',
-        );
-
         const syntaxTree = this.syntaxTreeManager.getSyntaxTree(params.textDocument.uri);
         if (!syntaxTree) {
             return;

--- a/src/autocomplete/RelatedResourcesInlineCompletionProvider.ts
+++ b/src/autocomplete/RelatedResourcesInlineCompletionProvider.ts
@@ -30,16 +30,6 @@ export class RelatedResourcesInlineCompletionProvider implements InlineCompletio
         context: Context,
         params: InlineCompletionParams,
     ): Promise<InlineCompletionItem[]> | InlineCompletionItem[] | undefined {
-        this.log.debug(
-            {
-                provider: 'RelatedResourcesInlineCompletion',
-                position: params.position,
-                section: context.section,
-                propertyPath: context.propertyPath,
-            },
-            'Processing related resources inline completion request',
-        );
-
         try {
             const document = this.documentManager.get(params.textDocument.uri);
             if (!document) {
@@ -62,7 +52,7 @@ export class RelatedResourcesInlineCompletionProvider implements InlineCompletio
 
             return this.generateInlineCompletionItems(relatedResourceTypes, params);
         } catch (error) {
-            this.log.error({ error: String(error) }, 'Error generating related resources inline completion');
+            this.log.error(error, 'Error generating related resources inline completion');
             return undefined;
         }
     }
@@ -184,10 +174,7 @@ export class RelatedResourcesInlineCompletionProvider implements InlineCompletio
 
             return this.formatSnippetForDocumentType(snippet, documentType, params);
         } catch (error) {
-            this.log.warn(
-                { error: String(error), resourceType },
-                'Error generating property snippet, falling back to simple format',
-            );
+            this.log.warn(error, `Error generating property snippet, falling back to simple format ${resourceType}`);
             return this.formatSnippetForDocumentType(
                 documentType === DocumentType.JSON
                     ? `"${logicalId}": {\n${indent1}"Type": "${resourceType}"\n}`

--- a/src/autocomplete/ResourceSectionCompletionProvider.ts
+++ b/src/autocomplete/ResourceSectionCompletionProvider.ts
@@ -33,18 +33,6 @@ export class ResourceSectionCompletionProvider implements CompletionProvider {
         context: Context,
         params: CompletionParams,
     ): Promise<CompletionItem[]> | CompletionItem[] | undefined {
-        this.log.debug(
-            {
-                provider: 'Resource Completion',
-                position: params.position,
-                entitySection: context.entitySection,
-                propertyPath: context.propertyPath,
-                atEntityKeyLevel: context.atEntityKeyLevel(),
-                text: context.text,
-            },
-            'Processing resource completion request',
-        );
-
         if (context.atEntityKeyLevel()) {
             return this.resourceProviders
                 .get(ResourceCompletionType.Entity)
@@ -77,7 +65,7 @@ export class ResourceSectionCompletionProvider implements CompletionProvider {
                             return [...stateCompletion, ...schemaPropertyCompletions];
                         })
                         .catch((error) => {
-                            this.log.debug(error, 'Received error from resource state autocomplete');
+                            this.log.warn(error, 'Received error from resource state autocomplete');
                             // Fallback to just property completions if state completions fail
                             return schemaPropertyCompletions;
                         });

--- a/src/context/ContextManager.ts
+++ b/src/context/ContextManager.ts
@@ -2,7 +2,7 @@ import { SyntaxNode } from 'tree-sitter';
 import { TextDocumentPositionParams } from 'vscode-languageserver-protocol/lib/common/protocol';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Track } from '../telemetry/TelemetryDecorator';
-import { extractErrorMessage } from '../utils/Errors';
+import { toString } from '../utils/String';
 import { Context } from './Context';
 import { ContextWithRelatedEntities } from './ContextWithRelatedEntities';
 import { PathAndEntity, SyntaxTree } from './syntaxtree/SyntaxTree';
@@ -29,14 +29,7 @@ export class ContextManager {
                 contextParams.pathInfo.entityRootNode,
             );
         } catch (error) {
-            this.log.error(
-                {
-                    error: extractErrorMessage(error),
-                    uri: params.textDocument.uri,
-                    position: params.position,
-                },
-                'Could not get context',
-            );
+            this.log.error(error, `Could not get context ${params.textDocument.uri} ${toString(params.position)}`);
         }
 
         return undefined;
@@ -65,14 +58,7 @@ export class ContextManager {
                 fullEntitySearch,
             );
         } catch (error) {
-            this.log.error(
-                {
-                    error: extractErrorMessage(error),
-                    uri: params.textDocument.uri,
-                    position: params.position,
-                },
-                'Could not get context',
-            );
+            this.log.error(error, `Could not get context ${params.textDocument.uri} ${toString(params.position)}`);
         }
 
         return undefined;
@@ -100,14 +86,7 @@ export class ContextManager {
 
             return { context, fullyResolved: result.fullyResolved };
         } catch (error) {
-            this.log.error(
-                {
-                    error: extractErrorMessage(error),
-                    uri,
-                    pathSegments,
-                },
-                'Could not get context from path',
-            );
+            this.log.error(error, `Could not get context from path ${uri} ${toString(pathSegments)}`);
         }
 
         return { context: undefined, fullyResolved: false };
@@ -117,7 +96,6 @@ export class ContextManager {
         const uri = params.textDocument.uri;
         const [tree, currentNode] = this.getFromTree(uri, (tree) => tree.getNodeAtPosition(params.position));
         if (!currentNode || !tree) {
-            this.log.debug({ uri }, 'No syntax node found at position');
             return undefined;
         }
 

--- a/src/context/FileContext.ts
+++ b/src/context/FileContext.ts
@@ -43,7 +43,7 @@ export class FileContext {
 
             this.cacheSectionsAndEntities(parsed);
         } catch (error) {
-            this.log.error({ error, uri: this.uri }, `Failed to parse and cache ${this.documentType} document`);
+            this.log.error(error, `Failed to parse and cache ${this.documentType} document ${this.uri}`);
         }
     }
 
@@ -91,7 +91,7 @@ export class FileContext {
                 createEntityFromObject(logicalId, parseObject(data, this.documentType), section),
             );
         } catch (error) {
-            this.log.error({ error, uri: this.uri, section }, 'Failed to create entities for section');
+            this.log.error(error, `Failed to create entities for section ${this.uri} - ${section}`);
             return [];
         }
     }

--- a/src/context/FileContextManager.ts
+++ b/src/context/FileContextManager.ts
@@ -15,19 +15,17 @@ export class FileContextManager {
     public getFileContext(uri: string): FileContext | undefined {
         const document = this.documentManager.get(uri);
         if (!document) {
-            this.log.debug({ uri }, 'Document not found');
             return undefined;
         }
 
         if (!this.documentManager.isTemplate(uri)) {
-            this.log.debug({ uri }, 'Document is not a CloudFormation template');
             return undefined;
         }
 
         try {
             return new FileContext(uri, document.documentType, document.contents());
         } catch (error) {
-            this.log.error({ error, uri }, 'Failed to create file context');
+            this.log.error(error, `Failed to create file context ${uri}`);
             return undefined;
         }
     }

--- a/src/context/SectionContextBuilder.ts
+++ b/src/context/SectionContextBuilder.ts
@@ -25,7 +25,7 @@ export function contextEntitiesInSections(
         try {
             entityNodes = findEntityNodesInSection(sectionNode, syntaxTree.type, targetLogicalIds);
         } catch (error) {
-            log.warn({ error, section }, 'Failed to process entities in section');
+            log.warn(error, `Failed to process entities in section ${section}`);
             continue;
         }
 
@@ -41,7 +41,7 @@ export function contextEntitiesInSections(
                     entities.set(context.logicalId, context);
                 }
             } catch (error) {
-                log.warn({ error, section }, 'Failed to create context for entity in section');
+                log.warn(error, `Failed to create context for entity in section ${section}`);
             }
         }
 

--- a/src/context/semantic/EntityBuilder.ts
+++ b/src/context/semantic/EntityBuilder.ts
@@ -42,7 +42,7 @@ export function nodeToEntity(type: DocumentType, node: SyntaxNode | undefined, s
             entityObject = nodeToObject(node, type)?.[id];
         }
     } catch (error) {
-        log.error({ error }, 'Error creating entity');
+        log.error(error, 'Error creating entity');
         entityObject = undefined;
     }
 

--- a/src/context/syntaxtree/SyntaxTreeManager.ts
+++ b/src/context/syntaxtree/SyntaxTreeManager.ts
@@ -3,7 +3,6 @@ import { CloudFormationFileType, DocumentType } from '../../document/Document';
 import { detectDocumentType } from '../../document/DocumentUtils';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { Measure } from '../../telemetry/TelemetryDecorator';
-import { extractErrorMessage } from '../../utils/Errors';
 import { JsonSyntaxTree } from './JsonSyntaxTree';
 import { SyntaxTree } from './SyntaxTree';
 import { YamlSyntaxTree } from './YamlSyntaxTree';
@@ -31,7 +30,7 @@ export class SyntaxTreeManager {
         try {
             this.createTree(uri, content, type, cfnFileType);
         } catch (error) {
-            logger.error(`Failed to create tree ${uri} ${type} ${cfnFileType}: ${extractErrorMessage(error)}`);
+            logger.error(error, `Failed to create tree ${uri} ${type} ${cfnFileType}`);
         }
     }
 
@@ -71,7 +70,7 @@ export class SyntaxTreeManager {
         try {
             this.getSyntaxTree(uri)?.update(text, startPoint, endPoint);
         } catch (error) {
-            this.log.error({ error: extractErrorMessage(error), uri }, 'Failed to update tree');
+            this.log.error(error, `Failed to update tree ${uri}`);
         }
     }
 
@@ -79,7 +78,7 @@ export class SyntaxTreeManager {
         try {
             this.getSyntaxTree(uri)?.updateWithEdit(content, edit);
         } catch (error) {
-            this.log.error({ error: extractErrorMessage(error), uri }, 'Failed to update tree');
+            this.log.error(error, `Failed to update tree ${uri}`);
         }
     }
 

--- a/src/datastore/LMDB.ts
+++ b/src/datastore/LMDB.ts
@@ -6,7 +6,6 @@ import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
 import { Telemetry } from '../telemetry/TelemetryDecorator';
 import { TelemetryService } from '../telemetry/TelemetryService';
 import { pathToArtifact } from '../utils/ArtifactsDir';
-import { extractErrorMessage } from '../utils/Errors';
 import { DataStore, DataStoreFactory } from './DataStore';
 import { encryptionStrategy } from './lmdb/Utils';
 
@@ -130,7 +129,7 @@ export class LMDBStoreFactory implements DataStoreFactory {
                     rmSync(join(this.rootDir, entry.name), { recursive: true, force: true });
                 }
             } catch (error) {
-                log.error({ error: extractErrorMessage(error) }, 'Failed to cleanup old LMDB versions');
+                log.error(error, 'Failed to cleanup old LMDB versions');
                 this.telemetry.count('oldVersion.cleanup.error', 1, { unit: '1' });
             }
         }

--- a/src/document/Document.ts
+++ b/src/document/Document.ts
@@ -1,7 +1,6 @@
 import { TextDocument, Position, Range, DocumentUri } from 'vscode-languageserver-textdocument';
 import { DefaultSettings } from '../settings/Settings';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../utils/Errors';
 import { detectCfnFileType } from './CloudFormationDetection';
 import { DocumentMetadata } from './DocumentProtocol';
 import { detectDocumentType, uriToPath } from './DocumentUtils';
@@ -33,13 +32,7 @@ export class Document {
             this.cfnFileType = detectCfnFileType(this.textDocument.getText(), this.documentType);
         } catch (error) {
             this.cfnFileType = CloudFormationFileType.Unknown;
-            this.log.error(
-                {
-                    error: extractErrorMessage(error),
-                    uri: this.textDocument.uri,
-                },
-                'Failed to detect CloudFormation file type',
-            );
+            this.log.error(error, `Failed to detect CloudFormation file type ${this.textDocument.uri}`);
         }
         this.tabSize = fallbackTabSize;
         this.processIndentation(detectIndentation, fallbackTabSize);

--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -97,7 +97,7 @@ export class DocumentManager implements SettingsConfigurable {
                 delay,
             )
             .catch((error) => {
-                this.log.debug(error);
+                this.log.error(error, 'Failed to send document metadata');
             });
     }
 

--- a/src/documentSymbol/DocumentSymbolRouter.ts
+++ b/src/documentSymbol/DocumentSymbolRouter.ts
@@ -8,7 +8,6 @@ import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
 import { FieldNames } from '../context/syntaxtree/utils/TreeSitterTypes';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Track } from '../telemetry/TelemetryDecorator';
-import { extractErrorMessage } from '../utils/Errors';
 import { nodeToRange, pointToPosition } from '../utils/TypeConverters';
 
 // Configuration for CloudFormation sections - defines all section behavior in one place
@@ -123,7 +122,7 @@ export class DocumentSymbolRouter {
 
             return symbols;
         } catch (error) {
-            log.error(`Error creating document symbols for ${params.textDocument.uri}: ${extractErrorMessage(error)}`);
+            log.error(error, `Error creating document symbols for ${params.textDocument.uri}`);
             return [];
         }
     }
@@ -227,9 +226,9 @@ export class DocumentSymbolRouter {
                 }
             }
         } catch (error) {
-            this.log.debug(
-                { error, logicalId, entityType },
-                'Failed to extract type information from entity during document symbol creation',
+            this.log.warn(
+                error,
+                `Failed to extract type information from entity during document symbol creation ${logicalId} ${entityType}`,
             );
         }
 

--- a/src/featureFlag/FeatureFlagProvider.ts
+++ b/src/featureFlag/FeatureFlagProvider.ts
@@ -5,7 +5,6 @@ import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Measure } from '../telemetry/TelemetryDecorator';
 import { Closeable } from '../utils/Closeable';
 import { AwsEnv } from '../utils/Environment';
-import { extractErrorMessage } from '../utils/Errors';
 import { FeatureFlag, TargetedFeatureFlag } from './FeatureFlagI';
 import { FeatureFlagSupplier, FeatureFlagConfigKey, TargetedFeatureFlagConfigKey } from './FeatureFlagSupplier';
 
@@ -30,7 +29,7 @@ export class FeatureFlagProvider implements Closeable {
         this.timeout = setInterval(
             () => {
                 this.refresh().catch((err) => {
-                    log.error(`Failed to sync feature flags from remote: ${extractErrorMessage(err)}`);
+                    log.error(err, `Failed to sync feature flags from remote`);
                 });
             },
             5 * 60 * 1000,

--- a/src/handlers/CodeActionHandler.ts
+++ b/src/handlers/CodeActionHandler.ts
@@ -2,7 +2,6 @@ import { CodeActionParams, CodeAction, Command } from 'vscode-languageserver';
 import { ServerRequestHandler } from 'vscode-languageserver/lib/common/server';
 import { ServerComponents } from '../server/ServerComponents';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../utils/Errors';
 
 const log = LoggerFactory.getLogger('CodeActionHandler');
 
@@ -10,18 +9,10 @@ export function codeActionHandler(
     components: ServerComponents,
 ): ServerRequestHandler<CodeActionParams, (Command | CodeAction)[] | undefined | null, (Command | CodeAction)[], void> {
     return (params, _token, _workDoneProgress, _resultProgress) => {
-        log.debug({
-            Handler: 'CodeAction',
-            Document: params.textDocument.uri,
-            Range: params.range,
-            Context: params.context,
-        });
-
         try {
-            // Generate code actions using the service
             return components.codeActionService.generateCodeActions(params);
         } catch (error) {
-            log.error(`Error in CodeAction handler: ${extractErrorMessage(error)}`);
+            log.error(error, `Error in CodeAction handler`);
             return [];
         }
     };

--- a/src/handlers/CodeLensHandler.ts
+++ b/src/handlers/CodeLensHandler.ts
@@ -1,19 +1,11 @@
 import { CodeLens, CodeLensParams } from 'vscode-languageserver';
 import { ServerRequestHandler } from 'vscode-languageserver/lib/common/server';
 import { ServerComponents } from '../server/ServerComponents';
-import { LoggerFactory } from '../telemetry/LoggerFactory';
-
-const log = LoggerFactory.getLogger('CodeLensHandler');
 
 export function codeLensHandler(
     components: ServerComponents,
 ): ServerRequestHandler<CodeLensParams, CodeLens[] | undefined | null, CodeLens[], void> {
     return (params, _token, _workDoneProgress, _resultProgress) => {
-        log.debug({
-            Handler: 'CodeLens',
-            Document: params.textDocument.uri,
-        });
-
         return components.codeLensProvider.getCodeLenses(params.textDocument.uri);
     };
 }

--- a/src/handlers/CompletionHandler.ts
+++ b/src/handlers/CompletionHandler.ts
@@ -1,9 +1,6 @@
 import { CompletionParams, CompletionList, CompletionItem } from 'vscode-languageserver';
 import { ServerRequestHandler } from 'vscode-languageserver/lib/common/server';
 import { ServerComponents } from '../server/ServerComponents';
-import { LoggerFactory } from '../telemetry/LoggerFactory';
-
-const log = LoggerFactory.getLogger('CompletionHandler');
 
 export function completionHandler(
     components: ServerComponents,
@@ -14,11 +11,6 @@ export function completionHandler(
     void
 > {
     return (params, _token, _workDoneProgress, _resultProgress) => {
-        log.debug({
-            Handler: 'Completion',
-            Document: params.textDocument.uri,
-            Position: params.position,
-        });
         return components.completionRouter.getCompletions(params);
     };
 }

--- a/src/handlers/ConfigurationHandler.ts
+++ b/src/handlers/ConfigurationHandler.ts
@@ -1,20 +1,14 @@
 import { DidChangeConfigurationParams } from 'vscode-languageserver';
 import { ServerComponents } from '../server/ServerComponents';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../utils/Errors';
 
 const log = LoggerFactory.getLogger('ConfigurationHandler');
 
 export function configurationHandler(components: ServerComponents): (params: DidChangeConfigurationParams) => void {
-    return (params: DidChangeConfigurationParams): void => {
-        log.debug({
-            Handler: 'Configuration',
-            Settings: params.settings, // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-        });
-
+    return (_params: DidChangeConfigurationParams): void => {
         // Pull configuration from LSP workspace and notify all components via subscriptions (fire-and-forget)
         components.settingsManager.syncConfiguration().catch((error) => {
-            log.error(`Failed to sync configuration: ${extractErrorMessage(error)}`);
+            log.error(error, `Failed to sync configuration`);
         });
     };
 }

--- a/src/handlers/DefinitionHandler.ts
+++ b/src/handlers/DefinitionHandler.ts
@@ -1,9 +1,6 @@
 import { DefinitionParams, Location, Definition, DefinitionLink } from 'vscode-languageserver';
 import { ServerRequestHandler } from 'vscode-languageserver/lib/common/server';
 import { ServerComponents } from '../server/ServerComponents';
-import { LoggerFactory } from '../telemetry/LoggerFactory';
-
-const log = LoggerFactory.getLogger('DefinitionHandler');
 
 export function definitionHandler(
     components: ServerComponents,
@@ -14,12 +11,6 @@ export function definitionHandler(
     void
 > {
     return (params, _token, _workDoneProgress, _resultProgress) => {
-        log.debug({
-            Handler: 'Definition',
-            Document: params.textDocument.uri,
-            Position: params.position,
-        });
-
         return components.definitionProvider.getDefinitions(params);
     };
 }

--- a/src/handlers/DocumentSymbolHandler.ts
+++ b/src/handlers/DocumentSymbolHandler.ts
@@ -1,19 +1,11 @@
 import { DocumentSymbol, DocumentSymbolParams } from 'vscode-languageserver';
 import { ServerRequestHandler } from 'vscode-languageserver/lib/common/server';
 import { ServerComponents } from '../server/ServerComponents';
-import { LoggerFactory } from '../telemetry/LoggerFactory';
-
-const log = LoggerFactory.getLogger('DocumentSymbolHandler');
 
 export function documentSymbolHandler(
     components: ServerComponents,
 ): ServerRequestHandler<DocumentSymbolParams, DocumentSymbol[] | null | undefined, DocumentSymbol[], void> {
     return (params, _token, _workDoneProgress, _resultProgress) => {
-        log.debug({
-            Handler: 'DocumentSymbol',
-            Document: params.textDocument.uri,
-        });
-
         return components.documentSymbolRouter.getDocumentSymbols(params);
     };
 }

--- a/src/handlers/ExecutionHandler.ts
+++ b/src/handlers/ExecutionHandler.ts
@@ -16,12 +16,6 @@ export function executionHandler(
     return (params): unknown => {
         TelemetryService.instance.get('ExecutionHandler').count(`execute.${params.command}`, 1, { unit: '1' });
 
-        log.debug({
-            Handler: 'Execution',
-            Command: params.command,
-            Arguments: params.arguments,
-        });
-
         switch (params.command) {
             case DESCRIBE_TEMPLATE: {
                 return executeWithError(components, async () => {
@@ -70,7 +64,7 @@ export function executionHandler(
                     const diagnosticId = args[1] as string;
                     components.diagnosticCoordinator
                         .handleClearCfnDiagnostic(uri, diagnosticId)
-                        .catch((err) => log.error(`Error clearing diagnostic: ${extractErrorMessage(err)}`));
+                        .catch((err) => log.error(err, `Error clearing diagnostic`));
                 }
                 break;
             }

--- a/src/handlers/HoverHandler.ts
+++ b/src/handlers/HoverHandler.ts
@@ -1,20 +1,11 @@
 import { Hover, HoverParams, MarkupKind } from 'vscode-languageserver';
 import { ServerRequestHandler } from 'vscode-languageserver/lib/common/server';
 import { ServerComponents } from '../server/ServerComponents';
-import { LoggerFactory } from '../telemetry/LoggerFactory';
-
-const log = LoggerFactory.getLogger('HoverHandler');
 
 export function hoverHandler(
     components: ServerComponents,
 ): ServerRequestHandler<HoverParams, Hover | undefined | null, never, void> {
     return (params, _token, _workDoneProgress, _resultProgress) => {
-        log.debug({
-            Handler: 'Hover',
-            Document: params.textDocument.uri,
-            Position: params.position,
-        });
-
         const doc = components.hoverRouter.getHoverDoc(params);
         if (doc === undefined) {
             return {

--- a/src/handlers/Initialize.ts
+++ b/src/handlers/Initialize.ts
@@ -1,7 +1,6 @@
 import { LspWorkspace } from '../protocol/LspWorkspace';
 import { ServerComponents } from '../server/ServerComponents';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../utils/Errors';
 
 const logger = LoggerFactory.getLogger('InitializedHandler');
 
@@ -20,12 +19,12 @@ export function initializedHandler(workspace: LspWorkspace, components: ServerCo
                         // Properly await the async mountFolder method
                         await components.cfnLintService.mountFolder(folder);
                     } catch (error) {
-                        logger.error(`Failed to mount folder ${folder.name}: ${extractErrorMessage(error)}`);
+                        logger.error(error, `Failed to mount folder ${folder.name}`);
                     }
                 }
             })
             .catch((error: unknown) => {
-                logger.error(`Failed to initialize server: ${extractErrorMessage(error)}`);
+                logger.error(error, `Failed to initialize server`);
             });
     };
 }

--- a/src/handlers/InlineCompletionHandler.ts
+++ b/src/handlers/InlineCompletionHandler.ts
@@ -1,20 +1,11 @@
 import { RequestHandler } from 'vscode-languageserver/node';
 import { InlineCompletionParams, InlineCompletionList, InlineCompletionItem } from 'vscode-languageserver-protocol';
 import { ServerComponents } from '../server/ServerComponents';
-import { LoggerFactory } from '../telemetry/LoggerFactory';
-
-const log = LoggerFactory.getLogger('InlineCompletionHandler');
 
 export function inlineCompletionHandler(
     components: ServerComponents,
 ): RequestHandler<InlineCompletionParams, InlineCompletionList | InlineCompletionItem[] | null | undefined, void> {
     return (params, _token) => {
-        log.debug({
-            Handler: 'InlineCompletion',
-            Document: params.textDocument.uri,
-            Position: params.position,
-            TriggerKind: params.context.triggerKind,
-        });
         return components.inlineCompletionRouter.getInlineCompletions(params);
     };
 }

--- a/src/handlers/ResourceHandler.ts
+++ b/src/handlers/ResourceHandler.ts
@@ -33,7 +33,7 @@ export function getResourceTypesHandler(
             const resourceTypes = components.resourceStateManager.getResourceTypes();
             return { resourceTypes };
         } catch (error) {
-            log.error({ error: extractErrorMessage(error) }, 'Error getting resource types');
+            log.error(error, 'Error getting resource types');
             return { resourceTypes: [] };
         }
     };
@@ -67,7 +67,7 @@ export function listResourcesHandler(
 
             return { resources };
         } catch (error) {
-            log.error({ error: extractErrorMessage(error) }, 'Error listing resources');
+            log.error(error, 'Error listing resources');
             return { resources: [] };
         }
     };

--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -50,8 +50,6 @@ export function getParametersHandler(
     components: ServerComponents,
 ): RequestHandler<TemplateUri, GetParametersResult, void> {
     return (rawParams) => {
-        log.debug({ Handler: 'getParametersHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseTemplateUriParams, rawParams);
             const syntaxTree = components.syntaxTreeManager.getSyntaxTree(params);
@@ -78,8 +76,6 @@ export function createValidationHandler(
     components: ServerComponents,
 ): RequestHandler<CreateValidationParams, CreateStackActionResult, void> {
     return async (rawParams) => {
-        log.debug({ Handler: 'createValidationHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseStackActionParams, rawParams);
             return await components.validationWorkflowService.start(params);
@@ -93,8 +89,6 @@ export function createDeploymentHandler(
     components: ServerComponents,
 ): RequestHandler<CreateDeploymentParams, CreateStackActionResult, void> {
     return async (rawParams) => {
-        log.debug({ Handler: 'createDeploymentHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseCreateDeploymentParams, rawParams);
             return await components.deploymentWorkflowService.start(params);
@@ -108,8 +102,6 @@ export function getValidationStatusHandler(
     components: ServerComponents,
 ): RequestHandler<Identifiable, GetStackActionStatusResult, void> {
     return (rawParams) => {
-        log.debug({ Handler: 'getValidationStatusHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseIdentifiable, rawParams);
             return components.validationWorkflowService.getStatus(params);
@@ -123,8 +115,6 @@ export function getDeploymentStatusHandler(
     components: ServerComponents,
 ): RequestHandler<Identifiable, GetStackActionStatusResult, void> {
     return (rawParams) => {
-        log.debug({ Handler: 'getDeploymentStatusHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseIdentifiable, rawParams);
             return components.deploymentWorkflowService.getStatus(params);
@@ -138,8 +128,6 @@ export function describeValidationStatusHandler(
     components: ServerComponents,
 ): RequestHandler<Identifiable, DescribeValidationStatusResult, void> {
     return (rawParams) => {
-        log.debug({ Handler: 'describeValidationStatusHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseIdentifiable, rawParams);
             return components.validationWorkflowService.describeStatus(params);
@@ -153,8 +141,6 @@ export function describeDeploymentStatusHandler(
     components: ServerComponents,
 ): RequestHandler<Identifiable, DescribeDeploymentStatusResult, void> {
     return (rawParams) => {
-        log.debug({ Handler: 'describeDeploymentStatusHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseIdentifiable, rawParams);
             return components.deploymentWorkflowService.describeStatus(params);
@@ -168,8 +154,6 @@ export function deleteChangeSetHandler(
     components: ServerComponents,
 ): RequestHandler<DeleteChangeSetParams, CreateStackActionResult, void> {
     return async (rawParams) => {
-        log.debug({ Handler: 'deleteChangeSetHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseDeleteChangeSetParams, rawParams);
             return await components.changeSetDeletionWorkflowService.start(params);
@@ -183,8 +167,6 @@ export function getChangeSetDeletionStatusHandler(
     components: ServerComponents,
 ): RequestHandler<Identifiable, GetStackActionStatusResult, void> {
     return (rawParams) => {
-        log.debug({ Handler: 'getChangeSetDeletionStatusHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseIdentifiable, rawParams);
             return components.changeSetDeletionWorkflowService.getStatus(params);
@@ -198,8 +180,6 @@ export function describeChangeSetDeletionStatusHandler(
     components: ServerComponents,
 ): RequestHandler<Identifiable, DescribeDeletionStatusResult, void> {
     return (rawParams) => {
-        log.debug({ Handler: 'describeChangeSetDeletionStatusHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseIdentifiable, rawParams);
             return components.changeSetDeletionWorkflowService.describeStatus(params);
@@ -213,8 +193,6 @@ export function getCapabilitiesHandler(
     components: ServerComponents,
 ): RequestHandler<TemplateUri, GetCapabilitiesResult, void> {
     return async (rawParams) => {
-        log.debug({ Handler: 'getCapabilitiesHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseTemplateUriParams, rawParams);
             const document = components.documentManager.get(params);
@@ -235,8 +213,6 @@ export function getTemplateResourcesHandler(
     components: ServerComponents,
 ): RequestHandler<TemplateUri, GetTemplateResourcesResult, void> {
     return (rawParams) => {
-        log.debug({ Handler: 'getTemplateResourcesHandler', rawParams });
-
         try {
             const params = parseWithPrettyError(parseTemplateUriParams, rawParams);
             const syntaxTree = components.syntaxTreeManager.getSyntaxTree(params);
@@ -311,7 +287,7 @@ export function listStacksHandler(
                 params.loadMore,
             );
         } catch (error) {
-            log.error({ error: extractErrorMessage(error) }, 'Error listing stacks');
+            log.error(error, 'Error listing stacks');
             return { stacks: [], nextToken: undefined };
         }
     };
@@ -353,7 +329,7 @@ export function listStackResourcesHandler(
                 nextToken: response.NextToken,
             };
         } catch (error) {
-            log.error({ error: extractErrorMessage(error) }, 'Error listing stack resources');
+            log.error(error, 'Error listing stack resources');
             return { resources: [] };
         }
     };

--- a/src/resourceState/ResourceStateImporter.ts
+++ b/src/resourceState/ResourceStateImporter.ts
@@ -15,7 +15,6 @@ import { CfnLspProviders } from '../server/CfnLspProviders';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
 import { Telemetry, Measure } from '../telemetry/TelemetryDecorator';
-import { extractErrorMessage } from '../utils/Errors';
 import { ResourceStateManager } from './ResourceStateManager';
 import {
     DeletionPolicyOnImport,
@@ -177,10 +176,7 @@ export class ResourceStateImporter {
                         this.getOrCreate(importResult.failedImports, resourceType, []).push(resourceIdentifier);
                     }
                 } catch (error) {
-                    log.error(
-                        { error: extractErrorMessage(error) },
-                        `Error importing resource state for ${resourceType} id: ${resourceIdentifier}`,
-                    );
+                    log.error(error, `Error importing resource state for ${resourceType} id: ${resourceIdentifier}`);
                     this.getOrCreate(importResult.failedImports, resourceType, []).push(resourceIdentifier);
                 }
             }

--- a/src/schema/GetSchemaTask.ts
+++ b/src/schema/GetSchemaTask.ts
@@ -3,7 +3,6 @@ import { Logger } from 'pino';
 import { DataStore } from '../datastore/DataStore';
 import { CfnService } from '../services/CfnService';
 import { Measure } from '../telemetry/TelemetryDecorator';
-import { extractErrorMessage } from '../utils/Errors';
 import { AwsRegion } from '../utils/Region';
 import { PrivateSchemas, PrivateSchemasType } from './PrivateSchemas';
 import { RegionalSchemas, RegionalSchemasType, SchemaFileType } from './RegionalSchemas';
@@ -88,7 +87,7 @@ export class GetPrivateSchemasTask extends GetSchemaTask {
                 logger?.info(`No private registry schemas found for profile: ${profile}`);
             }
         } catch (error) {
-            logger?.error(`Failed to get private schemas: ${extractErrorMessage(error)}`);
+            logger?.error(error, `Failed to get private schemas`);
             throw error;
         }
     }

--- a/src/services/CodeActionService.ts
+++ b/src/services/CodeActionService.ts
@@ -20,7 +20,6 @@ import { CfnInfraCore } from '../server/CfnInfraCore';
 import { CFN_VALIDATION_SOURCE } from '../stacks/actions/ValidationWorkflow';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Track } from '../telemetry/TelemetryDecorator';
-import { extractErrorMessage } from '../utils/Errors';
 import { pointToPosition } from '../utils/TypeConverters';
 import { ExtractToParameterProvider } from './extractToParameter/ExtractToParameterProvider';
 
@@ -37,7 +36,7 @@ export class CodeActionService {
     private readonly log = LoggerFactory.getLogger(CodeActionService);
 
     private logError(operation: string, error: unknown): void {
-        this.log.error(`Error ${operation}: ${extractErrorMessage(error)}`);
+        this.log.error(error, `Error ${operation}`);
     }
 
     constructor(
@@ -192,7 +191,7 @@ export class CodeActionService {
                 ],
             });
         } else {
-            this.log.debug(`Skipping quickfix for '${propertyName}' - could not determine proper range`);
+            this.log.warn(`Skipping quickfix for '${propertyName}' - could not determine proper range`);
         }
 
         return fixes;
@@ -220,7 +219,7 @@ export class CodeActionService {
         }
 
         // Fallback to the diagnostic range as provided by cfn-lint
-        this.log.debug(`Using fallback diagnostic range`);
+        this.log.warn(`Using fallback diagnostic range`);
         return diagnostic.range;
     }
 
@@ -256,7 +255,6 @@ export class CodeActionService {
                 return { start, end };
             }
 
-            this.log.debug(`No key-value pair found after traversal`);
             return {
                 start: pointToPosition(node.startPosition),
                 end: pointToPosition(node.endPosition),
@@ -379,7 +377,6 @@ export class CodeActionService {
 
                 // If no children exist, we can't determine proper indentation from the structure
                 // This shouldn't happen for valid YAML where we're adding a required property
-                this.log.debug(`No child properties found in block mapping pair - cannot determine indentation`);
                 return undefined;
             }
 

--- a/src/services/DiagnosticCoordinator.ts
+++ b/src/services/DiagnosticCoordinator.ts
@@ -5,7 +5,6 @@ import { FieldNames } from '../context/syntaxtree/utils/TreeSitterTypes';
 import { LspDiagnostics } from '../protocol/LspDiagnostics';
 import { CFN_VALIDATION_SOURCE } from '../stacks/actions/ValidationWorkflow';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../utils/Errors';
 
 type SourceToDiagnostics = Map<string, Diagnostic[]>;
 
@@ -55,14 +54,8 @@ export class DiagnosticCoordinator {
             };
 
             await this.lspDiagnostics.publishDiagnostics(params);
-
-            this.log.debug(
-                `Published ${mergedDiagnostics.length} diagnostics for ${uri} from ${collection.size} sources`,
-            );
         } catch (error) {
-            this.log.error(
-                `Failed to publish diagnostics for source ${source}, URI ${uri}: ${extractErrorMessage(error)}`,
-            );
+            this.log.error(error, `Failed to publish diagnostics for source ${source}, URI ${uri}`);
             throw error;
         }
     }
@@ -89,10 +82,8 @@ export class DiagnosticCoordinator {
                 uri,
                 diagnostics: [],
             });
-
-            this.log.debug(`Cleared all diagnostics for ${uri} from ${collection.size} sources`);
         } catch (error) {
-            this.log.error(`Failed to clear all diagnostics for URI ${uri}: ${extractErrorMessage(error)}`);
+            this.log.error(error, `Failed to clear all diagnostics for URI ${uri}`);
             throw error;
         }
     }

--- a/src/services/RelationshipSchemaService.ts
+++ b/src/services/RelationshipSchemaService.ts
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../utils/Errors';
 
 const logger = LoggerFactory.getLogger('RelationshipSchemaService');
 
@@ -55,14 +54,11 @@ export class RelationshipSchemaService {
                         relationships: processedRelationships,
                     });
                 } catch (error) {
-                    logger.warn(
-                        { error: extractErrorMessage(error) },
-                        `Failed to load relationship schema for ${resourceTypeKey}`,
-                    );
+                    logger.warn(error, `Failed to load relationship schema for ${resourceTypeKey}`);
                 }
             }
         } catch (error) {
-            logger.error({ error: extractErrorMessage(error) }, 'Failed to load relationship schemas');
+            logger.error(error, 'Failed to load relationship schemas');
         }
     }
 
@@ -150,7 +146,7 @@ export class RelationshipSchemaService {
                 }
             }
         } catch (error) {
-            logger.warn({ error: extractErrorMessage(error) }, 'Failed to extract resource types from template');
+            logger.warn(error, 'Failed to extract resource types from template');
         }
 
         return [...resourceTypes];

--- a/src/services/ResourceScanService.ts
+++ b/src/services/ResourceScanService.ts
@@ -1,6 +1,5 @@
 import { ScannedResource } from '@aws-sdk/client-cloudformation';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { extractErrorMessage } from '../utils/Errors';
 import { AwsClient } from './AwsClient';
 import { IacGeneratorService } from './IacGeneratorService';
 import { RelationshipSchemaService } from './RelationshipSchemaService';
@@ -56,7 +55,7 @@ export async function getFilteredScannedResources(
 
         return filterResourcesByRelationships(scannedResources, templateResourceTypes, relationshipService);
     } catch (error) {
-        logger.warn({ error: extractErrorMessage(error) }, 'Failed to get resource scan data');
+        logger.warn(error, 'Failed to get resource scan data');
         return undefined;
     }
 }

--- a/src/services/cfnLint/PyodideWorkerManager.ts
+++ b/src/services/cfnLint/PyodideWorkerManager.ts
@@ -95,7 +95,7 @@ export class PyodideWorkerManager {
 
                 // Set up error handler
                 this.worker.on('error', (error) => {
-                    this.log.error({ error }, 'Worker error');
+                    this.log.error(error, 'Worker error');
                     reject(new Error(`Worker error: ${error.message}`));
                 });
 
@@ -225,7 +225,7 @@ export class PyodideWorkerManager {
             try {
                 await this.worker.terminate();
             } catch (error) {
-                this.log.error({ error }, 'Error terminating worker');
+                this.log.error(error, 'Error terminating worker');
             }
             this.worker = undefined;
             this.initialized = false;

--- a/src/services/guard/GuardEngine.ts
+++ b/src/services/guard/GuardEngine.ts
@@ -123,7 +123,6 @@ export class GuardEngine {
         try {
             return this.performValidation(content, rules, severity);
         } catch (error) {
-            this.log.debug(`Guard validation failed: ${extractErrorMessage(error)}`);
             throw new Error(`Guard validation failed: ${extractErrorMessage(error)}`);
         }
     }
@@ -162,14 +161,9 @@ export class GuardEngine {
      * Perform the actual validation using SingleLineSummary format
      */
     private performValidation(content: string, rules: GuardRule[], severity: DiagnosticSeverity): GuardViolation[] {
-        try {
-            const output = this.executeGuardValidation(content, rules);
-            const violations = this.parseSingleLineSummaryOutput(output, rules, severity);
-            return this.deduplicateViolations(violations);
-        } catch (error) {
-            this.log.debug(`Guard WASM execution failed: ${extractErrorMessage(error)}`);
-            throw error;
-        }
+        const output = this.executeGuardValidation(content, rules);
+        const violations = this.parseSingleLineSummaryOutput(output, rules, severity);
+        return this.deduplicateViolations(violations);
     }
 
     /**

--- a/src/services/guard/GuardService.ts
+++ b/src/services/guard/GuardService.ts
@@ -192,11 +192,6 @@ export class GuardService implements SettingsConfigurable, Closeable {
             // Execute Guard validation with queuing for concurrent requests
             const violations = await this.queueValidation(uri, content, enabledRules);
 
-            // Only log violations if there are any (info level for actual findings)
-            if (violations.length > 0) {
-                this.log.debug(`Guard validation found ${violations.length} violations for ${uri}`);
-            }
-
             // Convert violations to LSP diagnostics
             const diagnostics = this.convertViolationsToDiagnostics(uri, violations);
 
@@ -214,7 +209,6 @@ export class GuardService implements SettingsConfigurable, Closeable {
             }
 
             // For other errors (WASM issues, timeouts, etc.), log as error and show diagnostic
-            this.log.debug(`Guard validation failed for ${uri}: ${errorMessage}`);
             this.publishErrorDiagnostics(uri, errorMessage);
         }
     }

--- a/src/services/guard/RuleConfiguration.ts
+++ b/src/services/guard/RuleConfiguration.ts
@@ -23,7 +23,7 @@ export class RuleConfiguration {
         const removed = [...previousPacks].filter((pack) => !this.enabledPacks.has(pack));
 
         if (added.length > 0 || removed.length > 0) {
-            this.log.debug('Rule pack configuration updated');
+            this.log.info('Rule pack configuration updated');
         }
     }
 
@@ -51,13 +51,10 @@ export class RuleConfiguration {
      */
     filterRulesByEnabledPacks(allRules: GuardRule[]): GuardRule[] {
         if (this.enabledPacks.size === 0) {
-            this.log.debug('No rule packs enabled, returning empty rule set');
             return [];
         }
 
         const filteredRules = allRules.filter((rule) => this.isPackEnabled(rule.pack));
-
-        this.log.debug(`Filtered ${allRules.length} rules to ${filteredRules.length} rules from enabled packs`);
 
         return filteredRules;
     }
@@ -69,13 +66,13 @@ export class RuleConfiguration {
      */
     filterRulePackNamesByEnabled(allPackNames: string[]): string[] {
         if (this.enabledPacks.size === 0) {
-            this.log.debug('No rule packs enabled, returning empty pack set');
+            this.log.info('No rule packs enabled, returning empty pack set');
             return [];
         }
 
         const filteredPacks = allPackNames.filter((packName) => this.isPackEnabled(packName));
 
-        this.log.debug(`Filtered ${allPackNames.length} rule packs to ${filteredPacks.length} enabled packs`);
+        this.log.info(`Filtered ${allPackNames.length} rule packs to ${filteredPacks.length} enabled packs`);
 
         return filteredPacks;
     }
@@ -128,6 +125,6 @@ export class RuleConfiguration {
      */
     reset(): void {
         this.enabledPacks.clear();
-        this.log.debug('Rule configuration reset');
+        this.log.info('Rule configuration reset');
     }
 }

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -3,7 +3,6 @@ import { LspWorkspace } from '../protocol/LspWorkspace';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
 import { Measure, Telemetry } from '../telemetry/TelemetryDecorator';
-import { extractErrorMessage } from '../utils/Errors';
 import { AwsRegion } from '../utils/Region';
 import { toString } from '../utils/String';
 import { PartialDataObserver, SubscriptionManager } from '../utils/SubscriptionManager';
@@ -59,7 +58,7 @@ export class SettingsManager implements ISettingsSubscriber {
             const settings = parseWithPrettyError(parseSettings, mergedConfig, this.getCurrentSettings());
             this.validateAndUpdate(settings);
         } catch (error) {
-            logger.error(`Failed to sync configuration, keeping previous settings: ${extractErrorMessage(error)}`);
+            logger.error(error, `Failed to sync configuration, keeping previous settings`);
         }
     }
 
@@ -74,9 +73,7 @@ export class SettingsManager implements ISettingsSubscriber {
                 },
             });
         } catch (error) {
-            logger.error(
-                `Failed to update profile configuration, keeping previous settings: ${extractErrorMessage(error)}`,
-            );
+            logger.error(error, `Failed to update profile configuration, keeping previous settings`);
         }
     }
 

--- a/src/stacks/actions/CapabilityAnalyzer.ts
+++ b/src/stacks/actions/CapabilityAnalyzer.ts
@@ -20,7 +20,7 @@ export async function analyzeCapabilities(document: Document, cfnService: CfnSer
 
         return validationResult.Capabilities;
     } catch (error) {
-        log.warn({ error }, 'Capability Analysis failed, assuming all capabilities are required');
+        log.warn(error, 'Capability Analysis failed, assuming all capabilities are required');
         return [Capability.CAPABILITY_IAM, Capability.CAPABILITY_NAMED_IAM, Capability.CAPABILITY_AUTO_EXPAND];
     }
 }

--- a/src/stacks/actions/ChangeSetDeletionWorkflow.ts
+++ b/src/stacks/actions/ChangeSetDeletionWorkflow.ts
@@ -117,7 +117,7 @@ export class ChangeSetDeletionWorkflow
                 failureReason: isSuccessful ? undefined : String(deploymentResult.reason), // reason only appears on failure
             });
         } catch (error) {
-            this.log.error({ error, workflowId }, 'Deletion workflow threw exception');
+            this.log.error(error, `Deletion workflow threw exception ${workflowId}`);
             existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
                 phase: StackActionPhase.DELETION_FAILED,
                 state: StackActionState.FAILED,

--- a/src/stacks/actions/DeploymentWorkflow.ts
+++ b/src/stacks/actions/DeploymentWorkflow.ts
@@ -135,7 +135,7 @@ export class DeploymentWorkflow implements StackActionWorkflow<CreateDeploymentP
                 state: deploymentResult.state,
             });
         } catch (error) {
-            this.log.error({ error, workflowId }, 'Deployment workflow threw exception');
+            this.log.error(error, `Deployment workflow threw exception ${workflowId}`);
             existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
                 phase: StackActionPhase.DEPLOYMENT_FAILED,
                 state: StackActionState.FAILED,
@@ -187,7 +187,7 @@ export class DeploymentWorkflow implements StackActionWorkflow<CreateDeploymentP
                 deploymentEvents: deploymentEvents,
             });
         } catch (error) {
-            this.log.error({ error, stackName }, 'Failed to process deployment events');
+            this.log.error(error, `Failed to process deployment events ${stackName}`);
 
             existingWorkflow = processWorkflowUpdates(this.workflows, existingWorkflow, {
                 phase: StackActionPhase.DEPLOYMENT_FAILED,

--- a/src/stacks/actions/StackActionOperations.ts
+++ b/src/stacks/actions/StackActionOperations.ts
@@ -32,7 +32,7 @@ import { CFN_VALIDATION_SOURCE } from './ValidationWorkflow';
 const logger = LoggerFactory.getLogger('StackActionOperations');
 
 function logCleanupError(error: unknown, workflowId: string, changeSetName: string, operation: string): void {
-    logger.warn({ error, workflowId, changeSetName }, `Failed to cleanup ${operation}`);
+    logger.warn(error, `Failed to cleanup ${operation} ${workflowId} ${changeSetName}`);
 }
 
 export async function processChangeSet(
@@ -99,7 +99,7 @@ export async function waitForChangeSetValidation(
             };
         }
     } catch (error) {
-        logger.error({ error: extractErrorMessage(error) }, 'Validation failed with error');
+        logger.error(error, 'Validation failed with error');
         return {
             phase: StackActionPhase.VALIDATION_FAILED,
             state: StackActionState.FAILED,
@@ -145,7 +145,7 @@ export async function waitForDeployment(
             };
         }
     } catch (error) {
-        logger.error({ error: extractErrorMessage(error) }, 'Deployment failed with error');
+        logger.error(error, 'Deployment failed with error');
         return {
             phase: StackActionPhase.DEPLOYMENT_FAILED,
             state: StackActionState.FAILED,
@@ -267,12 +267,10 @@ export async function publishValidationDiagnostics(
         let range: Range | undefined;
 
         if (event.ResourcePropertyPath) {
-            logger.debug({ event }, 'Getting property-specific start and end positions');
-
             range = diagnosticCoordinator.getKeyRangeFromPath(uri, event.ResourcePropertyPath);
         } else if (event.LogicalId) {
             // fall back to using LogicalId and underlining entire resource
-            logger.debug({ event }, 'No ResourcePropertyPath found, falling back to using LogicalId');
+            logger.warn(event, 'No ResourcePropertyPath found, falling back to using LogicalId');
             const resourcesMap = getEntityMap(syntaxTree, TopLevelSection.Resources);
 
             const startPosition = resourcesMap?.get(event.LogicalId)?.startPosition;

--- a/src/stacks/actions/ValidationWorkflow.ts
+++ b/src/stacks/actions/ValidationWorkflow.ts
@@ -170,7 +170,7 @@ export class ValidationWorkflow implements StackActionWorkflow<CreateValidationP
                 });
             }
         } catch (error) {
-            this.log.error({ error, workflowId }, 'Validation workflow threw exception');
+            this.log.error(error, `Validation workflow threw exception ${workflowId}`);
 
             const validation = this.validationManager.get(stackName);
             if (validation) {
@@ -199,7 +199,7 @@ export class ValidationWorkflow implements StackActionWorkflow<CreateValidationP
                     await deleteChangeSet(this.cfnService, existingWorkflow, params.id);
                 }
             } catch (error) {
-                this.log.error({ error }, 'resource cleanup failed');
+                this.log.error(error, 'Resource cleanup failed');
             }
         }
     }

--- a/src/stacks/actions/ValidationWorkflowV2.ts
+++ b/src/stacks/actions/ValidationWorkflowV2.ts
@@ -85,7 +85,7 @@ export class ValidationWorkflowV2 extends ValidationWorkflow {
                 this.diagnosticCoordinator,
             );
         } catch (error) {
-            this.log.error({ error, workflowId }, 'Validation workflow threw exception');
+            this.log.error(error, `Validation workflow threw exception ${workflowId}`);
 
             const validation = this.validationManager.get(stackName);
             if (validation) {

--- a/src/utils/GetAttUtils.ts
+++ b/src/utils/GetAttUtils.ts
@@ -131,7 +131,7 @@ export function getAttributeDocumentationFromSchema(
                 }
             }
         } catch (error) {
-            log.debug({ error, resourceType, attributeName }, 'Error resolving attribute documentation');
+            log.warn(error, `Error resolving attribute documentation ${resourceType} ${attributeName}`);
         }
     }
 

--- a/src/utils/SubscriptionManager.ts
+++ b/src/utils/SubscriptionManager.ts
@@ -122,7 +122,7 @@ export class SubscriptionManager<Data> {
         try {
             notifyFn();
         } catch (error) {
-            this.log.error({ error }, `Error in settings observer (subscription ${subscriptionId})`);
+            this.log.error(error, `Error in settings observer (subscription ${subscriptionId})`);
         }
     }
 

--- a/tst/unit/schema/GetSchemaTask.test.ts
+++ b/tst/unit/schema/GetSchemaTask.test.ts
@@ -169,7 +169,7 @@ describe('GetSchemaTask', () => {
             // Check that error was logged using Sinon stub
             expect(mockLogger.error.called).toBe(true);
             const errorCall = mockLogger.error.getCall(0);
-            expect(errorCall.args[0]).toContain('Failed to get private schemas');
+            expect(errorCall.lastArg).toContain('Failed to get private schemas');
         });
     });
 });

--- a/tst/unit/services/cfnLint/PyodideWorkerManager.test.ts
+++ b/tst/unit/services/cfnLint/PyodideWorkerManager.test.ts
@@ -1129,7 +1129,7 @@ describe('PyodideWorkerManager', () => {
             await new Promise((resolve) => setTimeout(resolve, 10));
 
             // Error should be logged
-            expect(mockLogging.error.calledWith({ error: terminationError }, 'Error terminating worker')).toBe(true);
+            expect(mockLogging.error.calledWith(terminationError, 'Error terminating worker')).toBe(true);
         });
     });
 });


### PR DESCRIPTION
## Summary

Pull Request #161 titled "Clean up debug logs, use pino to handle exception logging" by Satyaki Ghosh is currently open and makes significant logging
improvements across the CloudFormation Language Server codebase.

Key Changes:
• **102 additions, 364 deletions** across 55 files
• Removes excessive debug logging throughout handlers and services
• Standardizes error logging to use Pino's structured logging format
• Replaces custom error extraction with direct error object logging
• Removes verbose debug statements that were cluttering logs

Main Improvements:
1. Handler Cleanup: Removed debug logs from Definition, DocumentSymbol, Hover, InlineCompletion, and Stack handlers that were logging every request
2. Error Logging Standardization: Changed from log.error('message: ${extractErrorMessage(error)}') to log.error(error, 'message') pattern
3. Reduced Noise: Removed debug logs for cancelled operations and routine operations
4. Better Error Context: Uses Pino's structured logging to include error objects directly rather than extracting messages

Files Affected: Core handlers, services (CfnLint, Guard, Diagnostic), workflow components, and utility classes - essentially cleaning up logging across the entire language server implementation.
