### PR TITLE
Exclude Fn::ForEach resources from Ref and GetAtt argument completions

### DIFF
--- a/src/autocomplete/IntrinsicFunctionArgumentCompletionProvider.ts
+++ b/src/autocomplete/IntrinsicFunctionArgumentCompletionProvider.ts
@@ -341,6 +341,11 @@ export class IntrinsicFunctionArgumentCompletionProvider implements CompletionPr
                 continue;
             }
 
+            // Skip Fn::ForEach resources
+            if (resourceName.startsWith(IntrinsicFunction.ForEach)) {
+                continue;
+            }
+
             const resource = resourceContext.entity;
 
             completionItems.push(
@@ -690,7 +695,7 @@ export class IntrinsicFunctionArgumentCompletionProvider implements CompletionPr
         }
 
         const items = [...resourceEntities.keys()]
-            .filter((logicalId) => logicalId !== context.logicalId)
+            .filter((logicalId) => logicalId !== context.logicalId && !logicalId.startsWith(IntrinsicFunction.ForEach))
             .map((logicalId) => createCompletionItem(logicalId, CompletionItemKind.Reference, { context }));
 
         return context.text.length > 0 ? this.fuzzySearch(items, context.text) : items;

--- a/tst/unit/autocomplete/IntrinsicFunctionArgumentCompletionProvider.GetAtt.test.ts
+++ b/tst/unit/autocomplete/IntrinsicFunctionArgumentCompletionProvider.GetAtt.test.ts
@@ -288,6 +288,30 @@ describe('IntrinsicFunctionArgumentCompletionProvider - GetAtt Function', () => 
             expect(labels).toContain('LambdaRole');
             expect(labels).toContain('DatabaseInstance');
         });
+
+        it('should exclude Fn::ForEach resources from completions', () => {
+            const resourceDataWithForEach = {
+                ...mockResourceData,
+                'Fn::ForEach::Buckets': { Type: 'AWS::S3::Bucket' },
+                'Fn::ForEach::Instances': { Type: 'AWS::EC2::Instance' },
+            };
+            setupResourceEntities(resourceDataWithForEach);
+
+            const mockContext = createMockGetAttContext('', []);
+
+            const result = provider.getCompletions(mockContext, createTestParams());
+
+            expect(result).toBeDefined();
+            expect(result!.length).toBe(4); // Should only include the 4 regular resources
+
+            const labels = result!.map((item) => item.label);
+            expect(labels).toContain('MyVPC');
+            expect(labels).toContain('MyS3Bucket');
+            expect(labels).toContain('LambdaRole');
+            expect(labels).toContain('DatabaseInstance');
+            expect(labels).not.toContain('Fn::ForEach::Buckets');
+            expect(labels).not.toContain('Fn::ForEach::Instances');
+        });
     });
 
     describe('Invalid Arguments', () => {


### PR DESCRIPTION
## Summary
Filters out Fn::ForEach::* resources from autocomplete suggestions when inside !Ref and !GetAtt intrinsic functions. These loop construct resources are not valid references and should not appear as completion options.

## Changes
- IntrinsicFunctionArgumentCompletionProvider.ts:
  - getResourceCompletions(): Skip resources with names starting with Fn::ForEach::
  - getGetAttResourceCompletions(): Skip resources with names starting with Fn::ForEach::

## Testing
- Added unit tests in IntrinsicFunctionArgumentCompletionProvider.Ref.test.ts
- Added unit tests in IntrinsicFunctionArgumentCompletionProvider.GetAtt.test.ts
- Added e2e test in Completion.test.ts for YAML cross-reference completions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
