### PR TITLE
fix: prevent TypeError when logicalId is not a string

### DIFF
--- a/src/context/Context.ts
+++ b/src/context/Context.ts
@@ -367,7 +367,8 @@ export function logicalIdAndSection(propertyPath: PropertyPath) {
     let logicalId: string | undefined;
 
     if (propertyPath.length > 1 && section !== 'Unknown' && TopLevelSectionsWithLogicalIdsSet.has(section)) {
-        logicalId = propertyPath[1] as string;
+        const pathElement = propertyPath[1];
+        logicalId = typeof pathElement === 'string' ? pathElement : undefined;
     }
 
     return {

--- a/tst/unit/context/semantic/EntityBuilder.test.ts
+++ b/tst/unit/context/semantic/EntityBuilder.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { TopLevelSection, EntityType } from '../../../../src/context/CloudFormationEnums';
+import { logicalIdAndSection } from '../../../../src/context/Context';
+import { entityTypeFromSection } from '../../../../src/context/semantic/EntityBuilder';
+
+describe('EntityBuilder', () => {
+    describe('logicalIdAndSection', () => {
+        it('should return undefined logicalId when propertyPath[1] is a number', () => {
+            // This simulates malformed templates like: Resources: [...]
+            const propertyPath = ['Resources', 0, 'Type'] as any;
+
+            const result = logicalIdAndSection(propertyPath);
+
+            expect(result.section).toBe(TopLevelSection.Resources);
+            expect(result.logicalId).toBeUndefined();
+        });
+
+        it('should return string logicalId when propertyPath[1] is a string', () => {
+            const propertyPath = ['Resources', 'MyBucket', 'Type'];
+
+            const result = logicalIdAndSection(propertyPath);
+
+            expect(result.section).toBe(TopLevelSection.Resources);
+            expect(result.logicalId).toBe('MyBucket');
+        });
+    });
+
+    describe('entityTypeFromSection', () => {
+        it('should return Resource type for string logicalId', () => {
+            const result = entityTypeFromSection(TopLevelSection.Resources, 'MyBucket');
+            expect(result).toBe(EntityType.Resource);
+        });
+
+        it('should return ForEachResource type for Fn::ForEach logicalId', () => {
+            const result = entityTypeFromSection(TopLevelSection.Resources, 'Fn::ForEach::LoopName');
+            expect(result).toBe(EntityType.ForEachResource);
+        });
+
+        it('should return Output type for Outputs section', () => {
+            const result = entityTypeFromSection(TopLevelSection.Outputs, 'MyOutput');
+            expect(result).toBe(EntityType.Output);
+        });
+
+        it('should return Metadata type for Metadata section', () => {
+            const result = entityTypeFromSection(TopLevelSection.Metadata);
+            expect(result).toBe(EntityType.Metadata);
+        });
+    });
+});


### PR DESCRIPTION
Ensure `logicalId` is only set when `propertyPath[1]` is a `string` in `logicalIdAndSection()`. This prevents cascading TypeErrors in downstream functions that expect string logicalIds (e.g., startsWith, replace). Handles malformed templates with array structures gracefully.

*Issue #, if available:*

*Description of changes:*
Fixes the error `TypeError: logicalId?.startsWith is not a function`

TO confirm in YAML when a logical ID is an integer we will get `An error occurred (ValidationError) when calling the ValidateTemplate operation: Template format error: [/Resources] map keys must be strings; received numeric [123] instead`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
