### PR TITLE
fetch stack outputs

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -14,6 +14,7 @@ import {
     parseTemplateUriParams,
     parseGetStackEventsParams,
     parseClearStackEventsParams,
+    parseGetStackOutputsParams,
 } from '../stacks/actions/StackActionParser';
 import {
     TemplateUri,
@@ -39,6 +40,8 @@ import {
     GetStackEventsParams,
     GetStackEventsResult,
     ClearStackEventsParams,
+    GetStackOutputsParams,
+    GetStackOutputsResult,
 } from '../stacks/StackRequestType';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { extractErrorMessage } from '../utils/Errors';
@@ -361,6 +364,21 @@ export function clearStackEventsHandler(
             components.stackEventManager.clear();
         } catch (error) {
             handleStackActionError(error, 'Failed to clear stack events');
+        }
+    };
+}
+
+export function getStackOutputsHandler(
+    components: ServerComponents,
+): RequestHandler<GetStackOutputsParams, GetStackOutputsResult, void> {
+    return async (rawParams): Promise<GetStackOutputsResult> => {
+        try {
+            const params = parseWithPrettyError(parseGetStackOutputsParams, rawParams);
+            const response = await components.cfnService.describeStacks({ StackName: params.stackName });
+            const outputs = response.Stacks?.[0]?.Outputs ?? [];
+            return { outputs };
+        } catch (error) {
+            handleStackActionError(error, 'Failed to get stack outputs');
         }
     };
 }

--- a/src/protocol/LspStackHandlers.ts
+++ b/src/protocol/LspStackHandlers.ts
@@ -45,6 +45,9 @@ import {
     GetStackEventsRequest,
     ClearStackEventsParams,
     ClearStackEventsRequest,
+    GetStackOutputsParams,
+    GetStackOutputsResult,
+    GetStackOutputsRequest,
 } from '../stacks/StackRequestType';
 import { Identifiable } from './LspTypes';
 
@@ -121,5 +124,9 @@ export class LspStackHandlers {
 
     onClearStackEvents(handler: RequestHandler<ClearStackEventsParams, void, void>) {
         this.connection.onRequest(ClearStackEventsRequest.method, handler);
+    }
+
+    onGetStackOutputs(handler: RequestHandler<GetStackOutputsParams, GetStackOutputsResult, void>) {
+        this.connection.onRequest(GetStackOutputsRequest.method, handler);
     }
 }

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -38,6 +38,7 @@ import {
     describeChangeSetDeletionStatusHandler,
     getStackEventsHandler,
     clearStackEventsHandler,
+    getStackOutputsHandler,
 } from '../handlers/StackHandler';
 import { LspComponents } from '../protocol/LspComponents';
 import { closeSafely } from '../utils/Closeable';
