### PR TITLE
updated resource state importer to have custom logical id if called f…

### DIFF
--- a/src/resourceState/ResourceStateTypes.ts
+++ b/src/resourceState/ResourceStateTypes.ts
@@ -31,6 +31,7 @@ export interface ResourceStateParams {
     textDocument: TextDocumentIdentifier;
     resourceSelections?: ResourceSelection[];
     purpose: ResourceStatePurpose;
+    parentResourceType?: string;
 }
 
 export interface ResourceStateResult {


### PR DESCRIPTION
…rom related resources workflow

*Issue #, if available:*

*Description of changes:*
- Updated resource state imported to have a `parentResourceType` parameter which will be useful to find if the import workflow is opened from `Related resources` workflow or directly from `resource node`
- If import is performed through `Related Resources` workflow then the logicalid is set to `IAMManagedPolicyRelatedToIAMRole`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
