### PR TITLE
Enable validation and deployment CodeLens only for templates with res…

### DIFF
--- a/src/codeLens/CodeLensProvider.ts
+++ b/src/codeLens/CodeLensProvider.ts
@@ -6,7 +6,7 @@ import { getStackActionsCodeLenses } from './StackActionsCodeLens';
 
 export class CodeLensProvider {
     constructor(
-        syntaxTreeManager: SyntaxTreeManager,
+        private readonly syntaxTreeManager: SyntaxTreeManager,
         private readonly documentManager: DocumentManager,
         private readonly managedResource: ManagedResourceCodeLens = new ManagedResourceCodeLens(syntaxTreeManager),
     ) {}
@@ -18,6 +18,9 @@ export class CodeLensProvider {
             return;
         }
 
-        return [...getStackActionsCodeLenses(uri), ...this.managedResource.getCodeLenses(uri, doc)];
+        return [
+            ...getStackActionsCodeLenses(uri, doc, this.syntaxTreeManager),
+            ...this.managedResource.getCodeLenses(uri, doc),
+        ];
     }
 }

--- a/src/codeLens/StackActionsCodeLens.ts
+++ b/src/codeLens/StackActionsCodeLens.ts
@@ -1,4 +1,8 @@
 import { CodeLens, Position, Range } from 'vscode-languageserver';
