### PR TITLE
Fix intrinsic parsing issues

### DIFF
--- a/src/autocomplete/ConditionCompletionProvider.ts
+++ b/src/autocomplete/ConditionCompletionProvider.ts
@@ -1,6 +1,6 @@
 import { CompletionItem, CompletionItemKind, CompletionParams } from 'vscode-languageserver';
 import { Context } from '../context/Context';
-import { TopLevelSection } from '../context/ContextType';
+import { IntrinsicShortForms, TopLevelSection } from '../context/ContextType';
 import { getEntityMap } from '../context/SectionContextBuilder';
 import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
@@ -40,8 +40,14 @@ export class ConditionCompletionProvider implements CompletionProvider {
             [...conditionMap.keys()].filter((k) => k !== conditionLogicalNameToOmit),
         );
 
-        if (context.text.length > 0) {
-            return this.conditionFuzzySearch(items, context.text);
+        // Extract search text, handling !Condition prefix
+        let searchText = context.text;
+        if (searchText.startsWith(IntrinsicShortForms.Condition)) {
+            searchText = searchText.slice(IntrinsicShortForms.Condition.length).trim();
+        }
+
+        if (searchText.length > 0) {
+            return this.conditionFuzzySearch(items, searchText);
         }
 
         return items;

--- a/src/context/ContextType.ts
+++ b/src/context/ContextType.ts
@@ -45,6 +45,15 @@ export enum IntrinsicFunction {
     Implies = 'Fn::Implies',
 }
 
+export enum IntrinsicShortForms {
+    Condition = '!Condition',
+    Ref = '!Ref',
+}
+
+export enum EntitySection {
+    Condition = 'Condition',
+}
+
 export const IntrinsicsUsingConditionKeyword: ReadonlyArray<IntrinsicFunction> = [
     IntrinsicFunction.And,
     IntrinsicFunction.Or,

--- a/src/context/semantic/LogicalIdReferenceFinder.ts
+++ b/src/context/semantic/LogicalIdReferenceFinder.ts
@@ -216,13 +216,13 @@ const YamlIfColon = /['"]?Fn::If['"]?\s*:\s*\[\s*['"]?([A-Za-z][A-Za-z0-9]*)['"]
 const YamlCondition = /(?<![A-Za-z])['"]?Condition['"]?\s*:\s*['"]?([A-Za-z][A-Za-z0-9]*)['"]?/g; // Matches Condition:, 'Condition':, "Condition": ConditionName with optional quoted values
 const YamlSingleDep = /(?<![A-Za-z])['"]?DependsOn['"]?\s*:\s*['"]?([A-Za-z][A-Za-z0-9]*)['"]?/g; // Matches DependsOn: LogicalId with optional quotes
 const YamlInlineDeps = /(?<![A-Za-z])['"]?DependsOn['"]?\s*:\s*\[([^\]]+)]/g; // Matches DependsOn: [Id1, Id2] with optional quotes
-const YamlListItem = /-\s*([A-Za-z][A-Za-z0-9]*)/g; // Matches - LogicalId in YAML list format
+const YamlListItem = /(?:^|\s)-\s+([A-Za-z][A-Za-z0-9]*)/gm; // Matches - LogicalId in YAML list format (requires whitespace before hyphen)
 const YamlInlineItemPattern = /([A-Za-z][A-Za-z0-9]*)/g; // Matches LogicalId within the inline array
 const YamlValueOfShort = /!ValueOf\s+\[\s*['"]?([A-Za-z][A-Za-z0-9]*)['"]?/g; // Matches !ValueOf [ParamName, Attr] - YAML short form
 const YamlValueOf = /['"]?Fn::ValueOf['"]?\s*:\s*\[\s*['"]?([A-Za-z][A-Za-z0-9]*)['"]?/g; // Matches Fn::ValueOf: [ParamName, Attr] with optional quotes
 
 // Shared pattern for ${} variables - used by both JSON and YAML
-const SubVariables = /\$\{([A-Za-z][A-Za-z0-9]*)(?:[.:]|(?=\}))/g; // Matches ${LogicalId} or ${Resource.Attr} or ${AWS::Region} - captures first segment only
+const SubVariables = /\$\{([A-Za-z][A-Za-z0-9]*)(?:[^A-Za-z0-9]|$)/g; // Matches ${LogicalId} followed by any non-alphanumeric char or end
 
 const ValidLogicalId = /^[A-Za-z][A-Za-z0-9.]+$/;
 

--- a/tst/integration/autocomplete/Autocomplete.test.ts
+++ b/tst/integration/autocomplete/Autocomplete.test.ts
@@ -310,21 +310,16 @@ Conditions:
                         verification: {
                             position: { line: 103, character: 25 },
                             expectation: CompletionExpectationBuilder.create()
-                                .expectContainsItems(['AWS::Region'])
-                                .todo(
-                                    `intrinsic functions are being suggested incorrectly!
-                                [
-                                  "!RefAll",
-                                  "!GetAZs",
-                                  "!Ref",
-                                  "!Equals",
-                                  "!Base64",
-                                  "!GetAtt",
-                                  "!Transform",
-                                  "!EachMemberEquals",
-                                  "!EachMemberIn",
-                                ]`,
-                                )
+                                .expectItems([
+                                    'AWS::AccountId',
+                                    'AWS::NoValue',
+                                    'AWS::NotificationARNs',
+                                    'AWS::Partition',
+                                    'AWS::Region',
+                                    'AWS::StackId',
+                                    'AWS::StackName',
+                                    'AWS::URLSuffix',
+                                ])
                                 .build(),
                         },
                     },
@@ -393,8 +388,16 @@ Rules:
                         verification: {
                             position: { line: 114, character: 45 },
                             expectation: CompletionExpectationBuilder.create()
-                                .expectContainsItems(['AWS::Region'])
-                                .todo(`no suggestion of pseudo-parameter after AWS:: is typed; needs the R`)
+                                .expectItems([
+                                    'AWS::AccountId',
+                                    'AWS::NoValue',
+                                    'AWS::NotificationARNs',
+                                    'AWS::Partition',
+                                    'AWS::Region',
+                                    'AWS::StackId',
+                                    'AWS::StackName',
+                                    'AWS::URLSuffix',
+                                ])
                                 .build(),
                         },
                     },
@@ -1072,7 +1075,6 @@ Resources:
                                     'IsProductionOrStaging',
                                 ])
                                 .expectExcludesItems(['ComplexCondition', 'HasMultipleAZs'])
-                                .todo(`not working even when testing not on last line of YAML`)
                                 .build(),
                         },
                     },

--- a/tst/integration/goto/Goto.test.ts
+++ b/tst/integration/goto/Goto.test.ts
@@ -125,7 +125,6 @@ Resources:
                             position: { line: 65, character: 32 },
                             expectation: GotoExpectationBuilder.create()
                                 .expectDefinition('EnvironmentName')
-                                .todo('No logic for goto in formatted string')
                                 .expectDefinitionPosition({ line: 4, character: 2 })
                                 .build(),
                         },
@@ -492,7 +491,6 @@ Resources:
                             position: { line: 196, character: 35 },
                             expectation: GotoExpectationBuilder.create()
                                 .expectDefinition('EnvironmentName')
-                                .todo('No logic for goto in formatted string')
                                 .expectDefinitionPosition({ line: 4, character: 2 })
                                 .build(),
                         },
@@ -791,7 +789,6 @@ Outputs:
                             position: { line: 96, character: 46 },
                             expectation: GotoExpectationBuilder.create()
                                 .expectDefinition('EnvironmentName')
-                                .todo('No logic for goto in formatted string')
                                 .expectDefinitionPosition({ line: 4, character: 2 })
                                 .build(),
                         },
@@ -1172,10 +1169,7 @@ Outputs:
                         description: 'Click on EnvironmentName in !Sub formatted string',
                         verification: {
                             position: { line: 319, character: 46 },
-                            expectation: GotoExpectationBuilder.create()
-                                .expectDefinition('EnvironmentName')
-                                .todo('No logic for goto in formatted string')
-                                .build(),
+                            expectation: GotoExpectationBuilder.create().expectDefinition('EnvironmentName').build(),
                         },
                     },
                     {

--- a/tst/integration/hover/Hover.test.ts
+++ b/tst/integration/hover/Hover.test.ts
@@ -509,8 +509,7 @@ Conditions:`,
                         verification: {
                             position: { line: 101, character: 25 },
                             expectation: HoverExpectationBuilder.create()
-                                .expectContainsText(['**Condition**, IsProductionOrStaging'])
-                                .todo(`hover on condition name reference for !Condition and not just Condition:`)
+                                .expectContainsText(['**Condition:** IsProductionOrStaging'])
                                 .build(),
                         },
                     },
@@ -2572,8 +2571,7 @@ Resources:
                         verification: {
                             position: { line: 114, character: 28 },
                             expectation: HoverExpectationBuilder.create()
-                                .expectContainsText(['**Condition**, IsProductionOrStaging'])
-                                .todo('hover on condition name reference for !Condition and not just Condition:')
+                                .expectContainsText(['**Condition:** IsProductionOrStaging'])
                                 .build(),
                         },
                     },


### PR DESCRIPTION
### Bug 1: Nested !Ref Inside Intrinsics Returns Wrong Completions

Scenario: User types !Equals [!Ref AWS::, ...]

Problem: The completion provider saw the outer !Equals function and didn't recognize the nested !Ref. It incorrectly suggested intrinsic function names instead
of pseudo-parameters.

Fix: Detect when context.text starts with !Ref and route to the Ref argument handler. Also fixed shouldUseIntrinsicFunctionProvider() to only trigger when the
user is actually typing a function name (no space in text, or text after last space starts with !).

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Bug 2: !Condition Completions Not Working

Scenario: User types !Condition IsProd to reference a condition

Problem: Tree-sitter places the cursor inside the argument text, not at the !Condition tag. The existing check only looked at property paths and entitySection,
so it failed to recognize the condition context.

Fix: Added isInsideConditionShortForm() that traverses up to 3 parent nodes to find if we're inside a !Condition expression. Also strip the !Condition prefix
from search text before fuzzy matching.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Bug 3: Go-to-Definition Broken in !Sub Strings

Scenario: User clicks on ${EnvironmentName} inside a !Sub string to navigate to the parameter definition

Problem: context.text was empty or contained the full ${...} pattern. The definition provider couldn't extract the variable name.

Fix: Added fallback logic to extract the variable name from entityRootNode.text using regex when context.text is empty or contains ${.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Bug 4: Regex False Positives in Reference Finder

Problem 1: YamlListItem pattern -\s*([A-Za-z]...) matched hyphens in resource names like my-bucket.

Fix: Require whitespace before the hyphen: /(?:^|\s)-\s+([A-Za-z][A-Za-z0-9]*)/gm

Problem 2: SubVariables pattern required ., :, or } immediately after the variable name, missing valid cases.

Fix: Match any non-alphanumeric terminator: /\$\{([A-Za-z][A-Za-z0-9]*)(?:[^A-Za-z0-9]|$)/g