### PR TITLE
Modify getStackOutputs to be more centralized describeStack

### DIFF
--- a/src/handlers/StackHandler.ts
+++ b/src/handlers/StackHandler.ts
@@ -16,7 +16,7 @@ import {
     parseTemplateUriParams,
     parseGetStackEventsParams,
     parseClearStackEventsParams,
-    parseGetStackOutputsParams,
+    parseDescribeStackParams,
 } from '../stacks/actions/StackActionParser';
 import {
     TemplateUri,
@@ -42,8 +42,8 @@ import {
     GetStackEventsParams,
     GetStackEventsResult,
     ClearStackEventsParams,
-    GetStackOutputsParams,
-    GetStackOutputsResult,
+    DescribeStackParams,
+    DescribeStackResult,
     DescribeChangeSetParams,
     DescribeChangeSetResult,
 } from '../stacks/StackRequestType';
@@ -398,17 +398,17 @@ export function clearStackEventsHandler(
     };
 }
 
-export function getStackOutputsHandler(
+export function describeStackHandler(
     components: ServerComponents,
-): RequestHandler<GetStackOutputsParams, GetStackOutputsResult, void> {
-    return async (rawParams): Promise<GetStackOutputsResult> => {
+): RequestHandler<DescribeStackParams, DescribeStackResult, void> {
+    return async (rawParams): Promise<DescribeStackResult> => {
         try {
-            const params = parseWithPrettyError(parseGetStackOutputsParams, rawParams);
+            const params = parseWithPrettyError(parseDescribeStackParams, rawParams);
             const response = await components.cfnService.describeStacks({ StackName: params.stackName });
-            const outputs = response.Stacks?.[0]?.Outputs ?? [];
-            return { outputs };
+            const stack = response.Stacks?.[0];
+            return { stack };
         } catch (error) {
-            handleLspError(error, 'Failed to get stack outputs');
+            handleLspError(error, 'Failed to describe stack');
         }
     };
 }

--- a/src/protocol/LspStackHandlers.ts
+++ b/src/protocol/LspStackHandlers.ts
@@ -45,9 +45,9 @@ import {
     GetStackEventsRequest,
     ClearStackEventsParams,
     ClearStackEventsRequest,
-    GetStackOutputsParams,
-    GetStackOutputsResult,
-    GetStackOutputsRequest,
+    DescribeStackParams,
+    DescribeStackResult,
+    DescribeStackRequest,
     DescribeChangeSetParams,
     DescribeChangeSetResult,
     DescribeChangeSetRequest,
@@ -133,7 +133,7 @@ export class LspStackHandlers {
         this.connection.onRequest(ClearStackEventsRequest.method, handler);
     }
 
-    onGetStackOutputs(handler: RequestHandler<GetStackOutputsParams, GetStackOutputsResult, void>) {
-        this.connection.onRequest(GetStackOutputsRequest.method, handler);
+    onDescribeStack(handler: RequestHandler<DescribeStackParams, DescribeStackResult, void>) {
+        this.connection.onRequest(DescribeStackRequest.method, handler);
     }
 }

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -44,7 +44,7 @@ import {
     describeChangeSetDeletionStatusHandler,
     getStackEventsHandler,
     clearStackEventsHandler,
-    getStackOutputsHandler,
+    describeStackHandler,
     describeChangeSetHandler,
 } from '../handlers/StackHandler';
 import { LspComponents } from '../protocol/LspComponents';
@@ -125,7 +125,7 @@ export class CfnServer {
         this.lsp.stackHandlers.onGetStackTemplate(getManagedResourceStackTemplateHandler(this.components));
         this.lsp.stackHandlers.onGetStackEvents(getStackEventsHandler(this.components));
         this.lsp.stackHandlers.onClearStackEvents(clearStackEventsHandler(this.components));
-        this.lsp.stackHandlers.onGetStackOutputs(getStackOutputsHandler(this.components));
+        this.lsp.stackHandlers.onDescribeStack(describeStackHandler(this.components));
 
         this.lsp.environmentHandlers.onParseEnvironmentFiles(parseEnvironmentFilesHandler());
 

--- a/src/stacks/StackRequestType.ts
+++ b/src/stacks/StackRequestType.ts
@@ -1,4 +1,4 @@
-import { StackSummary, StackStatus, StackResourceSummary, StackEvent, Output } from '@aws-sdk/client-cloudformation';
+import { StackSummary, StackStatus, StackResourceSummary, StackEvent, Stack } from '@aws-sdk/client-cloudformation';
 import { RequestType } from 'vscode-languageserver-protocol';
 import { ChangeSetReference, StackChange } from './actions/StackActionRequestType';
 
@@ -95,16 +95,16 @@ export const ClearStackEventsRequest = new RequestType<ClearStackEventsParams, v
     'aws/cfn/stack/events/clear',
 );
 
-export type GetStackOutputsParams = {
+export type DescribeStackParams = {
     stackName: string;
 };
 
-export type GetStackOutputsResult = {
-    outputs: Output[];
+export type DescribeStackResult = {
+    stack?: Stack;
 };
 
-export const GetStackOutputsRequest = new RequestType<GetStackOutputsParams, GetStackOutputsResult, void>(
-    'aws/cfn/stack/outputs',
+export const DescribeStackRequest = new RequestType<DescribeStackParams, DescribeStackResult, void>(
+    'aws/cfn/stack/describe',
 );
 
 export const DescribeChangeSetRequest = new RequestType<DescribeChangeSetParams, DescribeChangeSetResult, void>(

--- a/src/stacks/actions/StackActionParser.ts
+++ b/src/stacks/actions/StackActionParser.ts
@@ -4,7 +4,7 @@ import {
     ListStackResourcesParams,
     GetStackEventsParams,
     ClearStackEventsParams,
-    GetStackOutputsParams,
+    DescribeStackParams,
     DescribeChangeSetParams,
 } from '../StackRequestType';
 import {
@@ -89,7 +89,7 @@ const ClearStackEventsParamsSchema = z.object({
     stackName: z.string().min(1).max(128),
 });
 
-const GetStackOutputsParamsSchema = z.object({
+const DescribeStackParamsSchema = z.object({
     stackName: z.string().min(1).max(128),
 });
 
@@ -121,8 +121,8 @@ export function parseClearStackEventsParams(input: unknown): ClearStackEventsPar
     return ClearStackEventsParamsSchema.parse(input);
 }
 
-export function parseGetStackOutputsParams(input: unknown): GetStackOutputsParams {
-    return GetStackOutputsParamsSchema.parse(input);
+export function parseDescribeStackParams(input: unknown): DescribeStackParams {
+    return DescribeStackParamsSchema.parse(input);
 }
 
 export function parseDescribeChangeSetParams(input: unknown): DescribeChangeSetParams {


### PR DESCRIPTION
*Description of changes:*
- We need a more centralized call to describeStacks since it will be used in multiple places
- Modified getStackOutputs to becomes DescribeStack which will return the entire stack[] object

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
