### PR TITLE
Updated to use parseValidYaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
       "devDependencies": {
         "@aws-sdk/types": "3.862.0",
         "@eslint/js": "9.34.0",
-        "@types/archiver": "^7.0.0",
+        "@types/archiver": "7.0.0",
         "@types/js-yaml": "4.0.9",
         "@types/luxon": "3.7.1",
         "@types/yargs": "17.0.33",

--- a/src/document/Document.ts
+++ b/src/document/Document.ts
@@ -5,7 +5,7 @@ import { detectCfnFileType } from './CloudFormationDetection';
 import { DocumentMetadata } from './DocumentProtocol';
 import { detectDocumentType, uriToPath } from './DocumentUtils';
 import { parseJson } from './JsonParser';
-import { parseYaml } from './YamlParser';
+import { parseValidYaml } from './YamlParser';
 
 export class Document {
     private readonly log = LoggerFactory.getLogger(Document);
@@ -44,7 +44,7 @@ export class Document {
         if (this.documentType === DocumentType.JSON) {
             return parseJson(this.contents());
         }
-        return parseYaml(this.contents(), 0, true);
+        return parseValidYaml(this.contents());
     }
 
     public getLine(lineNumber: number): string | undefined {

--- a/src/document/YamlParser.ts
+++ b/src/document/YamlParser.ts
@@ -37,6 +37,10 @@ export function parseYaml(yamlString: string, parseAttempt: number = 0, jsonPars
     }
 }
 
+export function parseValidYaml(validYamlString: string): any {
+    return load(validYamlString, { schema: CloudFormationSchema });
+}
+
 const CloudFormationYamlTypes = [
     // !Ref
     new Type('!Ref', {

--- a/tst/unit/document/Document.test.ts
+++ b/tst/unit/document/Document.test.ts
@@ -156,13 +156,12 @@ describe('Document', () => {
             expect(result).toBeDefined();
         });
 
-        it('should handle invalid YAML gracefully', () => {
-            const content = 'invalid:\n  - yaml\n    - structure';
+        it('should throw for invalid YAML', () => {
+            const content = 'key: value\n  invalid: indentation';
             const textDocument = TextDocument.create('file:///test.yaml', 'yaml', 1, content);
             const doc = new Document(textDocument);
 
-            const result = doc.getParsedDocumentContent();
-            expect(result).toBeDefined();
+            expect(() => doc.getParsedDocumentContent()).toThrow();
         });
     });
 });


### PR DESCRIPTION
*Issue #, if available:*
We're using the partial yaml parser which can lead to bad template

*Description of changes:*
Added parseValidYaml which only parses the valid yaml or throws

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
