### PR TITLE
reverting feature flags for alpha stage after successfully validating

### DIFF
--- a/assets/featureFlag/alpha.json
+++ b/assets/featureFlag/alpha.json
@@ -3,10 +3,10 @@
   "description": "Feature flags for alpha environment",
   "features": {
     "Constants": {
-      "enabled": true
+      "enabled": false
     },
     "EnhancedDryRun": {
-      "enabled": false,
+      "enabled": true,
       "fleetPercentage": 100,
       "allowlistedRegions": [
         "us-east-1",


### PR DESCRIPTION
*Description of changes:*
- Reverting feature flags back to regular state after successfully validating that the LSP server automatically updates on the server side with the attached features getting enabled / disabled after the feature flags are modified on main branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
