### PR TITLE
Setting up infrastructure for e2e-integration test for LSP

### DIFF
--- a/tst/integration/Completion.test.ts
+++ b/tst/integration/Completion.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { TestExtension } from '../utils/TestExtension';
 import { wait, getSimpleYamlTemplateText } from '../utils/Utils';
 
-describe('E2E-Integration: Completion', () => {
+describe('Integration Test: Completion', () => {
     let client: TestExtension;
 
     beforeAll(async () => {
-        client = new TestExtension(undefined, false);
+        client = new TestExtension();
         await client.ready();
     }, 30000);
 

--- a/tst/integration/Hover.test.ts
+++ b/tst/integration/Hover.test.ts
@@ -2,11 +2,11 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { TestExtension } from '../utils/TestExtension';
 import { wait, getSimpleYamlTemplateText } from '../utils/Utils';
 
-describe('E2E-Integration: Hover', () => {
+describe('Integration Test: Hover', () => {
     let client: TestExtension;
 
     beforeAll(async () => {
-        client = new TestExtension(undefined, false);
+        client = new TestExtension();
         await client.ready();
     }, 30000);
 

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
     ...baseConfig,
     test: {
         ...baseConfig.test,
-        include: ['tst/integration/**/*.test.ts', 'tst/e2e/**/*.test.ts', 'tst/e2e-integration/**/*.e2e.test.ts'],
+        include: ['tst/integration/**/*.test.ts', 'tst/e2e/**/*.test.ts'],
     },
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Setting up the infrastructure for `End-to-End` integration tests for LSP
- `LspClient` starts a new Lsp server without any mocks and the requests are pass through the server and the tests validate the response.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
