### PR TITLE
detect gap in stack events and inform client; measure describeStackEv…

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -366,8 +366,8 @@ export function getStackEventsHandler(
         try {
             const params = parseWithPrettyError(parseGetStackEventsParams, rawParams);
             if (params.refresh) {
-                const events = await components.stackEventManager.refresh(params.stackName);
-                return { events, nextToken: undefined };
+                const result = await components.stackEventManager.refresh(params.stackName);
+                return { events: result.events, nextToken: undefined, gapDetected: result.gapDetected };
             }
             return await components.stackEventManager.fetchEvents(params.stackName, params.nextToken);
         } catch (error) {

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -164,6 +164,7 @@ export class CfnService {
         return await this.withClient((client) => client.send(new DetectStackDriftCommand(params)));
     }
 
+    @Measure({ name: 'describeStackEvents' })
     public async describeStackEvents(
         params: {
             StackName: string;

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -70,6 +70,7 @@ export type GetStackEventsParams = {
 export type GetStackEventsResult = {
     events: StackEvent[];
     nextToken?: string;
+    gapDetected?: boolean;
 };
 
 export const GetStackEventsRequest = new RequestType<GetStackEventsParams, GetStackEventsResult, void>(


### PR DESCRIPTION
…ents

*Description of changes:*
- the server limits API calls to fetch stack events to 5 pages (500 events)
- during high activity, between the refresh intervals if there were more events generated there will be a gap in the events
- sending a flag to client when last observed event ID is not found and all 5 pages exhausted
- client will refresh and notify Cx
- solves for use case if Cx closes laptop/internet and resumes activity many hours later
- client refresh interval being updated to 5second to show more real time updates during deployment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
