### PR TITLE
make encryptionkey not required

### DIFF
--- a/src/auth/AwsCredentials.ts
+++ b/src/auth/AwsCredentials.ts
@@ -23,14 +23,14 @@ export class AwsCredentials {
     private readonly logger = LoggerFactory.getLogger(AwsCredentials);
 
     private iamCredentials?: IamCredentials;
-    private readonly encryptionKey: Buffer;
+    private readonly encryptionKey?: Buffer;
 
     constructor(
         private readonly awsHandlers: LspAuthHandlers,
         private readonly settingsManager: SettingsManager,
-        encryptionKey: string,
+        encryptionKey?: string,
     ) {
-        this.encryptionKey = Buffer.from(encryptionKey, 'base64');
+        this.encryptionKey = encryptionKey ? Buffer.from(encryptionKey, 'base64') : undefined;
     }
 
     getIAM(): DeepReadonly<IamCredentials> {
@@ -41,6 +41,11 @@ export class AwsCredentials {
     }
 
     async handleIamCredentialsUpdate(params: UpdateCredentialsParams): Promise<boolean> {
+        if (!this.encryptionKey) {
+            this.logger.error('Authentication failed: encryption key not configured');
+            return false;
+        }
+
         try {
             const decrypted = await compactDecrypt(params.data, this.encryptionKey);
             const rawCredentials = JSON.parse(new TextDecoder().decode(decrypted.plaintext)) as unknown;

--- a/src/server/CfnInfraCore.ts
+++ b/src/server/CfnInfraCore.ts
@@ -60,9 +60,6 @@ export class CfnInfraCore implements Configurables, Closeable {
         this.fileContextManager = overrides.fileContextManager ?? new FileContextManager(this.documentManager);
 
         const encryptionKey = initializeParams.initializationOptions?.encryption?.key;
-        if (!encryptionKey) {
-            throw new Error('Encryption key is required');
-        }
 
         this.awsCredentials =
             overrides.awsCredentials ??

--- a/src/services/AwsClient.ts
+++ b/src/services/AwsClient.ts
@@ -23,11 +23,15 @@ export class AwsClient {
     }
 
     private iamClientConfig(): IamClientConfig {
-        const credential = this.credentialsProvider.getIAM();
-        return {
-            region: credential.region,
-            credentials: this.credentialsProvider.getIAM(),
-            customUserAgent: `${ExtensionId}/${ExtensionVersion}`,
-        };
+        try {
+            const credential = this.credentialsProvider.getIAM();
+            return {
+                region: credential.region,
+                credentials: credential,
+                customUserAgent: `${ExtensionId}/${ExtensionVersion}`,
+            };
+        } catch {
+            throw new Error('AWS credentials not configured. Authentication required for online features.');
+        }
     }
 }

--- a/tst/unit/services/AwsClient.test.ts
+++ b/tst/unit/services/AwsClient.test.ts
@@ -47,9 +47,11 @@ describe('AwsClient', () => {
         });
 
         it('should handle credentials provider errors', () => {
-            mockComponents.awsCredentials.getIAM.throws(new Error('Credential provider error'));
+            mockComponents.awsCredentials.getIAM.throws(new Error('IAM credentials not configured'));
 
-            expect(() => component.getCloudFormationClient()).toThrow('Credential provider error');
+            expect(() => component.getCloudFormationClient()).toThrow(
+                'AWS credentials not configured. Authentication required for online features.',
+            );
         });
     });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Make encryption key not required so offline components still work.  This should help scenarios in which the language server could be used by things outside of vscode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
