### PR TITLE
Create databases on start, increase database size and improve logging…

### DIFF
--- a/src/app/standalone.ts
+++ b/src/app/standalone.ts
@@ -1,3 +1,4 @@
+import { arch, platform } from 'os';
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
 import { InitializedParams } from 'vscode-languageserver-protocol';
 import { LspCapabilities } from '../protocol/LspCapabilities';
@@ -33,6 +34,11 @@ async function onInitialize(params: ExtendedInitializeParams) {
         },
         `${ExtensionName} initializing...`,
     );
+    getLogger().info({
+        Machine: `${platform()}-${arch()}`,
+        Process: `${process.platform}-${process.arch}`,
+        Runtime: `node=${process.versions.node} v8=${process.versions.v8} uv=${process.versions.uv} modules=${process.versions.modules}`,
+    });
     LoggerFactory.initialize(AwsMetadata);
     TelemetryService.initialize(ClientInfo, AwsMetadata);
 
@@ -46,8 +52,8 @@ async function onInitialize(params: ExtendedInitializeParams) {
 }
 
 function onInitialized(params: InitializedParams) {
-    getLogger().info(`${ExtensionName} initialized`);
     (server as any).initialized(params);
+    getLogger().info(`${ExtensionName} initialized`);
 }
 
 function onShutdown() {

--- a/src/datastore/MemoryStore.ts
+++ b/src/datastore/MemoryStore.ts
@@ -1,7 +1,7 @@
 import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
 import { Telemetry } from '../telemetry/TelemetryDecorator';
 import { TelemetryService } from '../telemetry/TelemetryService';
-import { DataStore, DataStoreFactory } from './DataStore';
+import { DataStore, DataStoreFactory, StoreName } from './DataStore';
 
 export class MemoryStore implements DataStore {
     private readonly store = new Map<string, unknown>();
@@ -47,13 +47,13 @@ export class MemoryStore implements DataStore {
 export class MemoryStoreFactory implements DataStoreFactory {
     @Telemetry({ scope: 'MemoryStore.Global' }) private readonly telemetry!: ScopedTelemetry;
 
-    private readonly stores = new Map<string, MemoryStore>();
+    private readonly stores = new Map<StoreName, MemoryStore>();
 
     constructor() {
         this.registerMemoryStoreGauges();
     }
 
-    getOrCreate(store: string): DataStore {
+    get(store: StoreName): DataStore {
         let val = this.stores.get(store);
         if (val === undefined) {
             val = new MemoryStore(store);
@@ -65,21 +65,6 @@ export class MemoryStoreFactory implements DataStoreFactory {
 
     storeNames(): ReadonlyArray<string> {
         return [...this.stores.keys()];
-    }
-
-    stats(): unknown {
-        const keys = [];
-        const stores: Record<string, number> = {};
-        for (const [key, value] of this.stores.entries()) {
-            keys.push(key);
-            stores[key] = value.keys().length;
-        }
-
-        return {
-            numStores: keys.length,
-            storeNames: keys.sort(),
-            stores,
-        };
     }
 
     close(): Promise<void> {

--- a/src/schema/CombinedSchemas.ts
+++ b/src/schema/CombinedSchemas.ts
@@ -28,7 +28,7 @@ export class CombinedSchemas {
         const samSchema = samSchemas === undefined ? undefined : SamSchemas.from(samSchemas);
 
         CombinedSchemas.log.info(
-            `Schemas from ${regionalSchemas?.schemas.length} public schemas, ${privateSchema?.schemas.size} private schemas and ${samSchema?.schemas.size} sam schemas`,
+            `Combined schemas from public=${regionalSchemas?.schemas.length}, private=${privateSchema?.schemas.size}, SAM=${samSchema?.schemas.size}`,
         );
         return new CombinedSchemas(regionalSchema, privateSchema, samSchema);
     }

--- a/src/schema/GetSamSchemaTask.ts
+++ b/src/schema/GetSamSchemaTask.ts
@@ -1,12 +1,10 @@
+import { Logger } from 'pino';
 import { DataStore } from '../datastore/DataStore';
-import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Measure } from '../telemetry/TelemetryDecorator';
 import { downloadJson } from '../utils/RemoteDownload';
 import { GetSchemaTask } from './GetSchemaTask';
 import { SamSchemas, SamSchemasType, SamStoreKey } from './SamSchemas';
 import { CloudFormationResourceSchema, SamSchema, SamSchemaTransformer } from './SamSchemaTransformer';
-
-const logger = LoggerFactory.getLogger('GetSamSchemaTask');
 
 export class GetSamSchemaTask extends GetSchemaTask {
     constructor(private readonly getSamSchemas: () => Promise<Map<string, CloudFormationResourceSchema>>) {
@@ -14,7 +12,7 @@ export class GetSamSchemaTask extends GetSchemaTask {
     }
 
     @Measure({ name: 'getSchemas' })
-    override async runImpl(dataStore: DataStore): Promise<void> {
+    protected override async runImpl(dataStore: DataStore, logger?: Logger): Promise<void> {
         try {
             const resourceSchemas = await this.getSamSchemas();
 
@@ -34,9 +32,9 @@ export class GetSamSchemaTask extends GetSchemaTask {
 
             await dataStore.put(SamStoreKey, samSchemasData);
 
-            logger.info(`Downloaded and stored ${resourceSchemas.size} SAM resource schemas`);
+            logger?.info(`${resourceSchemas.size} SAM schemas downloaded and stored`);
         } catch (error) {
-            logger.error(error, 'Failed to download SAM schema');
+            logger?.error(error, 'Failed to download SAM schema');
             throw error;
         }
     }

--- a/src/schema/GetSchemaTask.ts
+++ b/src/schema/GetSchemaTask.ts
@@ -35,7 +35,7 @@ export class GetPublicSchemaTask extends GetSchemaTask {
     }
 
     @Measure({ name: 'getSchemas' })
-    override async runImpl(dataStore: DataStore, logger?: Logger) {
+    protected override async runImpl(dataStore: DataStore, logger?: Logger) {
         if (this.attempts >= GetPublicSchemaTask.MaxAttempts) {
             logger?.error(`Reached max attempts for retrieving schemas for ${this.region} without success`);
             return;
@@ -53,7 +53,7 @@ export class GetPublicSchemaTask extends GetSchemaTask {
         };
 
         await dataStore.put<RegionalSchemasType>(this.region, value);
-        logger?.info(`${schemas.length} resource schemas retrieved for ${this.region}`);
+        logger?.info(`${schemas.length} public schemas retrieved for ${this.region}`);
     }
 }
 
@@ -68,7 +68,7 @@ export class GetPrivateSchemasTask extends GetSchemaTask {
     }
 
     @Measure({ name: 'getSchemas' })
-    override async runImpl(dataStore: DataStore, logger?: Logger) {
+    protected override async runImpl(dataStore: DataStore, logger?: Logger) {
         try {
             const profile = this.getProfile();
             if (this.processedProfiles.has(profile)) {
@@ -88,11 +88,7 @@ export class GetPrivateSchemasTask extends GetSchemaTask {
             await dataStore.put<PrivateSchemasType>(profile, value);
 
             this.processedProfiles.add(profile);
-            if (schemas.length > 0) {
-                void logger?.info(`${schemas.length} private registry schemas retrieved for profile: ${profile}`);
-            } else {
-                logger?.info(`No private registry schemas found for profile: ${profile}`);
-            }
+            logger?.info(`${schemas.length} private schemas retrieved for profile: ${profile}`);
         } catch (error) {
             logger?.error(error, `Failed to get private schemas`);
             throw error;

--- a/src/schema/SchemaRetriever.ts
+++ b/src/schema/SchemaRetriever.ts
@@ -9,7 +9,6 @@ import { Closeable } from '../utils/Closeable';
 import { AwsRegion, getRegion } from '../utils/Region';
 import { CombinedSchemas } from './CombinedSchemas';
 import { GetSchemaTaskManager } from './GetSchemaTaskManager';
-import { PrivateSchemasType } from './PrivateSchemas';
 import { RegionalSchemasType, SchemaFileType } from './RegionalSchemas';
 import { SamSchemasType, SamStoreKey } from './SamSchemas';
 import { CloudFormationResourceSchema } from './SamSchemaTransformer';
@@ -18,7 +17,6 @@ import { SchemaStore } from './SchemaStore';
 const StaleDaysThreshold = 7;
 
 export class SchemaRetriever implements SettingsConfigurable, Closeable {
-    readonly availableRegions: Set<AwsRegion> = new Set();
     private settingsSubscription?: SettingsSubscription;
     private settings: ProfileSettings = DefaultSettings.profile;
     private readonly log = LoggerFactory.getLogger(SchemaRetriever);
@@ -102,45 +100,23 @@ export class SchemaRetriever implements SettingsConfigurable, Closeable {
     @Measure({ name: 'getSchemas' })
     get(region: AwsRegion, profile: string): CombinedSchemas {
         // Check if combined schemas are already cached first
-        const cacheKey = `${region}:${profile}`;
-        const cachedCombined = this.schemaStore.combinedSchemas.get<CombinedSchemas>(cacheKey);
-
+        const cachedCombined = this.schemaStore.get(region, profile);
         if (cachedCombined) {
             return cachedCombined;
         }
 
         // Only do expensive regional check if no cached combined schemas
         const regionalSchemas = this.getRegionalSchemasFromStore(region);
-        if (regionalSchemas) {
-            this.availableRegions.add(region);
-        } else {
+        if (!regionalSchemas) {
             this.schemaTaskManager.addTask(region);
         }
 
-        // Create and cache combined schemas
-        const privateSchemas = this.schemaStore.privateSchemas.get<PrivateSchemasType>(profile);
-        const samSchemas = this.schemaStore.samSchemas.get<SamSchemasType>(SamStoreKey);
-        const combinedSchemas = CombinedSchemas.from(regionalSchemas, privateSchemas, samSchemas);
-
-        void this.schemaStore.combinedSchemas.put(cacheKey, combinedSchemas);
-        return combinedSchemas;
+        return this.schemaStore.put(region, profile, regionalSchemas);
     }
 
     updatePrivateSchemas() {
         this.schemaStore.invalidateCombinedSchemas();
         this.schemaTaskManager.runPrivateTask();
-    }
-
-    // Method to invalidate cache when any schemas are updated
-    invalidateCache() {
-        this.schemaStore.invalidateCombinedSchemas();
-    }
-
-    // Proactively rebuild combined schemas to avoid lazy loading delays
-    @Measure({ name: 'rebuildCurrentSchemas' })
-    rebuildForCurrentSettings() {
-        this.schemaStore.invalidateCombinedSchemas();
-        this.get(this.settings.region, this.settings.profile);
     }
 
     // Surgically rebuild affected combined schemas
@@ -149,7 +125,7 @@ export class SchemaRetriever implements SettingsConfigurable, Closeable {
         if (!updatedRegion && !updatedProfile) {
             // SAM update - affects all schemas
             this.schemaStore.invalidateCombinedSchemas();
-            this.rebuildForCurrentSettings();
+            this.get(this.settings.region, this.settings.profile);
             return;
         }
 
@@ -158,7 +134,7 @@ export class SchemaRetriever implements SettingsConfigurable, Closeable {
             const [region, profile] = key.split(':');
             if ((updatedRegion && region === updatedRegion) || (updatedProfile && profile === updatedProfile)) {
                 // Invalidate and rebuild this specific combined schema
-                void this.schemaStore.combinedSchemas.remove(key);
+                this.schemaStore.combinedSchemas.remove(key).catch(this.log.error);
                 this.get(region as AwsRegion, profile);
             }
         }

--- a/src/schema/SchemaStore.ts
+++ b/src/schema/SchemaStore.ts
@@ -1,14 +1,39 @@
-import { DataStoreFactoryProvider, Persistence } from '../datastore/DataStore';
+import { DataStoreFactoryProvider, Persistence, StoreName } from '../datastore/DataStore';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { AwsRegion } from '../utils/Region';
+import { CombinedSchemas } from './CombinedSchemas';
+import { PrivateSchemasType } from './PrivateSchemas';
+import { RegionalSchemasType } from './RegionalSchemas';
+import { SamSchemasType, SamStoreKey } from './SamSchemas';
 
 export class SchemaStore {
-    public readonly publicSchemas = this.dataStoreFactory.get('public_schemas', Persistence.local);
-    public readonly privateSchemas = this.dataStoreFactory.get('private_schemas', Persistence.memory);
-    public readonly samSchemas = this.dataStoreFactory.get('sam_schemas', Persistence.local);
-    public readonly combinedSchemas = this.dataStoreFactory.get('combined_schemas', Persistence.memory);
+    private readonly log = LoggerFactory.getLogger(SchemaStore);
+
+    public readonly publicSchemas = this.dataStoreFactory.get(StoreName.public_schemas, Persistence.local);
+    public readonly privateSchemas = this.dataStoreFactory.get(StoreName.private_schemas, Persistence.memory);
+    public readonly samSchemas = this.dataStoreFactory.get(StoreName.sam_schemas, Persistence.local);
+    public readonly combinedSchemas = this.dataStoreFactory.get(StoreName.combined_schemas, Persistence.memory);
 
     constructor(private readonly dataStoreFactory: DataStoreFactoryProvider) {}
 
-    invalidateCombinedSchemas() {
-        void this.combinedSchemas.clear();
+    get(region: AwsRegion, profile: string) {
+        return this.combinedSchemas.get<CombinedSchemas>(cacheKey(region, profile));
     }
+
+    put(region: AwsRegion, profile: string, regionalSchemas?: RegionalSchemasType): CombinedSchemas {
+        const privateSchemas = this.privateSchemas.get<PrivateSchemasType>(profile);
+        const samSchemas = this.samSchemas.get<SamSchemasType>(SamStoreKey);
+
+        const combined = CombinedSchemas.from(regionalSchemas, privateSchemas, samSchemas);
+        this.combinedSchemas.put(cacheKey(region, profile), combined).catch(this.log.error);
+        return combined;
+    }
+
+    invalidateCombinedSchemas() {
+        this.combinedSchemas.clear().catch(this.log.error);
+    }
+}
+
+function cacheKey(region: AwsRegion, profile: string) {
+    return `${region}:${profile}`;
 }

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -68,14 +68,13 @@ export class CfnServer {
         private readonly external = new CfnExternal(lsp, core),
         private readonly providers = new CfnLspProviders(core, external),
     ) {
-        log.info('Initializing...');
+        log.info(`Setting up LSP handlers...`);
         this.components = {
             ...core,
             ...external,
             ...providers,
         };
 
-        log.info('Seting up handlers...');
         this.setupHandlers();
     }
 

--- a/tst/unit/datastore/LMDB.test.ts
+++ b/tst/unit/datastore/LMDB.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path, { join } from 'path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { DataStore } from '../../../src/datastore/DataStore';
+import { DataStore, StoreName } from '../../../src/datastore/DataStore';
 import { LMDBStoreFactory } from '../../../src/datastore/LMDB';
 
 describe('LMDB', () => {
@@ -15,7 +15,7 @@ describe('LMDB', () => {
         }
 
         lmdbFactory = new LMDBStoreFactory(testDir);
-        lmdbStore = lmdbFactory.getOrCreate('test-store');
+        lmdbStore = lmdbFactory.get(StoreName.public_schemas);
     });
 
     afterEach(async () => {
@@ -78,8 +78,8 @@ describe('LMDB', () => {
             const schemaValue = 'schema-value';
             const astValue = 'ast-value';
 
-            const schemaStore = lmdbFactory.getOrCreate('schemas');
-            const astStore = lmdbFactory.getOrCreate('ast');
+            const schemaStore = lmdbFactory.get(StoreName.public_schemas);
+            const astStore = lmdbFactory.get(StoreName.sam_schemas);
 
             await schemaStore.put(key, schemaValue);
             await astStore.put(key, astValue);
@@ -148,16 +148,13 @@ describe('LMDB', () => {
             const key = 'shared-key';
             const schemaValue = 'schema-value';
             const astValue = 'ast-value';
-            const settingsValue = 'settings-value';
 
-            const schemaStore = lmdbFactory.getOrCreate('schemas');
-            const astStore = lmdbFactory.getOrCreate('ast');
-            const settingsStore = lmdbFactory.getOrCreate('settings');
+            const schemaStore = lmdbFactory.get(StoreName.public_schemas);
+            const astStore = lmdbFactory.get(StoreName.sam_schemas);
 
             // Add data to multiple stores
             await schemaStore.put(key, schemaValue);
             await astStore.put(key, astValue);
-            await settingsStore.put(key, settingsValue);
 
             // Clear only the schemas store
             await schemaStore.clear();
@@ -165,7 +162,6 @@ describe('LMDB', () => {
             // Verify only schemas store is cleared
             expect(schemaStore.get<string>(key)).toBeUndefined();
             expect(astStore.get<string>(key)).toBe(astValue);
-            expect(settingsStore.get<string>(key)).toBe(settingsValue);
         });
 
         it('should allow putting new data after clearing', async () => {
@@ -199,7 +195,7 @@ describe('LMDB', () => {
 
             // Create new instance that should load from the same files
             const newFactory = new LMDBStoreFactory(testDir);
-            const newStore = newFactory.getOrCreate('test-store');
+            const newStore = newFactory.get(StoreName.public_schemas);
             const result = newStore.get<typeof value>(key);
 
             expect(result).toEqual(value);

--- a/tst/unit/datastore/MemoryStore.test.ts
+++ b/tst/unit/datastore/MemoryStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { DataStore } from '../../../src/datastore/DataStore';
+import { DataStore, StoreName } from '../../../src/datastore/DataStore';
 import { MemoryStoreFactory } from '../../../src/datastore/MemoryStore';
 
 describe('MemoryStore', () => {
@@ -8,7 +8,7 @@ describe('MemoryStore', () => {
 
     beforeEach(() => {
         memoryFactory = new MemoryStoreFactory();
-        memoryStore = memoryFactory.getOrCreate('test-store');
+        memoryStore = memoryFactory.get(StoreName.public_schemas);
     });
 
     describe('get', () => {
@@ -32,8 +32,8 @@ describe('MemoryStore', () => {
             const schemaValue = { type: 'schema' };
             const astValue = { type: 'ast' };
 
-            const schemaStore = memoryFactory.getOrCreate('schemas');
-            const astStore = memoryFactory.getOrCreate('ast');
+            const schemaStore = memoryFactory.get(StoreName.public_schemas);
+            const astStore = memoryFactory.get(StoreName.sam_schemas);
 
             await schemaStore.put(key, schemaValue);
             await astStore.put(key, astValue);
@@ -88,8 +88,8 @@ describe('MemoryStore', () => {
             const schemaValue = 'schema-value';
             const astValue = 'ast-value';
 
-            const schemaStore = memoryFactory.getOrCreate('schemas');
-            const astStore = memoryFactory.getOrCreate('ast');
+            const schemaStore = memoryFactory.get(StoreName.public_schemas);
+            const astStore = memoryFactory.get(StoreName.sam_schemas);
 
             await schemaStore.put(key, schemaValue);
             await astStore.put(key, astValue);
@@ -135,9 +135,9 @@ describe('MemoryStore', () => {
             const astValue = 'ast-value';
             const settingsValue = 'settings-value';
 
-            const schemaStore = memoryFactory.getOrCreate('schemas');
-            const astStore = memoryFactory.getOrCreate('ast');
-            const settingsStore = memoryFactory.getOrCreate('settings');
+            const schemaStore = memoryFactory.get(StoreName.public_schemas);
+            const astStore = memoryFactory.get(StoreName.sam_schemas);
+            const settingsStore = memoryFactory.get(StoreName.private_schemas);
 
             // Add data to multiple stores
             await schemaStore.put(key, schemaValue);
@@ -170,42 +170,6 @@ describe('MemoryStore', () => {
             expect(memoryStore.get<string>('key1')).toBeUndefined();
             expect(memoryStore.get<string>('key2')).toBeUndefined();
         });
-
-        it('should update factory stats correctly after clearing', async () => {
-            const schemaStore = memoryFactory.getOrCreate('schemas');
-            const astStore = memoryFactory.getOrCreate('ast');
-
-            // Add data to multiple stores
-            await schemaStore.put('key1', 'value1');
-            await schemaStore.put('key2', 'value2');
-            await astStore.put('key1', 'value1');
-
-            // Verify initial stats (including test-store from beforeEach)
-            let stats = memoryFactory.stats() as {
-                numStores: number;
-                storeNames: string[];
-                stores: Record<string, number>;
-            };
-            expect(stats.numStores).toBe(3); // test-store, schemas, ast
-            expect(stats.stores.schemas).toBe(2);
-            expect(stats.stores.ast).toBe(1);
-
-            // Clear schemas store
-            await schemaStore.clear();
-
-            // Verify updated stats - cleared store still exists but with 0 entries
-            stats = memoryFactory.stats() as {
-                numStores: number;
-                storeNames: string[];
-                stores: Record<string, number>;
-            };
-            expect(stats.numStores).toBe(3); // test-store, schemas, ast
-            expect(stats.storeNames).toContain('ast');
-            expect(stats.storeNames).toContain('schemas');
-            expect(stats.storeNames).toContain('test-store');
-            expect(stats.stores.schemas).toBe(0);
-            expect(stats.stores.ast).toBe(1);
-        });
     });
 
     describe('keys', () => {
@@ -229,82 +193,16 @@ describe('MemoryStore', () => {
         });
     });
 
-    describe('stats', () => {
-        it('should return stats including test-store for a factory with one store', () => {
-            const stats = memoryFactory.stats() as {
-                numStores: number;
-                storeNames: string[];
-                stores: Record<string, number>;
-            };
-
-            expect(stats.numStores).toBe(1); // test-store from beforeEach
-            expect(stats.storeNames).toEqual(['test-store']);
-            expect(stats.stores).toEqual({ 'test-store': 0 });
-        });
-
-        it('should return correct stats after adding items', async () => {
-            const schemaStore = memoryFactory.getOrCreate('schemas');
-            const astStore = memoryFactory.getOrCreate('ast');
-
-            await schemaStore.put('key1', 'value1');
-            await schemaStore.put('key2', 'value2');
-            await astStore.put('key1', 'value1');
-
-            const stats = memoryFactory.stats() as {
-                numStores: number;
-                storeNames: string[];
-                stores: Record<string, number>;
-            };
-
-            expect(stats.numStores).toBe(3); // test-store, schemas, ast
-            expect(stats.storeNames).toEqual(['ast', 'schemas', 'test-store']);
-            expect(stats.stores).toEqual({
-                schemas: 2,
-                ast: 1,
-                'test-store': 0,
-            });
-        });
-
-        it('should update stats after removing items', async () => {
-            const schemaStore = memoryFactory.getOrCreate('schemas');
-
-            await schemaStore.put('key1', 'value1');
-            await schemaStore.put('key2', 'value2');
-            await schemaStore.remove('key1');
-
-            const stats = memoryFactory.stats() as {
-                numStores: number;
-                storeNames: string[];
-                stores: Record<string, number>;
-            };
-
-            expect(stats.numStores).toBe(2); // test-store, schemas
-            expect(stats.storeNames).toEqual(['schemas', 'test-store']);
-            expect(stats.stores).toEqual({
-                schemas: 1,
-                'test-store': 0,
-            });
-        });
-    });
-
     describe('close', () => {
+        // eslint-disable-next-line vitest/expect-expect
         it('should close factory without error', async () => {
-            const schemaStore = memoryFactory.getOrCreate('schemas');
-            const astStore = memoryFactory.getOrCreate('ast');
+            const schemaStore = memoryFactory.get(StoreName.public_schemas);
+            const astStore = memoryFactory.get(StoreName.sam_schemas);
 
             await schemaStore.put('key1', 'value1');
             await astStore.put('key1', 'value1');
 
             await memoryFactory.close();
-
-            // Factory should still report stores exist after close
-            const stats = memoryFactory.stats() as {
-                numStores: number;
-                storeNames: string[];
-                stores: Record<string, number>;
-            };
-
-            expect(stats.numStores).toBe(3); // test-store, schemas, ast
         });
     });
 });

--- a/tst/unit/schema/GetSchemaTask.test.ts
+++ b/tst/unit/schema/GetSchemaTask.test.ts
@@ -51,9 +51,7 @@ describe('GetSchemaTask', () => {
             );
 
             expect(
-                mockLogger.info.calledWith(
-                    `${mockSchemas.length} resource schemas retrieved for ${AwsRegion.US_EAST_1}`,
-                ),
+                mockLogger.info.calledWith(`${mockSchemas.length} public schemas retrieved for ${AwsRegion.US_EAST_1}`),
             ).toBe(true);
 
             dateNowSpy.mockRestore();

--- a/tst/unit/schema/SchemaRetriever.test.ts
+++ b/tst/unit/schema/SchemaRetriever.test.ts
@@ -123,14 +123,6 @@ describe('SchemaRetriever', () => {
         expect(mockGetPublicSchemas).toHaveBeenCalledWith(AwsRegion.US_EAST_1);
     });
 
-    it('should track available regions', async () => {
-        // Put data in the store first
-        await schemaStore.publicSchemas.put(AwsRegion.US_EAST_1, mockSchemaData);
-
-        schemaRetriever.get(AwsRegion.US_EAST_1, 'default');
-        expect(schemaRetriever.availableRegions.has(AwsRegion.US_EAST_1)).toBe(true);
-    });
-
     it('should get default schema using user settings', async () => {
         // Put data in the store first
         await schemaStore.publicSchemas.put(AwsRegion.US_EAST_1, mockSchemaData);
@@ -173,23 +165,6 @@ describe('SchemaRetriever', () => {
 
         // Rebuild affected schemas
         schemaRetriever.rebuildAffectedCombinedSchemas(AwsRegion.US_EAST_1);
-
-        // Should still have the schema (rebuilt)
-        expect(schemaStore.combinedSchemas.keys(10)).toHaveLength(1);
-    });
-
-    it('should rebuild for current settings', async () => {
-        // Put data in the store first
-        await schemaStore.publicSchemas.put(AwsRegion.US_EAST_1, mockSchemaData);
-
-        // Get a schema to create a cached entry
-        schemaRetriever.get(AwsRegion.US_EAST_1, 'default');
-
-        // Verify it's cached
-        expect(schemaStore.combinedSchemas.keys(10)).toHaveLength(1);
-
-        // Rebuild for current settings
-        schemaRetriever.rebuildForCurrentSettings();
 
         // Should still have the schema (rebuilt)
         expect(schemaStore.combinedSchemas.keys(10)).toHaveLength(1);


### PR DESCRIPTION
## Summary

This PR refactors the CloudFormation Language Server's data storage layer with a focus on initialization, performance, and observability improvements.

## Changes

### 1. Database Initialization Strategy
• **Before**: Databases were created lazily on first access via getOrCreate()
• **After**: Databases are created upfront during LMDB initialization
• Stores are now explicitly defined using a StoreName enum instead of arbitrary strings

### 2. Increased Database Size
• LMDB max size increased from 100MB → 250MB 
  • With SAM schemas the total database is already > 100MB
• Added configuration for page size (8192) and remapping chunks for better performance

### 3. Logging & Metrics
• Added system information logging on startup (OS platform, architecture, Node.js version, V8 version)
• Improved log messages to be more concise and informative:
  • "X public schemas retrieved" instead of "X resource schemas retrieved"
  • "Combined schemas from public=X, private=Y, SAM=Z"
• Enhanced LMDB metrics with per-store size and entry counts
• Added global database usage percentage metric


## Runtime Memory Safety Changes

### **LMDB Memory Access**

Before: Databases created inside transactionSync() with race conditions
After: All databases created synchronously during constructor before any async operations
typescript

Impact:
• **No lazy async database creation** - eliminates race conditions where multiple threads try to create same store
• **Memory mapped before use** - all LMDB memory regions mapped at startup, no runtime mapping failures
• **remapChunks: true** - allows safe remapping if database grows beyond initial allocation
• **Predictable memory layout** - all stores exist in memory map from start, no fragmentation from lazy creation

### **Async/Sync Safety**

Fix: Removed void promises that silently swallow errors
Impact:
• **No silent failures** - async errors in cache operations now visible
• **Proper error propagation** - LMDB write failures won't be ignored
• **Safer concurrent access** - errors from race conditions will be logged instead of lost

### **Memory Unmapping Risk**

Before: Stores could be accessed before memory mapping completed (lazy creation)

After:
• All memory regions mapped synchronously at startup
• No dynamic store creation means no runtime unmapping/remapping during access