@@ -117,6 +118,7 @@ export class CfnServer {
         this.lsp.stackHandlers.onGetStackTemplate(getManagedResourceStackTemplateHandler(this.components));
         this.lsp.stackHandlers.onGetStackEvents(getStackEventsHandler(this.components));
         this.lsp.stackHandlers.onClearStackEvents(clearStackEventsHandler(this.components));
+        this.lsp.stackHandlers.onGetStackOutputs(getStackOutputsHandler(this.components));
 
         this.lsp.resourceHandlers.onListResources(listResourcesHandler(this.components));
         this.lsp.resourceHandlers.onRefreshResourceList(refreshResourceListHandler(this.components));

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -103,6 +103,7 @@ export class CfnService {
         return await this.withClient((client) => client.send(new CreateStackCommand(params)));
     }
 
+    @Measure({ name: 'describeStacks' })
     public async describeStacks(params?: {
         StackName?: string;
         NextToken?: string;

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -1,4 +1,4 @@
-import { StackSummary, StackStatus, StackResourceSummary, StackEvent } from '@aws-sdk/client-cloudformation';
+import { StackSummary, StackStatus, StackResourceSummary, StackEvent, Output } from '@aws-sdk/client-cloudformation';
 import { RequestType } from 'vscode-languageserver-protocol';
 
 export type ListStacksParams = {
@@ -83,4 +83,16 @@ export type ClearStackEventsParams = {
 
 export const ClearStackEventsRequest = new RequestType<ClearStackEventsParams, void, void>(
     'aws/cfn/stack/events/clear',
+);
+
+export type GetStackOutputsParams = {
+    stackName: string;
+};
+
+export type GetStackOutputsResult = {
+    outputs: Output[];
+};
+
+export const GetStackOutputsRequest = new RequestType<GetStackOutputsParams, GetStackOutputsResult, void>(
+    'aws/cfn/stack/outputs',
 );

--- a/src/stacks/actions/StackActionParser.ts
+++ b/src/stacks/actions/StackActionParser.ts
@@ -1,6 +1,11 @@
 import { Capability } from '@aws-sdk/client-cloudformation';
 import { z } from 'zod';
-import { ListStackResourcesParams, GetStackEventsParams, ClearStackEventsParams } from '../StackRequestType';
+import {
+    ListStackResourcesParams,
+    GetStackEventsParams,
+    ClearStackEventsParams,
+    GetStackOutputsParams,
+} from '../StackRequestType';
 import {
     CreateDeploymentParams,
     CreateValidationParams,
@@ -67,6 +72,10 @@ const ClearStackEventsParamsSchema = z.object({
     stackName: z.string().min(1).max(128),
 });
 
+const GetStackOutputsParamsSchema = z.object({
+    stackName: z.string().min(1).max(128),
+});
+
 export function parseStackActionParams(input: unknown): CreateValidationParams {
     return StackActionParamsSchema.parse(input);
 }
@@ -93,4 +102,8 @@ export function parseGetStackEventsParams(input: unknown): GetStackEventsParams 
 
 export function parseClearStackEventsParams(input: unknown): ClearStackEventsParams {
     return ClearStackEventsParamsSchema.parse(input);
+}
+
+export function parseGetStackOutputsParams(input: unknown): GetStackOutputsParams {
+    return GetStackOutputsParamsSchema.parse(input);
 }

--- a/tst/unit/handlers/StackHandler.test.ts
+++ b/tst/unit/handlers/StackHandler.test.ts
@@ -22,6 +22,7 @@ import {
     deleteChangeSetHandler,
     describeChangeSetDeletionStatusHandler,
     getChangeSetDeletionStatusHandler,
+    getStackOutputsHandler,
 } from '../../../src/handlers/StackHandler';
 import { analyzeCapabilities } from '../../../src/stacks/actions/CapabilityAnalyzer';
 import {
@@ -32,7 +33,12 @@ import {
     StackActionPhase,
     StackActionState,
 } from '../../../src/stacks/actions/StackActionRequestType';
-import { ListStacksParams, ListStacksResult, ListStackResourcesResult } from '../../../src/stacks/StackRequestType';
+import {
+    ListStacksParams,
+    ListStacksResult,
+    ListStackResourcesResult,
+    GetStackOutputsResult,
+} from '../../../src/stacks/StackRequestType';
 import {
     createMockComponents,
     createMockSyntaxTreeManager,
@@ -55,6 +61,7 @@ vi.mock('../../../src/stacks/actions/StackActionParser', () => ({
     parseCreateDeploymentParams: vi.fn((input) => input),
     parseDeleteChangeSetParams: vi.fn((input) => input),
     parseListStackResourcesParams: vi.fn((input) => input),
+    parseGetStackOutputsParams: vi.fn((input) => input),
 }));
 
 vi.mock('../../../src/utils/ZodErrorWrapper', () => ({
@@ -688,6 +695,71 @@ describe('StackActionHandler', () => {
 
             expect(result.resources).toHaveLength(1);
             expect(result.resources[0].logicalId).toBe('MyBucket');
+        });
+    });
+
+    describe('getStackOutputsHandler', () => {
+        it('returns outputs for a stack', async () => {
+            const params = { stackName: 'MyStack' };
+            const mockOutputs = [
+                { OutputKey: 'BucketName', OutputValue: 'my-bucket', Description: 'S3 Bucket' },
+                { OutputKey: 'FunctionArn', OutputValue: 'arn:aws:lambda:...', ExportName: 'MyFunction' },
+            ];
+
+            mockComponents.cfnService.describeStacks.resolves({
+                Stacks: [{ StackName: 'MyStack', Outputs: mockOutputs }],
+            } as any);
+
+            const handler = getStackOutputsHandler(mockComponents);
+            const result = (await handler(params, {} as any)) as GetStackOutputsResult;
+
+            expect(result.outputs).toHaveLength(2);
+            expect(result.outputs[0].OutputKey).toBe('BucketName');
+            expect(result.outputs[1].ExportName).toBe('MyFunction');
+        });
+
+        it('returns empty array when stack has no outputs', async () => {
+            const params = { stackName: 'MyStack' };
+
+            mockComponents.cfnService.describeStacks.resolves({
+                Stacks: [{ StackName: 'MyStack', Outputs: undefined }],
+            } as any);
+
+            const handler = getStackOutputsHandler(mockComponents);
+            const result = (await handler(params, {} as any)) as GetStackOutputsResult;
+
+            expect(result.outputs).toEqual([]);
+        });
+
+        it('returns empty array when Stacks array is empty', async () => {
+            const params = { stackName: 'MyStack' };
+
+            mockComponents.cfnService.describeStacks.resolves({
+                Stacks: [],
+            } as any);
+
+            const handler = getStackOutputsHandler(mockComponents);
+            const result = (await handler(params, {} as any)) as GetStackOutputsResult;
+
+            expect(result.outputs).toEqual([]);
+        });
+
+        it('throws ResponseError for invalid stack name', async () => {
+            const params = { stackName: '' };
+
+            const handler = getStackOutputsHandler(mockComponents);
+
+            await expect(handler(params, {} as any)).rejects.toThrow(ResponseError);
+        });
+
+        it('throws ResponseError when API call fails', async () => {
+            const params = { stackName: 'MyStack' };
+
+            mockComponents.cfnService.describeStacks.rejects(new Error('Stack not found'));
+
+            const handler = getStackOutputsHandler(mockComponents);
+
+            await expect(handler(params, {} as any)).rejects.toThrow(ResponseError);
         });
     });
 });


### PR DESCRIPTION
*Description of changes:*
- calling `describeStacks` using stack name and returning the outputs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