+import { TopLevelSection } from '../context/ContextType';
+import { getEntityMap } from '../context/SectionContextBuilder';
+import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
+import { Document } from '../document/Document';
 
 const STACK_ACTION_TITLES = {
     VALIDATE_DEPLOYMENT: 'Validate Deployment',
@@ -10,8 +14,39 @@ const STACK_ACTION_COMMANDS = {
     DEPLOY: 'aws.cloudformation.api.deployTemplate',
 } as const;
 
-export function getStackActionsCodeLenses(uri: string): CodeLens[] {
-    const range = Range.create(Position.create(0, 0), Position.create(0, 0));
+export function getStackActionsCodeLenses(
+    uri: string,
+    document: Document,
+    syntaxTreeManager: SyntaxTreeManager,
+): CodeLens[] {
+    const syntaxTree = syntaxTreeManager.getSyntaxTree(uri);
+    if (!syntaxTree) {
+        return [];
+    }
+
+    const resourcesMap = getEntityMap(syntaxTree, TopLevelSection.Resources);
+    if (!resourcesMap || resourcesMap.size === 0) {
+        return [];
+    }
+
+    if (!document.isTemplate()) {
+        document.updateCfnFileType();
+        if (!document.isTemplate()) {
+            return [];
+        }
+    }
+
+    let codeLensLine = 0;
+    const lines = document.getLines();
+    for (const [i, line] of lines.entries()) {
+        const lineContents = line.trim();
+        if (lineContents.length > 0 && !lineContents.startsWith('#')) {
+            codeLensLine = i;
+            break;
+        }
+    }
+
+    const range = Range.create(Position.create(codeLensLine, 0), Position.create(codeLensLine, 0));
 
     return [
         {

--- a/tst/unit/codeLens/StackActionsCodeLens.test.ts
+++ b/tst/unit/codeLens/StackActionsCodeLens.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { getStackActionsCodeLenses } from '../../../src/codeLens/StackActionsCodeLens';
+import { getEntityMap } from '../../../src/context/SectionContextBuilder';
+import { Document } from '../../../src/document/Document';
+import { createMockSyntaxTreeManager } from '../../utils/MockServerComponents';
+
+vi.mock('../../../src/context/SectionContextBuilder', () => ({
+    getEntityMap: vi.fn(),
+}));
+
+describe('StackActionsCodeLens', () => {
+    let mockSyntaxTreeManager: ReturnType<typeof createMockSyntaxTreeManager>;
+    let mockGetEntityMap: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockSyntaxTreeManager = createMockSyntaxTreeManager();
+        mockGetEntityMap = vi.mocked(getEntityMap);
+    });
+
+    it('should return empty array when syntax tree is not found', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns(undefined);
+
+        const document = new Document(
+            TextDocument.create('file:///test.yaml', 'yaml', 1, 'Resources:\n  Bucket:\n    Type: AWS::S3::Bucket'),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should return empty array when Resources section is not found', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(undefined);
+
+        const document = new Document(
+            TextDocument.create('file:///test.yaml', 'yaml', 1, 'AWSTemplateFormatVersion: "2010-09-09"'),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should return empty array when Resources section is empty', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map());
+
+        const document = new Document(TextDocument.create('file:///test.yaml', 'yaml', 1, 'Resources: {}'));
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should return empty array for non-template files', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create('file:///test.yaml', 'yaml', 1, 'some: random\nyaml: content'),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result).toEqual([]);
+    });
+
+    it('should return two code lenses for valid CFN template with Resources', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create('file:///test.yaml', 'yaml', 1, 'Resources:\n  Bucket:\n    Type: AWS::S3::Bucket'),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].command?.title).toBe('Validate Deployment');
+        expect(result[0].command?.command).toBe('aws.cloudformation.api.validateDeployment');
+        expect(result[0].command?.arguments).toEqual(['file:///test.yaml']);
+        expect(result[1].command?.title).toBe('Deploy Template');
+        expect(result[1].command?.command).toBe('aws.cloudformation.api.deployTemplate');
+        expect(result[1].command?.arguments).toEqual(['file:///test.yaml']);
+    });
+
+    it('should place code lens on line 0 for simple template', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create('file:///test.yaml', 'yaml', 1, 'Resources:\n  Bucket:\n    Type: AWS::S3::Bucket'),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result[0].range.start.line).toBe(0);
+        expect(result[0].range.end.line).toBe(0);
+    });
+
+    it('should skip empty lines and place code lens on first non-empty line', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create('file:///test.yaml', 'yaml', 1, '\n\nResources:\n  Bucket:\n    Type: AWS::S3::Bucket'),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result[0].range.start.line).toBe(2);
+    });
+
+    it('should skip comment lines and place code lens on first non-comment line', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create(
+                'file:///test.yaml',
+                'yaml',
+                1,
+                '# This is a comment\n# Another comment\nResources:\n  Bucket:\n    Type: AWS::S3::Bucket',
+            ),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result[0].range.start.line).toBe(2);
+    });
+
+    it('should skip empty and comment lines together', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create(
+                'file:///test.yaml',
+                'yaml',
+                1,
+                '\n# Comment\n\n# Another comment\n\nResources:\n  Bucket:\n    Type: AWS::S3::Bucket',
+            ),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result[0].range.start.line).toBe(5);
+    });
+
+    it('should handle template with AWSTemplateFormatVersion', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create(
+                'file:///test.yaml',
+                'yaml',
+                1,
+                'AWSTemplateFormatVersion: "2010-09-09"\nResources:\n  Bucket:\n    Type: AWS::S3::Bucket',
+            ),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result).toHaveLength(2);
+        expect(result[0].range.start.line).toBe(0);
+    });
+
+    it('should handle template with Transform', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Function', {}]]));
+
+        const document = new Document(
+            TextDocument.create(
+                'file:///test.yaml',
+                'yaml',
+                1,
+                'Transform: AWS::Serverless-2016-10-31\nResources:\n  Function:\n    Type: AWS::Serverless::Function',
+            ),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result).toHaveLength(2);
+    });
+
+    it('should handle JSON template', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create('file:///test.json', 'json', 1, '{"Resources":{"Bucket":{"Type":"AWS::S3::Bucket"}}}'),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.json', document, mockSyntaxTreeManager);
+
+        expect(result).toHaveLength(2);
+    });
+
+    it('should handle template with multiple resources', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(
+            new Map([
+                ['Bucket', {}],
+                ['Table', {}],
+                ['Function', {}],
+            ]),
+        );
+
+        const document = new Document(
+            TextDocument.create(
+                'file:///test.yaml',
+                'yaml',
+                1,
+                'Resources:\n  Bucket:\n    Type: AWS::S3::Bucket\n  Table:\n    Type: AWS::DynamoDB::Table',
+            ),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result).toHaveLength(2);
+    });
+
+    it('should handle whitespace-only lines correctly', () => {
+        mockSyntaxTreeManager.getSyntaxTree.returns({ rootNode: {} } as any);
+        mockGetEntityMap.mockReturnValue(new Map([['Bucket', {}]]));
+
+        const document = new Document(
+            TextDocument.create(
+                'file:///test.yaml',
+                'yaml',
+                1,
+                '   \n\t\n  \nResources:\n  Bucket:\n    Type: AWS::S3::Bucket',
+            ),
+        );
+
+        const result = getStackActionsCodeLenses('file:///test.yaml', document, mockSyntaxTreeManager);
+
+        expect(result[0].range.start.line).toBe(3);
+    });
+});


### PR DESCRIPTION
…ources

*Issue #, if available:*

*Description of changes:*
- prevent `Validate Deployment | Deploy Template` CodeLens from being provided on non-template files
- match line where the deployment CodeLens are provided to be the same as `Visualize with Infrastructure Composer`
- moving all 3 to top of file can be addressed after final integration and collaboration with Toolkit
<img width="461" height="170" alt="image" src="https://github.com/user-attachments/assets/a1ce4f6e-8374-446e-9ff5-9430f04d3d86" />

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
