### PR TITLE
Refactor DescribeEvents to be paginated and move page exhaustion loop…

### DIFF
--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -201,35 +201,22 @@ export class CfnService {
 
     @Count({ name: 'describeEvents' })
     public async describeEvents(params: {
-        ChangeSetName: string;
-        StackName: string;
+        StackName?: string;
+        ChangeSetName?: string;
+        OperationId?: string;
+        FailedEventsOnly?: boolean;
+        NextToken?: string;
     }): Promise<DescribeEventsCommandOutput> {
         return await this.withClient(async (client) => {
-            let nextToken: string | undefined;
-            let result: DescribeEventsCommandOutput | undefined;
-            const operationEvents: DescribeEventsCommandOutput['OperationEvents'] = [];
-
-            do {
-                const response = (await client.send(
-                    new DescribeEventsCommand({
-                        ...params,
-                        NextToken: nextToken,
-                    }),
-                )) as unknown as DescribeEventsCommandOutput;
-
-                if (result) {
-                    operationEvents.push(...(response.OperationEvents ?? []));
-                } else {
-                    result = response;
-                    operationEvents.push(...(result.OperationEvents ?? []));
-                }
-
-                nextToken = response.NextToken;
-            } while (nextToken);
-
-            result.OperationEvents = operationEvents;
-            result.NextToken = undefined;
-            return result;
+            return (await client.send(
+                new DescribeEventsCommand({
+                    StackName: params.StackName,
+                    ChangeSetName: params.ChangeSetName,
+                    OperationId: params.OperationId,
+                    Filters: params.FailedEventsOnly ? { FailedEvents: true } : undefined,
+                    NextToken: params.NextToken,
+                }),
+            )) as unknown as DescribeEventsCommandOutput;
         });
     }
 

--- a/tst/unit/services/CfnService.test.ts
+++ b/tst/unit/services/CfnService.test.ts
@@ -357,7 +357,7 @@ describe('CfnService', () => {
             expect(result).toEqual(MOCK_RESPONSES.DESCRIBE_EVENTS);
         });
 
-        it('should fetch all pages when paginated', async () => {
+        it('should return single page with NextToken for pagination', async () => {
             const page1 = {
                 ...MOCK_RESPONSES.DESCRIBE_EVENTS,
                 OperationEvents: [
@@ -376,30 +376,16 @@ describe('CfnService', () => {
                 ],
                 NextToken: 'token1',
             };
-            const page2 = {
-                ...MOCK_RESPONSES.DESCRIBE_EVENTS,
-                OperationEvents: [
-                    {
-                        EventId: 'event-3',
-                        EventType: EventType.VALIDATION_ERROR,
-                        Timestamp: new Date('2023-01-01T00:02:00Z'),
-                        LogicalResourceId: 'Resource3',
-                    },
-                ],
-                NextToken: undefined,
-            };
 
-            cloudFormationMock.on(DescribeEventsCommand).resolvesOnce(page1).resolvesOnce(page2);
+            cloudFormationMock.on(DescribeEventsCommand).resolvesOnce(page1);
 
             const result = await service.describeEvents({
                 ChangeSetName: TEST_CONSTANTS.CHANGE_SET_NAME,
                 StackName: TEST_CONSTANTS.STACK_NAME,
             });
 
-            expect(result.OperationEvents).toHaveLength(3);
-            expect(result.OperationEvents?.[0].EventId).toBe('event-1');
-            expect(result.OperationEvents?.[2].EventId).toBe('event-3');
-            expect(result.NextToken).toBeUndefined();
+            expect(result.OperationEvents).toHaveLength(2);
+            expect(result.NextToken).toBe('token1');
         });
 
         it('should throw CloudFormationServiceException when API call fails', async () => {

--- a/tst/unit/stackActions/StackActionWorkflowOperations.test.ts
+++ b/tst/unit/stackActions/StackActionWorkflowOperations.test.ts
@@ -5,6 +5,7 @@ import {
     OnStackFailure,
     EventType,
     HookFailureMode,
+    OperationEvent,
 } from '@aws-sdk/client-cloudformation';
 import { WaiterState } from '@smithy/util-waiter';
 import { DateTime } from 'luxon';
@@ -432,36 +433,33 @@ describe('StackActionWorkflowOperations', () => {
 
     describe('parseValidationEvents', () => {
         it('should parse validation events correctly', () => {
-            const events = {
-                OperationEvents: [
-                    {
-                        EventId: 'event-1',
-                        EventType: EventType.VALIDATION_ERROR,
-                        Timestamp: new Date('2023-01-01T00:00:00Z'),
-                        LogicalResourceId: 'MyS3Bucket',
-                        ValidationPath: '/Resources/MyS3Bucket/Properties/BucketName',
-                        ValidationFailureMode: HookFailureMode.FAIL,
-                        ValidationName: 'S3BucketValidation',
-                        ValidationStatusReason: 'Bucket name must be globally unique',
-                    },
-                    {
-                        EventId: 'event-2',
-                        EventType: EventType.VALIDATION_ERROR,
-                        Timestamp: new Date('2023-01-01T00:01:00Z'),
-                        LogicalResourceId: 'MyLambda',
-                        ValidationFailureMode: HookFailureMode.WARN,
-                        ValidationName: 'LambdaValidation',
-                        ValidationStatusReason: 'Runtime version is deprecated',
-                    },
-                    {
-                        EventId: 'event-3',
-                        EventType: EventType.HOOK_INVOCATION_ERROR,
-                        Timestamp: new Date('2023-01-01T00:02:00Z'),
-                        LogicalResourceId: 'MyResource',
-                    },
-                ],
-                $metadata: {},
-            };
+            const events = [
+                {
+                    EventId: 'event-1',
+                    EventType: EventType.VALIDATION_ERROR,
+                    Timestamp: new Date('2023-01-01T00:00:00Z'),
+                    LogicalResourceId: 'MyS3Bucket',
+                    ValidationPath: '/Resources/MyS3Bucket/Properties/BucketName',
+                    ValidationFailureMode: HookFailureMode.FAIL,
+                    ValidationName: 'S3BucketValidation',
+                    ValidationStatusReason: 'Bucket name must be globally unique',
+                },
+                {
+                    EventId: 'event-2',
+                    EventType: EventType.VALIDATION_ERROR,
+                    Timestamp: new Date('2023-01-01T00:01:00Z'),
+                    LogicalResourceId: 'MyLambda',
+                    ValidationFailureMode: HookFailureMode.WARN,
+                    ValidationName: 'LambdaValidation',
+                    ValidationStatusReason: 'Runtime version is deprecated',
+                },
+                {
+                    EventId: 'event-3',
+                    EventType: EventType.HOOK_INVOCATION_ERROR,
+                    Timestamp: new Date('2023-01-01T00:02:00Z'),
+                    LogicalResourceId: 'MyResource',
+                },
+            ];
 
             const validationName = 'Enhanced Validation';
             const result = parseValidationEvents(events, validationName);
@@ -488,10 +486,7 @@ describe('StackActionWorkflowOperations', () => {
         });
 
         it('should handle empty events', () => {
-            const events = {
-                OperationEvents: [],
-                $metadata: {},
-            };
+            const events: OperationEvent[] = [];
 
             const result = parseValidationEvents(events, 'Test Validation');
 


### PR DESCRIPTION
*Description of changes:*
- DescribeEvents is planned to be exposed externally via LSP method
- current usage is server-internal and exhausts all pages
- refactored api wrapper layer to be paginated and moved exhaustive loop to business layer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
