### PR TITLE
Add optional flags for create validation request

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -10,7 +10,7 @@ import {
     parseCreateDeploymentParams,
     parseDeleteChangeSetParams,
     parseListStackResourcesParams,
-    parseStackActionParams,
+    parseCreateValidationParams,
     parseTemplateUriParams,
     parseGetStackEventsParams,
     parseClearStackEventsParams,
@@ -80,7 +80,7 @@ export function createValidationHandler(
 ): RequestHandler<CreateValidationParams, CreateStackActionResult, void> {
     return async (rawParams) => {
         try {
-            const params = parseWithPrettyError(parseStackActionParams, rawParams);
+            const params = parseWithPrettyError(parseCreateValidationParams, rawParams);
             return await components.validationWorkflowService.start(params);
         } catch (error) {
             handleStackActionError(error, 'Failed to start validation workflow');

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -53,6 +53,8 @@ import {
     ChangeSetSummary,
     ListChangeSetsCommand,
     waitUntilStackDeleteComplete,
+    Tag,
+    OnStackFailure,
 } from '@aws-sdk/client-cloudformation';
 import { WaiterConfiguration, WaiterResult } from '@smithy/util-waiter';
 import { Measure } from '../telemetry/TelemetryDecorator';
@@ -125,6 +127,10 @@ export class CfnService {
         Capabilities?: Capability[];
         ChangeSetType?: 'CREATE' | 'UPDATE' | 'IMPORT';
         ResourcesToImport?: ResourceToImport[];
+        OnStackFailure?: OnStackFailure;
+        IncludeNestedStacks?: boolean;
+        Tags?: Tag[];
+        ImportExistingResources?: boolean;
     }): Promise<CreateChangeSetCommandOutput> {
         return await this.withClient((client) => client.send(new CreateChangeSetCommand(params)));
     }

--- a/src/stacks/actions/StackActionOperations.ts
+++ b/src/stacks/actions/StackActionOperations.ts
@@ -56,6 +56,10 @@ export async function processChangeSet(
         Capabilities: params.capabilities,
         ChangeSetType: changeSetType,
         ResourcesToImport: params.resourcesToImport,
+        OnStackFailure: params.onStackFailure,
+        IncludeNestedStacks: params.includeNestedStacks,
+        Tags: params.tags,
+        ImportExistingResources: params.importExistingResources,
     });
 
     return changeSetName;

--- a/src/stacks/actions/StackActionRequestType.ts
+++ b/src/stacks/actions/StackActionRequestType.ts
@@ -4,6 +4,8 @@ import {
     ResourceChangeDetail,
     ResourceStatus,
     DetailedStatus,
+    OnStackFailure,
+    Tag,
 } from '@aws-sdk/client-cloudformation';
 import { DateTime } from 'luxon';
 import { Parameter as EntityParameter } from '../../context/semantic/Entity';
@@ -22,6 +24,10 @@ export type CreateValidationParams = Identifiable & {
     capabilities?: Capability[];
     resourcesToImport?: ResourceToImport[];
     keepChangeSet?: boolean;
+    onStackFailure?: OnStackFailure;
+    includeNestedStacks?: boolean;
+    tags?: Tag[];
+    importExistingResources?: boolean;
 };
 
 export type ChangeSetReference = {

--- a/tst/unit/handlers/StackHandler.test.ts
+++ b/tst/unit/handlers/StackHandler.test.ts
@@ -56,12 +56,13 @@ vi.mock('../../../src/protocol/LspParser', () => ({
 }));
 
 vi.mock('../../../src/stacks/actions/StackActionParser', () => ({
-    parseStackActionParams: vi.fn((input) => input),
+    parseCreateValidationParams: vi.fn((input) => input),
     parseTemplateUriParams: vi.fn((input) => input),
     parseCreateDeploymentParams: vi.fn((input) => input),
     parseDeleteChangeSetParams: vi.fn((input) => input),
     parseListStackResourcesParams: vi.fn((input) => input),
     parseGetStackOutputsParams: vi.fn((input) => input),
+    parseDescribeChangeSetParams: vi.fn((input) => input),
 }));
 
 vi.mock('../../../src/utils/ZodErrorWrapper', () => ({

--- a/tst/unit/services/CfnService.test.ts
+++ b/tst/unit/services/CfnService.test.ts
@@ -21,6 +21,7 @@ import {
     waitUntilChangeSetCreateComplete,
     waitUntilStackUpdateComplete,
     waitUntilStackCreateComplete,
+    OnFailure,
 } from '@aws-sdk/client-cloudformation';
 import { WaiterState } from '@smithy/util-waiter';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -195,6 +196,21 @@ describe('CfnService', () => {
                 StackName: TEST_CONSTANTS.STACK_NAME,
                 ChangeSetName: TEST_CONSTANTS.CHANGE_SET_NAME,
                 TemplateBody: TEST_CONSTANTS.TEMPLATE_BODY,
+                Parameters: [
+                    {
+                        ParameterKey: 'Key',
+                        ParameterValue: 'Value',
+                    },
+                ],
+                Tags: [
+                    {
+                        Key: 'Key',
+                        Value: 'Value',
+                    },
+                ],
+                IncludeNestedStacks: true,
+                ImportExistingResources: false,
+                OnStackFailure: OnFailure.DELETE,
             });
 
             expect(result).toEqual(MOCK_RESPONSES.CREATE_CHANGE_SET);


### PR DESCRIPTION
*Description of changes:*
- Added additional optional flags for create validation requests that would ultimately create the change set with these optional flags
- Added:
  - tags
  - includeNestedStacks
  - importExistingResources
  - onStackFailure

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
