### PR TITLE
Updated to parse jsonstring with JSON.parse

### DIFF
--- a/src/document/Document.ts
+++ b/src/document/Document.ts
@@ -4,7 +4,6 @@ import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { detectCfnFileType } from './CloudFormationDetection';
 import { DocumentMetadata } from './DocumentProtocol';
 import { detectDocumentType, uriToPath } from './DocumentUtils';
-import { parseJson } from './JsonParser';
 import { parseValidYaml } from './YamlParser';
 
 export class Document {
@@ -42,7 +41,7 @@ export class Document {
 
     public getParsedDocumentContent(): unknown {
         if (this.documentType === DocumentType.JSON) {
-            return parseJson(this.contents());
+            return JSON.parse(this.contents());
         }
         return parseValidYaml(this.contents());
     }

--- a/tst/unit/document/Document.test.ts
+++ b/tst/unit/document/Document.test.ts
@@ -147,13 +147,12 @@ describe('Document', () => {
             });
         });
 
-        it('should handle invalid JSON gracefully', () => {
+        it('should throw for invalid JSON', () => {
             const content = '{"invalid": json}';
             const textDocument = TextDocument.create('file:///test.json', 'json', 1, content);
             const doc = new Document(textDocument);
 
-            const result = doc.getParsedDocumentContent();
-            expect(result).toBeDefined();
+            expect(() => doc.getParsedDocumentContent()).toThrow();
         });
 
         it('should throw for invalid YAML', () => {


### PR DESCRIPTION
*Issue #, if available:*
Similar to https://github.com/aws-cloudformation/cloudformation-languageserver/pull/208, but for JSON

*Description of changes:*
updated JSON to also use full parser or throw if it's invalida

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
