### PR TITLE
Make feature flags and regions backwards compatible

### DIFF
--- a/assets/featureFlag/alpha.json
+++ b/assets/featureFlag/alpha.json
@@ -41,7 +41,8 @@
         "me-south-1",
         "me-central-1",
         "af-south-1",
-        "il-central-1"
+        "il-central-1",
+        "test-region"
       ]
     }
   }

--- a/src/featureFlag/FeatureFlag.ts
+++ b/src/featureFlag/FeatureFlag.ts
@@ -1,4 +1,3 @@
-import { AwsRegion, getRegion } from '../utils/Region';
 import { FeatureFlag, TargetedFeatureFlag } from './FeatureFlagI';
 import { PartialFleetSelector } from './PartialFleetSelector';
 
@@ -37,18 +36,18 @@ export class FleetTargetedFeatureFlag implements TargetedFeatureFlag<string> {
 }
 
 export class RegionAllowlistFeatureFlag implements TargetedFeatureFlag<string> {
-    private readonly allowlist: Set<AwsRegion>;
+    private readonly allowlist: Set<string>;
 
     constructor(
         private readonly featureName: string,
-        allowedRegions: AwsRegion[],
+        allowedRegions: string[],
     ) {
         this.allowlist = new Set(allowedRegions);
     }
 
     isEnabled(region: string): boolean {
         try {
-            return this.allowlist.has(getRegion(region));
+            return this.allowlist.has(region);
         } catch {
             return false;
         }

--- a/src/featureFlag/FeatureFlagBuilder.ts
+++ b/src/featureFlag/FeatureFlagBuilder.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { AwsRegion } from '../utils/Region';
 import { AndFeatureFlag, CompoundFeatureFlag, LocalHostTargetedFeatureFlag } from './CombinedFeatureFlags';
 import { FleetTargetedFeatureFlag, RegionAllowlistFeatureFlag, StaticFeatureFlag } from './FeatureFlag';
 import { FeatureFlag, TargetedFeatureFlag } from './FeatureFlagI';
@@ -7,7 +6,7 @@ import { FeatureFlag, TargetedFeatureFlag } from './FeatureFlagI';
 const FeatureFlagSchema = z.object({
     enabled: z.boolean(),
     fleetPercentage: z.number().optional(),
-    allowlistedRegions: z.array(z.enum(Object.values(AwsRegion))).optional(),
+    allowlistedRegions: z.array(z.string()).optional(),
 });
 
 export const FeatureFlagConfigSchema = z.object({
@@ -47,7 +46,7 @@ export function buildLocalHost(name: string, config?: FeatureFlagConfigType) {
 }
 
 export function buildRegional(name: string, config?: FeatureFlagConfigType) {
-    let allowlist: AwsRegion[] = [];
+    let allowlist: string[] = [];
 
     if (config?.allowlistedRegions !== undefined) {
         allowlist = config.allowlistedRegions;

--- a/src/settings/SettingsParser.ts
+++ b/src/settings/SettingsParser.ts
@@ -1,13 +1,14 @@
 import { z } from 'zod';
-import { AwsRegion } from '../utils/Region';
+import { getRegion } from '../utils/Region';
 import { ProfileSettings, Settings } from './Settings';
-
-const AwsRegionSchema = z.enum(Object.values(AwsRegion));
 
 function createProfileSchema(defaults: Settings['profile']) {
     return z
         .object({
-            region: AwsRegionSchema.nullish().transform((val) => val ?? defaults.region),
+            region: z
+                .string()
+                .nullish()
+                .transform((val) => getRegion(val ?? defaults.region)),
             profile: z
                 .string()
                 .nullish()

--- a/src/utils/Region.ts
+++ b/src/utils/Region.ts
@@ -1,5 +1,6 @@
 // https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/resource-type-schemas.html
-import { dashesToUnderscores } from './String';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { dashesToUnderscores, toString } from './String';
 
 // Make sure keys and values are exactly the same (ignore casing, '-', '_')
 export enum AwsRegion {
@@ -65,7 +66,8 @@ export function getRegion(region: unknown): AwsRegion {
 
     const value = AwsRegion[enumKey as keyof typeof AwsRegion];
     if (!value) {
-        throw new Error(`Unknown region ${String(region)}`);
+        LoggerFactory.getLogger('Region').warn(`Unknown region ${toString(region)}`);
+        return enumKey.replaceAll('_', '-').toLowerCase() as AwsRegion;
     }
 
     return value;

--- a/tst/unit/featureFlag/FeatureFlagProvider.test.ts
+++ b/tst/unit/featureFlag/FeatureFlagProvider.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, it, expect } from 'vitest';
+import { FeatureFlagConfigSchema } from '../../../src/featureFlag/FeatureFlagBuilder';
+
+describe('FeatureFlagProvider', () => {
+    it('can parse feature flags', () => {
+        [
+            join(__dirname, '..', '..', '..', 'assets', 'featureFlag', 'alpha.json'),
+            join(__dirname, '..', '..', '..', 'assets', 'featureFlag', 'beta.json'),
+            join(__dirname, '..', '..', '..', 'assets', 'featureFlag', 'prod.json'),
+        ].map((path) => {
+            const file = readFileSync(path, 'utf8');
+            expect(file).toBeDefined();
+            expect(FeatureFlagConfigSchema.parse(JSON.parse(file))).toBeDefined();
+        });
+    });
+});

--- a/tst/unit/utils/Region.test.ts
+++ b/tst/unit/utils/Region.test.ts
@@ -26,9 +26,9 @@ describe('Region', () => {
             expect(getRegion('EU_WEST_1')).toBe(AwsRegion.EU_WEST_1);
         });
 
-        it('should throw an error for invalid region strings', () => {
-            expect(() => getRegion('invalid-region')).toThrow('Unknown region invalid-region');
-            expect(() => getRegion('us-central-1')).toThrow('Unknown region us-central-1');
+        it('should not throw when region is unknown or invalid', () => {
+            expect(getRegion('invalid_region')).toBe('invalid-region');
+            expect(getRegion('US_test-1')).toBe('us-test-1');
         });
     });
 });


### PR DESCRIPTION
* Use strings instead of enums in feature flags
* Do not throw errors if region is unknown (to support new regions) 