### PR TITLE
fix: prevent [object Object] in resource identifier

### DIFF
--- a/src/autocomplete/ResourceStateCompletionProvider.ts
+++ b/src/autocomplete/ResourceStateCompletionProvider.ts
@@ -117,7 +117,11 @@ export class ResourceStateCompletionProvider implements CompletionProvider {
             if (!value) {
                 return;
             }
-            identifierValues.push(value as string);
+            // Only accept primitive values as identifiers, not intrinsic functions or objects
+            if (typeof value === 'object') {
+                return;
+            }
+            identifierValues.push(String(value));
         }
 
         return identifierValues.join('|');


### PR DESCRIPTION
Check if value is an object before using as resource identifier in ResourceStateCompletionProvider. When properties contain intrinsic functions (e.g., {Ref: 'Param'}), return undefined instead of passing '[object Object]' to Cloud Control API which causes InvalidRequestException.

Includes test to verify intrinsic functions in identifiers are handled gracefully without attempting API calls.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
