### PR TITLE
Fix codelens command and naming

### DIFF
--- a/src/codeLens/StackActionsCodeLens.ts
+++ b/src/codeLens/StackActionsCodeLens.ts
@@ -1,12 +1,12 @@
 import { CodeLens, Position, Range } from 'vscode-languageserver';
 
 const STACK_ACTION_TITLES = {
-    DRY_RUN: 'Dry Run Template',
+    VALIDATE_DEPLOYMENT: 'Validate Deployment',
     DEPLOY: 'Deploy Template',
 } as const;
 
 const STACK_ACTION_COMMANDS = {
-    DRY_RUN: 'aws.cloudformation.api.dryRunTemplate',
+    VALIDATE_DEPLOYMENT: 'aws.cloudformation.api.validateDeployment',
     DEPLOY: 'aws.cloudformation.api.deployTemplate',
 } as const;
 
@@ -17,8 +17,8 @@ export function getStackActionsCodeLenses(uri: string): CodeLens[] {
         {
             range,
             command: {
-                title: STACK_ACTION_TITLES.DRY_RUN,
-                command: STACK_ACTION_COMMANDS.DRY_RUN,
+                title: STACK_ACTION_TITLES.VALIDATE_DEPLOYMENT,
+                command: STACK_ACTION_COMMANDS.VALIDATE_DEPLOYMENT,
                 arguments: [uri],
             },
         },

--- a/tst/unit/handlers/CodeLensHandler.test.ts
+++ b/tst/unit/handlers/CodeLensHandler.test.ts
@@ -65,7 +65,7 @@ describe('CodeLensHandler', () => {
         const result = await handler(params, CancellationToken.None);
 
         expect(result).toHaveLength(3); // 2 stack actions + 1 managed resource
-        expect(result[0].command?.title).toBe('Dry Run Template');
+        expect(result[0].command?.title).toBe('Validate Deployment');
         expect(result[1].command?.title).toBe('Deploy Template');
         expect(result[2].command?.title).toBe('Open Stack Template');
     });


### PR DESCRIPTION
*Description of changes:*
- Modify codelens name to be the same as what's in the command palette name
- Modified verbiage

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
