### PR TITLE
Improve enum usage and reduce expensive operations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -117,6 +117,53 @@ export default tseslint.config([
         },
     },
     {
+        files: ['src/**'],
+        rules: {
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector: 'CallExpression[callee.property.name="logRecord"]',
+                    message:
+                        'Usage of logRecord() function is restricted in src code. This is meant for debugging purposes only',
+                },
+                {
+                    selector: 'MemberExpression[property.name="entityType"]',
+                    message:
+                        'Usage of entityType property is restricted in src code. This call is an expensive operations, use getEntityType from Context instead',
+                },
+                {
+                    selector:
+                        'Literal[value=/^(Resources|Parameters|Outputs|Mappings|Metadata|Rules|Conditions|Transform|AWSTemplateFormatVersion)$/]',
+                    message:
+                        'Usage of raw TopLevelSection strings is restricted in src code. Use TopLevelSection enum instead',
+                },
+                {
+                    selector:
+                        'Literal[value=/^(Output|Mapping|Metadata|Rule|Transform|AWSTemplateFormatVersion|ForEachResource)$/]',
+                    message: 'Usage of raw EntityType strings is restricted in src code. Use EntityType enum instead',
+                },
+                {
+                    selector:
+                        'Literal[value=/^Fn::(Base64|Cidr|FindInMap|ForEach|GetAtt|GetAZs|ImportValue|Join|Length|Select|Split|Sub|ToJsonString|Transform|And|Equals|If|Not|Or|Contains|EachMemberEquals|EachMemberIn|RefAll|ValueOf|ValueOfAll|Implies)$/]',
+                    message:
+                        'Usage of raw IntrinsicFunction strings is restricted in src code. Use IntrinsicFunction enum instead',
+                },
+                {
+                    selector:
+                        'Literal[value=/^AWS::(AccountId|Region|StackId|StackName|NotificationARNs|NoValue|Partition|URLSuffix)$/]',
+                    message:
+                        'Usage of raw PseudoParameter strings is restricted in src code. Use PseudoParameter enum instead',
+                },
+                {
+                    selector:
+                        'Literal[value=/^(CreationPolicy|DeletionPolicy|UpdatePolicy|UpdateReplacePolicy|DependsOn|Metadata)$/]',
+                    message:
+                        'Usage of raw ResourceAttribute strings is restricted in src code. Use ResourceAttribute enum instead',
+                },
+            ],
+        },
+    },
+    {
         files: ['tst/**'],
         plugins: {
             vitest,

--- a/src/autocomplete/CompletionRouter.ts
+++ b/src/autocomplete/CompletionRouter.ts
@@ -1,7 +1,12 @@
 import { CompletionParams } from 'vscode-languageserver';
 import { Context } from '../context/Context';
 import { ContextManager } from '../context/ContextManager';
-import { IntrinsicFunction, IntrinsicsUsingConditionKeyword, TopLevelSection } from '../context/ContextType';
+import {
+    IntrinsicFunction,
+    IntrinsicsUsingConditionKeyword,
+    ResourceAttribute,
+    TopLevelSection,
+} from '../context/ContextType';
 import { isCondition } from '../context/ContextUtils';
 import { Entity, Output, Parameter } from '../context/semantic/Entity';
 import { EntityType } from '../context/semantic/SemanticTypes';
@@ -79,7 +84,7 @@ export class CompletionRouter implements SettingsConfigurable, Closeable {
         } else if (context.section === TopLevelSection.Resources) {
             provider = this.completionProviderMap.get(EntityType.Resource);
         } else if (context.atEntityKeyLevel()) {
-            provider = this.entityFieldCompletionProviderMap.get(context.entity.entityType);
+            provider = this.entityFieldCompletionProviderMap.get(context.getEntityType());
         }
 
         const completions = provider?.getCompletions(context, params) ?? [];
@@ -137,12 +142,12 @@ export class CompletionRouter implements SettingsConfigurable, Closeable {
         }
 
         // Resource UpdatePolicy Condition: ['Resources', 'LogicalId', 'UpdatePolicy', this.CONDITION]
-        if (context.matchPathWithLogicalId(TopLevelSection.Resources, 'UpdatePolicy', Condition)) {
+        if (context.matchPathWithLogicalId(TopLevelSection.Resources, ResourceAttribute.UpdatePolicy, Condition)) {
             return true;
         }
 
         // Resource Metadata Condition: ['Resources', 'LogicalId', 'Metadata', this.CONDITION]
-        if (context.matchPathWithLogicalId(TopLevelSection.Resources, 'Metadata', Condition)) {
+        if (context.matchPathWithLogicalId(TopLevelSection.Resources, ResourceAttribute.Metadata, Condition)) {
             return true;
         }
 

--- a/src/autocomplete/EntityFieldCompletionProvider.ts
+++ b/src/autocomplete/EntityFieldCompletionProvider.ts
@@ -6,6 +6,7 @@ import { FuzzySearchFunction, getFuzzySearchFunction } from '../utils/FuzzySearc
 import { CompletionProvider } from './CompletionProvider';
 import { createCompletionItem } from './CompletionUtils';
 
+/* eslint-disable no-restricted-syntax -- Entire class depends on Entity */
 export class EntityFieldCompletionProvider<T extends Entity> implements CompletionProvider {
     public getCompletions(context: Context, _: CompletionParams): CompletionItem[] {
         const entity = context.entity as T;

--- a/src/autocomplete/IntrinsicFunctionArgumentCompletionProvider.ts
+++ b/src/autocomplete/IntrinsicFunctionArgumentCompletionProvider.ts
@@ -310,7 +310,7 @@ export class IntrinsicFunctionArgumentCompletionProvider implements CompletionPr
             }
 
             const resource = resourceContext.entity as Resource;
-            if (!resource.Type || typeof resource.Type !== 'string') {
+            if (!resource.Type) {
                 continue;
             }
 
@@ -601,7 +601,7 @@ export class IntrinsicFunctionArgumentCompletionProvider implements CompletionPr
     private getMappingEntity(mappingsEntities: Map<string, Context>, mappingName: string): Mapping | undefined {
         try {
             const mappingContext = mappingsEntities.get(mappingName);
-            if (!mappingContext?.entity || mappingContext.entity.entityType !== EntityType.Mapping) {
+            if (!mappingContext || mappingContext.getEntityType() !== EntityType.Mapping) {
                 return undefined;
             }
             return mappingContext.entity as Mapping;
@@ -655,13 +655,13 @@ export class IntrinsicFunctionArgumentCompletionProvider implements CompletionPr
         }
 
         const resourceContext = resourceEntities.get(resourceLogicalId);
-        if (!resourceContext?.entity || resourceContext.entity.entityType !== EntityType.Resource) {
+        if (!resourceContext || resourceContext.getEntityType() !== EntityType.Resource) {
             return undefined;
         }
 
         const resource = resourceContext.entity as Resource;
         const resourceType = resource.Type;
-        if (!resourceType || typeof resourceType !== 'string') {
+        if (!resourceType) {
             return undefined;
         }
 

--- a/src/context/Context.ts
+++ b/src/context/Context.ts
@@ -5,21 +5,22 @@ import {
     IntrinsicsSet,
     PseudoParametersSet,
     ResourceAttributesSet,
+    SectionType,
     TopLevelSection,
     TopLevelSectionsSet,
     TopLevelSectionsWithLogicalIdsSet,
 } from './ContextType';
 import { IntrinsicContext } from './IntrinsicContext';
 import { Entity } from './semantic/Entity';
-import { nodeToEntity } from './semantic/EntityBuilder';
+import { entityTypeFromSection, nodeToEntity } from './semantic/EntityBuilder';
 import { normalizeIntrinsicFunction } from './semantic/Intrinsics';
+import { EntityType } from './semantic/SemanticTypes';
 import { PropertyPath } from './syntaxtree/SyntaxTree';
 import { NodeType } from './syntaxtree/utils/NodeType';
 import { YamlNodeTypes, CommonNodeTypes } from './syntaxtree/utils/TreeSitterTypes';
 import { TransformContext } from './TransformContext';
 
-export type SectionType = TopLevelSection | 'Unknown';
-export type QuoteCharacter = '"' | "'";
+type QuoteCharacter = '"' | "'";
 
 export class Context {
     public readonly section: SectionType;
@@ -62,6 +63,10 @@ export class Context {
     public get entity(): Entity {
         this._entity ??= nodeToEntity(this.documentType, this.entityRootNode, this.section, this.logicalId);
         return this._entity;
+    }
+
+    public getEntityType(): EntityType {
+        return entityTypeFromSection(this.section, this.logicalId);
     }
 
     public get intrinsicContext(): IntrinsicContext {
@@ -310,7 +315,7 @@ export class Context {
         return undefined;
     }
 
-    public record() {
+    public logRecord() {
         return {
             section: this.section,
             logicalId: this.logicalId,
@@ -322,7 +327,7 @@ export class Context {
             node: { start: this.node.startPosition, end: this.node.endPosition },
             root: { start: this.entityRootNode?.startPosition, end: this.entityRootNode?.endPosition },
             entity: this.entity,
-            intrinsicContext: this.intrinsicContext.record(),
+            intrinsicContext: this.intrinsicContext.logRecord(), // eslint-disable-line no-restricted-syntax
             isKey: this.isKey(),
             isValue: this.isValue(),
         };

--- a/src/context/ContextType.ts
+++ b/src/context/ContextType.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax -- enum definitions */
 export enum TopLevelSection {
     Resources = 'Resources',
     Parameters = 'Parameters',
@@ -10,6 +11,8 @@ export enum TopLevelSection {
     AWSTemplateFormatVersion = 'AWSTemplateFormatVersion',
     Description = 'Description',
 }
+
+export type SectionType = TopLevelSection | 'Unknown';
 
 export enum IntrinsicFunction {
     Base64 = 'Fn::Base64',

--- a/src/context/ContextWithRelatedEntities.ts
+++ b/src/context/ContextWithRelatedEntities.ts
@@ -1,7 +1,7 @@
 import { SyntaxNode } from 'tree-sitter';
 import { DocumentType } from '../document/Document';
-import { Context, SectionType, logicalIdAndSection } from './Context';
-import { TopLevelSection, TopLevelSectionsWithLogicalIdsSet } from './ContextType';
+import { Context, logicalIdAndSection } from './Context';
+import { SectionType, TopLevelSection, TopLevelSectionsWithLogicalIdsSet } from './ContextType';
 import { contextEntitiesInSections } from './SectionContextBuilder';
 import { Entity } from './semantic/Entity';
 import { referencedLogicalIds, selectText } from './semantic/LogicalIdReferenceFinder';
@@ -29,9 +29,9 @@ export class ContextWithRelatedEntities extends Context {
         return this._relatedEntities;
     }
 
-    override record() {
+    override logRecord() {
         return {
-            ...super.record(),
+            ...super.logRecord(), // eslint-disable-line no-restricted-syntax
             relatedEntities: this.transformNestedMap(this.relatedEntities),
         };
     }

--- a/src/context/FileContext.ts
+++ b/src/context/FileContext.ts
@@ -82,7 +82,7 @@ export class FileContext {
 
         try {
             if (section === TopLevelSection.Transform) {
-                return [createEntityFromObject('Transform', parseObject(parsedData, this.documentType), section)];
+                return [createEntityFromObject('Unknown', parseObject(parsedData, this.documentType), section)];
             }
 
             if (typeof parsedData !== 'object') return [];

--- a/src/context/IntrinsicContext.ts
+++ b/src/context/IntrinsicContext.ts
@@ -89,11 +89,11 @@ export class IntrinsicContext {
         return IntrinsicsSet.has(normalized) ? (normalized as IntrinsicFunction) : undefined;
     }
 
-    public record() {
+    public logRecord() {
         const intrinsicFunction = this.intrinsicFunction();
         return {
             isInsideIntrinsic: intrinsicFunction !== undefined,
-            intrinsicFunction: intrinsicFunction?.record(),
+            intrinsicFunction: intrinsicFunction?.logRecord(), // eslint-disable-line no-restricted-syntax
         };
     }
 }
@@ -208,7 +208,7 @@ class IntrinsicFunctionInfo {
         set.add(text.split('.')[0].trim());
     }
 
-    public record() {
+    public logRecord() {
         return {
             type: this.type,
             args: this.args,

--- a/src/context/SectionContextBuilder.ts
+++ b/src/context/SectionContextBuilder.ts
@@ -1,8 +1,8 @@
 import { SyntaxNode } from 'tree-sitter';
 import { DocumentType } from '../document/Document';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
-import { Context, SectionType } from './Context';
-import { TopLevelSection, TopLevelSectionsWithLogicalIdsSet } from './ContextType';
+import { Context } from './Context';
+import { SectionType, TopLevelSection, TopLevelSectionsWithLogicalIdsSet } from './ContextType';
 import { SyntaxTree } from './syntaxtree/SyntaxTree';
 import { NodeType } from './syntaxtree/utils/NodeType';
 import { FieldNames, YamlNodeTypes } from './syntaxtree/utils/TreeSitterTypes';

--- a/src/context/semantic/Entity.ts
+++ b/src/context/semantic/Entity.ts
@@ -19,7 +19,7 @@ export abstract class Entity {
         return this._keys;
     }
 
-    record() {
+    logRecord() {
         const record: Record<string, unknown> = {};
         for (const key of this.keys) {
             record[key] = this[key as keyof this];

--- a/src/context/semantic/LogicalIdReferenceFinder.ts
+++ b/src/context/semantic/LogicalIdReferenceFinder.ts
@@ -1,6 +1,6 @@
 import { SyntaxNode } from 'tree-sitter';
 import { DocumentType } from '../../document/Document';
-import { PseudoParametersSet } from '../ContextType';
+import { PseudoParametersSet, ResourceAttributes } from '../ContextType';
 
 export function selectText(specificNode: SyntaxNode, fullEntitySearch: boolean, rootNode?: SyntaxNode): string {
     let text: string | undefined;
@@ -175,13 +175,8 @@ const CommonProperties = new Set(
     [
         'Type',
         'Properties',
-        'DependsOn',
+        ...ResourceAttributes,
         'Condition',
-        'Metadata',
-        'CreationPolicy',
-        'DeletionPolicy',
-        'UpdatePolicy',
-        'UpdateReplacePolicy',
         'Description',
         'Value',
         'Export',

--- a/src/context/semantic/SemanticTypes.ts
+++ b/src/context/semantic/SemanticTypes.ts
@@ -1,5 +1,6 @@
 import { Condition } from './Entity';
 
+/* eslint-disable no-restricted-syntax -- enum definitions */
 export enum EntityType {
     Metadata = 'Metadata',
     Output = 'Output',

--- a/src/documentSymbol/DocumentSymbolRouter.ts
+++ b/src/documentSymbol/DocumentSymbolRouter.ts
@@ -1,7 +1,7 @@
 import { SyntaxNode } from 'tree-sitter';
 import { DocumentSymbol, SymbolKind, DocumentSymbolParams, Range, Position } from 'vscode-languageserver';
-import { Context, SectionType } from '../context/Context';
-import { TopLevelSection } from '../context/ContextType';
+import { Context } from '../context/Context';
+import { SectionType, TopLevelSection } from '../context/ContextType';
 import { contextEntitiesInSections } from '../context/SectionContextBuilder';
 import { EntityType } from '../context/semantic/SemanticTypes';
 import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
@@ -90,6 +90,7 @@ const SECTION_CONFIGS: SectionConfig[] = [
 ];
 const log = LoggerFactory.getLogger('DocumentSymbolRouter');
 
+/* eslint-disable no-restricted-syntax -- Entire class depends on Entity values */
 export class DocumentSymbolRouter {
     private readonly log = LoggerFactory.getLogger(DocumentSymbolRouter);
 

--- a/src/hover/HoverFormatter.ts
+++ b/src/hover/HoverFormatter.ts
@@ -1,5 +1,6 @@
 import { deletionPolicyValueDocsMap } from '../artifacts/resourceAttributes/DeletionPolicyPropertyDocs';
 import { updateReplacePolicyValueDocsMap } from '../artifacts/resourceAttributes/UpdateReplacePolicyPropertyDocs-1';
+import { Context } from '../context/Context';
 import { ResourceAttribute } from '../context/ContextType';
 import { Condition, Entity, Mapping, Parameter, Resource } from '../context/semantic/Entity';
 import { EntityType } from '../context/semantic/SemanticTypes';
@@ -853,44 +854,42 @@ function buildConstraintsDocumentation(property: PropertyType): string[] {
 
     return typeInfo;
 }
+
 /**
  * Formats hover information for intrinsic function arguments (like !Ref, !GetAtt arguments)
  *
- * @param entity - The entity being referenced (Resource, Parameter, Condition, Mapping)
  * @returns Formatted markdown string for hover display
  */
-export function formatIntrinsicArgumentHover(entity: Entity): string {
+export function formatIntrinsicArgumentHover(context: Context): string {
     const doc: string[] = [];
 
     // Add entity-specific information
-    switch (entity.entityType) {
+    switch (context.getEntityType()) {
         case EntityType.Resource: {
-            doc.push(formatResourceHover(entity as Resource));
+            doc.push(formatResourceHover(context.entity as Resource));
             break;
         }
 
         case EntityType.Parameter: {
             // Use the shared parameter formatter for consistent formatting
-            doc.push(formatParameterHover(entity as Parameter));
+            doc.push(formatParameterHover(context.entity as Parameter));
             break;
         }
 
         case EntityType.Condition: {
-            const condition = entity as Condition;
+            const condition = context.entity as Condition;
             doc.push(`**Condition:** ${condition.name}`);
             break;
         }
 
         case EntityType.Mapping: {
-            const mapping = entity as Mapping;
+            const mapping = context.entity as Mapping;
             doc.push(`**Mapping:** ${mapping.name}`);
             break;
         }
     }
 
-    const result = doc.filter((item) => item.trim() !== '').join('\n\n');
-
-    return result;
+    return doc.filter((item) => item.trim() !== '').join('\n\n');
 }
 
 /**
@@ -899,6 +898,7 @@ export function formatIntrinsicArgumentHover(entity: Entity): string {
 function getIntrinsicReturnType(intrinsicType: string, entity: Entity): string {
     switch (intrinsicType) {
         case 'Ref': {
+            // eslint-disable-next-line no-restricted-syntax -- Entity is already resolved
             switch (entity.entityType) {
                 case EntityType.Resource: {
                     return 'string';
@@ -1102,8 +1102,7 @@ export function formatParameterHover(parameter: Parameter): string {
         doc.push(`**Constraint Description:** ${parameter.ConstraintDescription}`);
     }
 
-    const result = doc.filter((item) => item.trim() !== '').join('\n\n');
-    return result;
+    return doc.filter((item) => item.trim() !== '').join('\n\n');
 }
 
 /**
@@ -1138,8 +1137,7 @@ export function formatResourceHover(resource: Resource): string {
         doc.push(`**Update Replace Policy:** ${resource.UpdateReplacePolicy}`);
     }
 
-    const result = doc.filter((item) => item.trim() !== '').join('\n\n');
-    return result;
+    return doc.filter((item) => item.trim() !== '').join('\n\n');
 }
 
 /**

--- a/src/hover/HoverRouter.ts
+++ b/src/hover/HoverRouter.ts
@@ -155,7 +155,7 @@ export class HoverRouter implements SettingsConfigurable, Closeable {
     }
 
     private getInfoForReference(context: Context): string | undefined {
-        switch (context.entity.entityType) {
+        switch (context.getEntityType()) {
             case EntityType.Parameter: {
                 return this.hoverProviderMap.get(HoverType.Parameter)?.getInformation(context);
             }

--- a/src/hover/IntrinsicFunctionArgumentHoverProvider.ts
+++ b/src/hover/IntrinsicFunctionArgumentHoverProvider.ts
@@ -92,7 +92,7 @@ export class IntrinsicFunctionArgumentHoverProvider implements HoverProvider {
     }
 
     private buildSchemaAndFormat(relatedContext: Context): string | undefined {
-        return formatIntrinsicArgumentHover(relatedContext.entity);
+        return formatIntrinsicArgumentHover(relatedContext);
     }
 
     /**
@@ -126,13 +126,13 @@ export class IntrinsicFunctionArgumentHoverProvider implements HoverProvider {
         }
 
         const resourceContext = resourcesSection.get(resourceLogicalId);
-        if (!resourceContext?.entity || resourceContext.entity.entityType !== EntityType.Resource) {
+        if (!resourceContext || resourceContext.getEntityType() !== EntityType.Resource) {
             return undefined;
         }
 
         const resource = resourceContext.entity as Resource;
         const resourceType = resource.Type;
-        if (!resourceType || typeof resourceType !== 'string') {
+        if (!resourceType) {
             return undefined;
         }
 

--- a/src/schema/transformers/RemoveMutuallyExclusivePropertiesTransformer.ts
+++ b/src/schema/transformers/RemoveMutuallyExclusivePropertiesTransformer.ts
@@ -1,3 +1,4 @@
+import { IntrinsicFunction } from '../../context/ContextType';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { PropertyType, ResourceSchema } from '../ResourceSchema';
 import { dependentExcludedMap } from './MutuallyExclusivePropertiesForValidation';
@@ -17,7 +18,7 @@ export class RemoveMutuallyExclusivePropertiesTransformer implements ResourceTem
     private readonly PATH_START = '#';
     private readonly UNINDEXED_PATH = '0';
     private readonly REFERENCE_MAX_DEPTH = 5;
-    private readonly GETATT_ID = 'Fn::GetAtt';
+    private readonly GETATT_ID = IntrinsicFunction.GetAtt as string;
     private readonly REF_ID = 'Ref';
     private readonly dependentExcludedMap = dependentExcludedMap;
 

--- a/src/services/extractToParameter/LiteralValueDetector.ts
+++ b/src/services/extractToParameter/LiteralValueDetector.ts
@@ -149,7 +149,7 @@ export class LiteralValueDetector {
         // These are functions where the value is already a reference to another resource/parameter
         const referenceFunctions = [
             'Ref',
-            'Fn::GetAtt',
+            IntrinsicFunction.GetAtt,
             'GetAtt', // YAML allows short forms without Fn:: prefix
             'Condition', // Condition references should also not be extractable
         ];

--- a/src/utils/PathUtils.ts
+++ b/src/utils/PathUtils.ts
@@ -1,4 +1,4 @@
-import { IntrinsicsSet } from '../context/ContextType';
+import { IntrinsicFunction, IntrinsicsSet } from '../context/ContextType';
 
 /**
  * Convert CloudFormation template path to JSON Pointer path format
@@ -20,7 +20,7 @@ export function templatePathToJsonPointerPath(templatePath: (string | number)[])
         if (typeof segment === 'number') {
             // Convert any number to wildcard
             segments.push('*');
-        } else if (segment === 'Fn::If') {
+        } else if (segment === (IntrinsicFunction.If as string)) {
             // Handle Fn::If specially
             const nextSegment = templatePath[i + 1];
             if (typeof nextSegment === 'number') {

--- a/tools/debug_tree.ts
+++ b/tools/debug_tree.ts
@@ -333,7 +333,7 @@ class DebugTreeTool {
 
                 if (context) {
                     // Store the JSON string for markdown output
-                    const record = context.record();
+                    const record = context.logRecord();
                     record['text'] = this.truncateWithEllipsis(context.text, 25);
                     contextInfo.contextJson = toString(record);
 

--- a/tst/unit/context/IntrinsicContext.test.ts
+++ b/tst/unit/context/IntrinsicContext.test.ts
@@ -61,7 +61,7 @@ describe('IntrinsicContext', () => {
     }
 
     function expectProperRecord(intrinsicContext: any, isInside: boolean, expectedType?: IntrinsicFunction) {
-        const record = intrinsicContext!.record();
+        const record = intrinsicContext!.logRecord();
         expect(record.isInsideIntrinsic).toBe(isInside);
 
         if (isInside && expectedType) {
@@ -208,7 +208,7 @@ describe('IntrinsicContext', () => {
                 expect(intrinsicContext).toBeDefined();
                 expectProperRecord(intrinsicContext, true, IntrinsicFunction.Ref);
 
-                const record = intrinsicContext!.record();
+                const record = intrinsicContext!.logRecord();
                 expect(record.intrinsicFunction!.logicalIds).toContain('StringParam');
             });
 
@@ -226,7 +226,7 @@ describe('IntrinsicContext', () => {
                 const functionInfo = expectIntrinsicFunction(context, IntrinsicFunction.FindInMap);
                 expectArrayProperties(functionInfo);
 
-                const record = functionInfo!.record();
+                const record = functionInfo!.logRecord();
                 expect(record.type).toBe(IntrinsicFunction.FindInMap);
                 expect(record.args).toBeDefined();
                 expect(Array.isArray(record.logicalIds)).toBe(true);
@@ -338,7 +338,7 @@ describe('IntrinsicContext', () => {
                 expect(intrinsicContext).toBeDefined();
                 expectProperRecord(intrinsicContext, true, IntrinsicFunction.Ref);
 
-                const record = intrinsicContext!.record();
+                const record = intrinsicContext!.logRecord();
                 expect(record.intrinsicFunction!.logicalIds).toContain('StringParam');
             });
 
@@ -356,7 +356,7 @@ describe('IntrinsicContext', () => {
                 const functionInfo = expectIntrinsicFunction(context, IntrinsicFunction.FindInMap);
                 expectArrayProperties(functionInfo);
 
-                const record = functionInfo!.record();
+                const record = functionInfo!.logRecord();
                 expect(record.type).toBe(IntrinsicFunction.FindInMap);
                 expect(record.args).toBeDefined();
                 expect(Array.isArray(record.logicalIds)).toBe(true);

--- a/tst/utils/MockContext.ts
+++ b/tst/utils/MockContext.ts
@@ -1,7 +1,7 @@
 import { Point, SyntaxNode } from 'tree-sitter';
 import { Position } from 'vscode-languageserver';
-import { Context, SectionType } from '../../src/context/Context';
-import { TopLevelSection } from '../../src/context/ContextType';
+import { Context } from '../../src/context/Context';
+import { SectionType, TopLevelSection } from '../../src/context/ContextType';
 import { ContextWithRelatedEntities } from '../../src/context/ContextWithRelatedEntities';
 import { Condition, Entity, Mapping, Output, Parameter, Resource, Unknown } from '../../src/context/semantic/Entity';
 import { PropertyPath } from '../../src/context/syntaxtree/SyntaxTree';

--- a/tst/utils/TemplateBuilder.ts
+++ b/tst/utils/TemplateBuilder.ts
@@ -6,9 +6,9 @@ import {
 } from 'vscode-languageserver-protocol/lib/common/protocol';
 import { Position, Range, TextDocument } from 'vscode-languageserver-textdocument';
 import { CompletionRouter, createCompletionProviders } from '../../src/autocomplete/CompletionRouter';
-import { Context, SectionType } from '../../src/context/Context';
+import { Context } from '../../src/context/Context';
 import { ContextManager } from '../../src/context/ContextManager';
-import { TopLevelSection } from '../../src/context/ContextType';
+import { SectionType, TopLevelSection } from '../../src/context/ContextType';
 import { SyntaxTreeManager } from '../../src/context/syntaxtree/SyntaxTreeManager';
 import { DocumentType } from '../../src/document/Document';
 import { DocumentManager } from '../../src/document/DocumentManager';
@@ -340,7 +340,7 @@ export class TemplateBuilder {
         }
 
         if (expected.entityProperties !== undefined) {
-            const actualProperties = context!.entity.record();
+            const actualProperties = context!.entity.logRecord();
             for (const [key, expectedValue] of Object.entries(expected.entityProperties)) {
                 expectAt(
                     actualProperties[key],

--- a/tst/utils/TemplateTestOrchestrator.ts
+++ b/tst/utils/TemplateTestOrchestrator.ts
@@ -104,7 +104,7 @@ export class TemplateTestOrchestrator {
             ) {
                 record = context?.entity.value;
             } else {
-                record = context?.entity.record();
+                record = context?.entity.logRecord();
             }
             // Normalize both entities for comparison
             const normalizedExpected = this.normalizeEntity(expectedEntity);


### PR DESCRIPTION
*Description of changes:*

This PR improves code quality and type safety by enforcing enum usage throughout the codebase:

**ESLint Rules Added:**
- Restrict raw string literals for TopLevelSection, EntityType, PseudoParameter, and ResourceAttribute
- Prevent usage of `logRecord()` in production code (debugging only)
- Prevent direct `entityType` property access (expensive operation)

**Code Improvements:**
- Replace string literals with enum constants (e.g., `'UpdatePolicy'` → `ResourceAttribute.UpdatePolicy`)
- Replace `entity.entityType` with `context.getEntityType()` for better performance
- Rename `record()` → `logRecord()` to clarify debugging intent
- Add `getEntityType()` helper method to Context class
- Move `SectionType` type definition to `ContextType.ts`

**Benefits:**
- Catch errors at lint time instead of runtime
- Safer refactoring with compile-time checks
- Eliminate magic strings
- Improved performance by avoiding expensive property lookups

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.