### PR TITLE
Simplify FileStore error recovery to prevent startup crash on decryption failure

### DIFF
--- a/src/datastore/file/EncryptedFileStore.ts
+++ b/src/datastore/file/EncryptedFileStore.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, statSync, writeFileSync } from 'fs'; // eslin
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
 import { Logger } from 'pino';
-import { lock, LockOptions, lockSync } from 'proper-lockfile';
+import { lock, LockOptions } from 'proper-lockfile';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../../telemetry/ScopedTelemetry';
 import { TelemetryService } from '../../telemetry/TelemetryService';
@@ -33,13 +33,8 @@ export class EncryptedFileStore implements DataStore {
             } catch (error) {
                 this.log.error(error, 'Failed to decrypt file store, recreating store');
                 this.telemetry.count('filestore.recreate', 1);
-
-                const release = lockSync(this.file, LOCK_OPTIONS_SYNC);
-                try {
-                    this.saveSync();
-                } finally {
-                    release();
-                }
+                this.content = {};
+                this.saveSync();
             }
         } else {
             this.saveSync();


### PR DESCRIPTION
## Simplify FileStore error recovery to prevent startup crash on decryption failure

### Problem
The language server can fail to start on Windows when the encrypted FileStore cache cannot be decrypted, resulting in
"Unsupported state or unable to authenticate data" error.

Fixes https://github.com/aws/aws-toolkit-vscode/issues/8458

### Solution
Simplify error recovery by removing the lockSync wrapper and directly overwriting the corrupted file with a fresh empty
store.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
