### PR TITLE
Insert newline at the end of YAML resource state import/clone

### DIFF
--- a/src/resourceState/ResourceStateImporter.ts
+++ b/src/resourceState/ResourceStateImporter.ts
@@ -335,10 +335,10 @@ export class ResourceStateImporter {
         const yamlOutput = this.yamlStringifyPreservingSnippets(output);
         if (resourceSectionExists) {
             // Existing resource section - add 2 spaces to all lines for proper indentation
-            return '\n  ' + yamlOutput.replaceAll('\n', '\n  ').trim();
+            return '\n  ' + yamlOutput.replaceAll('\n', '\n  ').trim() + '\n';
         } else {
             // No resource section - content is already properly indented
-            return '\n' + yamlOutput.trim();
+            return '\n' + yamlOutput.trim() + '\n';
         }
     }
 

--- a/tst/unit/resourceState/StateImportExpectation.ts
+++ b/tst/unit/resourceState/StateImportExpectation.ts
@@ -207,7 +207,8 @@ ${formatPropertiesForYaml(properties)}
     Metadata:
       PrimaryIdentifier: ${identifier}
       ManagedByStack: "true"
-      StackName: test-stack`);
+      StackName: test-stack
+`);
         } else {
             return PlaceholderReplacer.replaceWithTabStops(`
 Resources:
@@ -219,7 +220,8 @@ ${formatPropertiesForYaml(properties)}
     Metadata:
       PrimaryIdentifier: ${identifier}
       ManagedByStack: "true"
-      StackName: test-stack`);
+      StackName: test-stack
+`);
         }
     }
 }
@@ -282,7 +284,8 @@ export function getCloneExpectation(scenario: TestScenario, resourceType: string
     Properties:
 ${formatPropertiesForYaml(cloneProperties)}
     Metadata:
-      PrimaryIdentifier: <CLONE>${identifier}`);
+      PrimaryIdentifier: <CLONE>${identifier}
+`);
         } else {
             return PlaceholderReplacer.replaceWithTabStops(`
 Resources:
@@ -291,7 +294,8 @@ Resources:
     Properties:
 ${formatPropertiesForYaml(cloneProperties)}
     Metadata:
-      PrimaryIdentifier: <CLONE>${identifier}`);
+      PrimaryIdentifier: <CLONE>${identifier}
+`);
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- added new line end of YAML state insertion which fixes malformation of next section. Also when resources section doesn't exist this fixes a cfn lint issue where it complains about the way the file ends: `SyntaxError: unterminated triple-quoted string literal (detected at line 34)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
