### PR TITLE
implement ref and getAtt for related resources

### DIFF
--- a/src/handlers/RelatedResourcesHandler.ts
+++ b/src/handlers/RelatedResourcesHandler.ts
@@ -3,6 +3,7 @@ import { TopLevelSection } from '../context/CloudFormationEnums';
 import { getEntityMap } from '../context/SectionContextBuilder';
 import { Resource } from '../context/semantic/Entity';
 import {
+    AuthoredResource,
     GetRelatedResourceTypesParams,
     InsertRelatedResourcesParams,
     RelatedResourcesCodeAction,
@@ -19,7 +20,7 @@ import {
 
 export function getAuthoredResourceTypesHandler(
     components: ServerComponents,
-): RequestHandler<TemplateUri, string[], void> {
+): RequestHandler<TemplateUri, AuthoredResource[], void> {
     return (rawParams) => {
         try {
             const templateUri = parseWithPrettyError(parseTemplateUriParams, rawParams);
@@ -27,14 +28,17 @@ export function getAuthoredResourceTypesHandler(
             if (syntaxTree) {
                 const resourcesMap = getEntityMap(syntaxTree, TopLevelSection.Resources);
                 if (resourcesMap) {
-                    const resourceTypes = [...resourcesMap.values()]
-                        .map((context) => {
-                            const resource = context.entity as Resource;
-                            return resource?.Type;
-                        })
-                        .filter((type): type is string => type !== undefined && type !== null);
-
-                    return [...new Set(resourceTypes)];
+                    const resources: AuthoredResource[] = [];
+                    for (const [logicalId, context] of resourcesMap) {
+                        const resource = context.entity as Resource;
+                        if (resource?.Type) {
+                            resources.push({
+                                logicalId,
+                                type: resource.Type,
+                            });
+                        }
+                    }
+                    return resources;
                 }
             }
 
@@ -124,7 +128,7 @@ export function insertRelatedResourcesHandler(
 ): RequestHandler<InsertRelatedResourcesParams, RelatedResourcesCodeAction, void> {
     return (rawParams) => {
         try {
-            const { templateUri, relatedResourceTypes, parentResourceType } = parseWithPrettyError(
+            const { templateUri, relatedResourceTypes, parentResourceType, parentLogicalId } = parseWithPrettyError(
                 parseInsertRelatedResourcesParams,
                 rawParams,
             );
@@ -132,6 +136,7 @@ export function insertRelatedResourcesHandler(
                 templateUri,
                 relatedResourceTypes,
                 parentResourceType,
+                parentLogicalId,
             );
         } catch (error) {
             handleLspError(error, 'Failed to insert related resources');

--- a/src/handlers/RelatedResourcesHandler.ts
+++ b/src/handlers/RelatedResourcesHandler.ts
@@ -57,7 +57,6 @@ export function getRelatedResourceTypesHandler(
             const { parentResourceType } = parseWithPrettyError(parseGetRelatedResourceTypesParams, rawParams);
             const relatedTypes = components.relationshipSchemaService.getAllRelatedResourceTypes(parentResourceType);
 
-            // Filter to only resource types with exactly one populatable relationship
             const filtered = [...relatedTypes].filter((relatedType) =>
                 hasExactlyOnePopulatableRelationship(relatedType, parentResourceType, components),
             );
@@ -72,14 +71,6 @@ export function getRelatedResourceTypesHandler(
 /**
  * Checks if a related resource type has exactly one top-level property
  * that references the parent resource type, and that property is not an array.
- *
- * This mirrors the snippet provider's population logic exactly:
- * - countTopLevelParentReferences counts ALL top-level refs (including arrays)
- * - If count > 1, nothing gets populated (ambiguous)
- * - If count === 1 but it's an array, nothing gets populated
- * - Only if count === 1 AND it's not an array does it get populated
- *
- * Resources that won't get a !Ref or !GetAtt populated are excluded from the dropdown.
  */
 function hasExactlyOnePopulatableRelationship(
     relatedType: string,
@@ -93,16 +84,12 @@ function hasExactlyOnePopulatableRelationship(
 
     const schema = components.schemaRetriever.getDefault().schemas.get(relatedType);
 
-    // Count ALL top-level properties referencing the parent (including arrays)
-    // This mirrors countTopLevelParentReferences in the snippet provider
     const topLevelParentRefs: { property: string; isArray: boolean }[] = [];
     for (const rel of relationships.relationships) {
-        // Skip nested properties
         if (rel.property.includes('/')) {
             continue;
         }
 
-        // Check if this property references the parent type
         const referencesParent = rel.relatedResourceTypes.some((rt) => rt.typeName === parentResourceType);
         if (!referencesParent) {
             continue;
@@ -110,14 +97,16 @@ function hasExactlyOnePopulatableRelationship(
 
         const isArray = schema?.properties?.[rel.property]?.type === 'array';
         topLevelParentRefs.push({ property: rel.property, isArray });
+
+        if (topLevelParentRefs.length > 1) {
+            break;
+        }
     }
 
-    // Must have exactly 1 total top-level ref (matching provider's count > 1 guard)
     if (topLevelParentRefs.length !== 1) {
         return false;
     }
 
-    // The single ref must not be an array
     return !topLevelParentRefs[0].isArray;
 }
 

--- a/src/handlers/RelatedResourcesHandler.ts
+++ b/src/handlers/RelatedResourcesHandler.ts
@@ -108,9 +108,7 @@ function hasExactlyOnePopulatableRelationship(
             continue;
         }
 
-        const isArray =
-            schema?.properties?.[rel.property]?.type === 'array' ||
-            schema?.properties?.[rel.property]?.items !== undefined;
+        const isArray = schema?.properties?.[rel.property]?.type === 'array';
         topLevelParentRefs.push({ property: rel.property, isArray });
     }
 

--- a/src/handlers/RelatedResourcesHandler.ts
+++ b/src/handlers/RelatedResourcesHandler.ts
@@ -52,11 +52,71 @@ export function getRelatedResourceTypesHandler(
         try {
             const { parentResourceType } = parseWithPrettyError(parseGetRelatedResourceTypesParams, rawParams);
             const relatedTypes = components.relationshipSchemaService.getAllRelatedResourceTypes(parentResourceType);
-            return [...relatedTypes];
+
+            // Filter to only resource types with exactly one populatable relationship
+            const filtered = [...relatedTypes].filter((relatedType) =>
+                hasExactlyOnePopulatableRelationship(relatedType, parentResourceType, components),
+            );
+
+            return filtered;
         } catch (error) {
             handleLspError(error, 'Failed to get related resource types');
         }
     };
+}
+
+/**
+ * Checks if a related resource type has exactly one top-level property
+ * that references the parent resource type, and that property is not an array.
+ *
+ * This mirrors the snippet provider's population logic exactly:
+ * - countTopLevelParentReferences counts ALL top-level refs (including arrays)
+ * - If count > 1, nothing gets populated (ambiguous)
+ * - If count === 1 but it's an array, nothing gets populated
+ * - Only if count === 1 AND it's not an array does it get populated
+ *
+ * Resources that won't get a !Ref or !GetAtt populated are excluded from the dropdown.
+ */
+function hasExactlyOnePopulatableRelationship(
+    relatedType: string,
+    parentResourceType: string,
+    components: ServerComponents,
+): boolean {
+    const relationships = components.relationshipSchemaService.getRelationshipsForResourceType(relatedType);
+    if (!relationships) {
+        return false;
+    }
+
+    const schema = components.schemaRetriever.getDefault().schemas.get(relatedType);
+
+    // Count ALL top-level properties referencing the parent (including arrays)
+    // This mirrors countTopLevelParentReferences in the snippet provider
+    const topLevelParentRefs: { property: string; isArray: boolean }[] = [];
+    for (const rel of relationships.relationships) {
+        // Skip nested properties
+        if (rel.property.includes('/')) {
+            continue;
+        }
+
+        // Check if this property references the parent type
+        const referencesParent = rel.relatedResourceTypes.some((rt) => rt.typeName === parentResourceType);
+        if (!referencesParent) {
+            continue;
+        }
+
+        const isArray =
+            schema?.properties?.[rel.property]?.type === 'array' ||
+            schema?.properties?.[rel.property]?.items !== undefined;
+        topLevelParentRefs.push({ property: rel.property, isArray });
+    }
+
+    // Must have exactly 1 total top-level ref (matching provider's count > 1 guard)
+    if (topLevelParentRefs.length !== 1) {
+        return false;
+    }
+
+    // The single ref must not be an array
+    return !topLevelParentRefs[0].isArray;
 }
 
 export function insertRelatedResourcesHandler(

--- a/src/handlers/RelatedResourcesParser.ts
+++ b/src/handlers/RelatedResourcesParser.ts
@@ -16,6 +16,7 @@ const InsertRelatedResourcesParamsSchema = z.object({
     templateUri: NonEmptyZodString,
     relatedResourceTypes: z.array(NonEmptyZodString).min(1),
     parentResourceType: NonEmptyZodString,
+    parentLogicalId: NonEmptyZodString.optional(),
 });
 
 export function parseTemplateUriParams(input: unknown): TemplateUri {

--- a/src/protocol/LspRelatedResourcesHandlers.ts
+++ b/src/protocol/LspRelatedResourcesHandlers.ts
@@ -1,5 +1,6 @@
 import { Connection, RequestHandler } from 'vscode-languageserver';
 import {
+    AuthoredResource,
     GetAuthoredResourceTypesRequest,
     GetRelatedResourceTypesParams,
     GetRelatedResourceTypesRequest,
@@ -12,7 +13,7 @@ import {
 export class LspRelatedResourcesHandlers {
     constructor(private readonly connection: Connection) {}
 
-    onGetAuthoredResourceTypes(handler: RequestHandler<TemplateUri, string[], void>) {
+    onGetAuthoredResourceTypes(handler: RequestHandler<TemplateUri, AuthoredResource[], void>) {
         this.connection.onRequest(GetAuthoredResourceTypesRequest.method, handler);
     }
 

--- a/src/protocol/RelatedResourcesProtocol.ts
+++ b/src/protocol/RelatedResourcesProtocol.ts
@@ -6,10 +6,16 @@ export type GetRelatedResourceTypesParams = {
     parentResourceType: string;
 };
 
+export type AuthoredResource = {
+    logicalId: string;
+    type: string;
+};
+
 export type InsertRelatedResourcesParams = {
     templateUri: string;
     relatedResourceTypes: string[];
     parentResourceType: string;
+    parentLogicalId?: string;
 };
 
 export interface RelatedResourcesCodeAction extends CodeAction {
@@ -19,7 +25,7 @@ export interface RelatedResourcesCodeAction extends CodeAction {
     };
 }
 
-export const GetAuthoredResourceTypesRequest = new RequestType<TemplateUri, string[], void>(
+export const GetAuthoredResourceTypesRequest = new RequestType<TemplateUri, AuthoredResource[], void>(
     'aws/cfn/template/resources/authored',
 );
 

--- a/src/relatedResources/RelatedResourcesSnippetProvider.ts
+++ b/src/relatedResources/RelatedResourcesSnippetProvider.ts
@@ -1,9 +1,14 @@
 import { CodeActionKind, Range, TextEdit } from 'vscode-languageserver';
+import { TopLevelSection } from '../context/CloudFormationEnums';
+import { getEntityMap } from '../context/SectionContextBuilder';
+import { Resource } from '../context/semantic/Entity';
 import { SyntaxTree } from '../context/syntaxtree/SyntaxTree';
 import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
+import { DocumentType } from '../document/Document';
 import { DocumentManager } from '../document/DocumentManager';
 import { RelatedResourcesCodeAction } from '../protocol/RelatedResourcesProtocol';
 import { SchemaRetriever } from '../schema/SchemaRetriever';
+import { RelationshipSchemaService } from '../services/RelationshipSchemaService';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import {
     combineResourcesToDocumentFormat,
@@ -14,10 +19,13 @@ import {
 
 const log = LoggerFactory.getLogger('RelatedResourcesSnippetProvider');
 
+const REF_PLACEHOLDER_PREFIX = '__CFN_REF_';
+const REF_PLACEHOLDER_SUFFIX = '__';
+
 export interface RelatedResourceObject {
     [logicalId: string]: {
         Type: string;
-        Properties?: Record<string, string>;
+        Properties?: Record<string, unknown>;
     };
 }
 
@@ -28,6 +36,7 @@ export class RelatedResourcesSnippetProvider {
         private readonly documentManager: DocumentManager,
         private readonly syntaxTreeManager: SyntaxTreeManager,
         private readonly schemaRetriever: SchemaRetriever,
+        private readonly relationshipSchemaService: RelationshipSchemaService,
     ) {}
 
     insertRelatedResources(
@@ -47,19 +56,25 @@ export class RelatedResourcesSnippetProvider {
             const syntaxTree: SyntaxTree | undefined = this.syntaxTreeManager.getSyntaxTree(templateUri);
             const editorSettings = this.documentManager.getEditorSettingsForDocument(templateUri);
 
+            const parentLogicalId = this.findParentLogicalId(syntaxTree, parentResourceType);
+
             const resources = relatedResourceTypes.map((resourceType) =>
-                this.generateResourceObject(resourceType, parentResourceType),
+                this.generateResourceObject(resourceType, parentResourceType, parentLogicalId, documentType),
             );
 
             const resourceSection = syntaxTree ? getResourceSection(syntaxTree) : undefined;
             const resourceSectionExists = resourceSection !== undefined;
 
-            const formattedText = combineResourcesToDocumentFormat(
+            let formattedText = combineResourcesToDocumentFormat(
                 resources,
                 documentType,
                 resourceSectionExists,
                 editorSettings,
             );
+
+            if (documentType === DocumentType.YAML) {
+                formattedText = this.replaceRefPlaceholders(formattedText);
+            }
 
             const insertPosition = getInsertPosition(resourceSection, document);
 
@@ -90,17 +105,28 @@ export class RelatedResourcesSnippetProvider {
         }
     }
 
-    private generateResourceObject(resourceType: string, parentResourceType: string): RelatedResourceObject {
+    private generateResourceObject(
+        resourceType: string,
+        parentResourceType: string,
+        parentLogicalId: string | undefined,
+        documentType: DocumentType,
+    ): RelatedResourceObject {
         const logicalId = this.generateLogicalId(resourceType, parentResourceType);
 
         try {
             const schema = this.schemaRetriever.getDefault().schemas.get(resourceType);
-            const resource: { Type: string; Properties?: Record<string, string> } = { Type: resourceType };
+            const resource: { Type: string; Properties?: Record<string, unknown> } = { Type: resourceType };
 
             if (schema?.required && schema.required.length > 0) {
                 resource.Properties = {};
                 for (const propName of schema.required) {
-                    resource.Properties[propName] = '';
+                    resource.Properties[propName] = this.getPropertyValueForRelatedResource(
+                        propName,
+                        resourceType,
+                        parentResourceType,
+                        parentLogicalId,
+                        documentType,
+                    );
                 }
             }
 
@@ -108,6 +134,86 @@ export class RelatedResourcesSnippetProvider {
         } catch {
             return { [logicalId]: { Type: resourceType } };
         }
+    }
+
+    /**
+     * Determines the property value for a related resource property.
+     * If the property references the parent resource type, returns a !Ref reference.
+     * Otherwise returns an empty string.
+     */
+    private getPropertyValueForRelatedResource(
+        propName: string,
+        resourceType: string,
+        parentResourceType: string,
+        parentLogicalId: string | undefined,
+        documentType: DocumentType,
+    ): unknown {
+        if (!parentLogicalId) {
+            return '';
+        }
+
+        const relationships = this.relationshipSchemaService.getRelationshipsForResourceType(resourceType);
+        if (!relationships) {
+            return '';
+        }
+
+        for (const rel of relationships.relationships) {
+            // Only match direct top-level property names
+            // rel.property may contain nested paths like "VpcConfig/SecurityGroupIds"
+            // We only match when the property path is exactly the propName (top-level)
+            if (rel.property === propName) {
+                const matchesParent = rel.relatedResourceTypes.some((rt) => rt.typeName === parentResourceType);
+                if (matchesParent) {
+                    if (documentType === DocumentType.YAML) {
+                        // Use a placeholder that will be replaced after YAML serialization
+                        return `${REF_PLACEHOLDER_PREFIX}${parentLogicalId}${REF_PLACEHOLDER_SUFFIX}`;
+                    } else {
+                        // For JSON, return the intrinsic function object
+                        return { Ref: parentLogicalId };
+                    }
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Replaces Ref placeholders in the serialized YAML output with proper !Ref intrinsic functions.
+     * The YAML serializer quotes strings starting with !, so we use placeholders during serialization
+     * and then replace them with the unquoted !Ref syntax afterward.
+     */
+    private replaceRefPlaceholders(text: string): string {
+        // Match both quoted and unquoted placeholders
+        // The YAML serializer may produce: '__CFN_REF_MyVpc__' or __CFN_REF_MyVpc__
+        const placeholderRegex = new RegExp(
+            `['"]?${REF_PLACEHOLDER_PREFIX}([a-zA-Z0-9]+)${REF_PLACEHOLDER_SUFFIX}['"]?`,
+            'g',
+        );
+        return text.replaceAll(placeholderRegex, '!Ref $1');
+    }
+
+    /**
+     * Finds the logical ID of the first resource in the template that matches the given resource type.
+     */
+    private findParentLogicalId(syntaxTree: SyntaxTree | undefined, parentResourceType: string): string | undefined {
+        if (!syntaxTree) {
+            return undefined;
+        }
+
+        const resourcesMap = getEntityMap(syntaxTree, TopLevelSection.Resources);
+        if (!resourcesMap) {
+            return undefined;
+        }
+
+        for (const [logicalId, context] of resourcesMap) {
+            const resource = context.entity as Resource;
+            if (resource?.Type === parentResourceType) {
+                return logicalId;
+            }
+        }
+
+        return undefined;
     }
 
     private generateLogicalId(resourceType: string, parentResourceType: string): string {

--- a/src/relatedResources/RelatedResourcesSnippetProvider.ts
+++ b/src/relatedResources/RelatedResourcesSnippetProvider.ts
@@ -1,5 +1,5 @@
 import { CodeActionKind, Range, TextEdit } from 'vscode-languageserver';
-import { TopLevelSection } from '../context/CloudFormationEnums';
+import { IntrinsicFunction, TopLevelSection } from '../context/CloudFormationEnums';
 import { getEntityMap } from '../context/SectionContextBuilder';
 import { Resource } from '../context/semantic/Entity';
 import { SyntaxTree } from '../context/syntaxtree/SyntaxTree';
@@ -21,6 +21,9 @@ const log = LoggerFactory.getLogger('RelatedResourcesSnippetProvider');
 
 const REF_PLACEHOLDER_PREFIX = '__CFN_REF_';
 const REF_PLACEHOLDER_SUFFIX = '__';
+const GETATT_PLACEHOLDER_PREFIX = '__CFN_GETATT_';
+const GETATT_PLACEHOLDER_SEPARATOR = '_DOT_';
+const GETATT_PLACEHOLDER_SUFFIX = '__';
 
 export interface RelatedResourceObject {
     [logicalId: string]: {
@@ -73,7 +76,7 @@ export class RelatedResourcesSnippetProvider {
             );
 
             if (documentType === DocumentType.YAML) {
-                formattedText = this.replaceRefPlaceholders(formattedText);
+                formattedText = this.replaceIntrinsicPlaceholders(formattedText);
             }
 
             const insertPosition = getInsertPosition(resourceSection, document);
@@ -116,10 +119,11 @@ export class RelatedResourcesSnippetProvider {
         try {
             const schema = this.schemaRetriever.getDefault().schemas.get(resourceType);
             const resource: { Type: string; Properties?: Record<string, unknown> } = { Type: resourceType };
+            const requiredProps = new Set(schema?.required);
 
-            if (schema?.required && schema.required.length > 0) {
+            if (requiredProps.size > 0) {
                 resource.Properties = {};
-                for (const propName of schema.required) {
+                for (const propName of requiredProps) {
                     resource.Properties[propName] = this.getPropertyValueForRelatedResource(
                         propName,
                         resourceType,
@@ -130,6 +134,16 @@ export class RelatedResourcesSnippetProvider {
                 }
             }
 
+            // Also add non-required properties that reference the parent type
+            this.addParentReferencingProperties(
+                resource,
+                resourceType,
+                parentResourceType,
+                parentLogicalId,
+                documentType,
+                requiredProps,
+            );
+
             return { [logicalId]: resource };
         } catch {
             return { [logicalId]: { Type: resourceType } };
@@ -137,8 +151,95 @@ export class RelatedResourcesSnippetProvider {
     }
 
     /**
+     * Counts the number of top-level properties on the inserted resource type
+     * that reference the parent resource type. Used to determine whether to
+     * auto-populate: if multiple properties reference the same parent, we leave
+     * them empty since we can't determine which one the user intends.
+     */
+    private countTopLevelParentReferences(resourceType: string, parentResourceType: string): number {
+        const relationships = this.relationshipSchemaService.getRelationshipsForResourceType(resourceType);
+        if (!relationships) {
+            return 0;
+        }
+
+        let count = 0;
+        for (const rel of relationships.relationships) {
+            if (rel.property.includes('/')) {
+                continue;
+            }
+            const matchesParent = rel.relatedResourceTypes.some((rt) => rt.typeName === parentResourceType);
+            if (matchesParent) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Adds non-required properties that reference the parent resource type.
+     * These properties are discovered from the relationship schema and are
+     * pre-populated with !Ref or !GetAtt to the parent logical ID.
+     * Only populates when exactly one top-level property references the parent.
+     */
+    private addParentReferencingProperties(
+        resource: { Type: string; Properties?: Record<string, unknown> },
+        resourceType: string,
+        parentResourceType: string,
+        parentLogicalId: string | undefined,
+        documentType: DocumentType,
+        requiredProps: Set<string>,
+    ): void {
+        if (!parentLogicalId) {
+            return;
+        }
+
+        // Don't auto-populate if multiple top-level properties reference the parent
+        if (this.countTopLevelParentReferences(resourceType, parentResourceType) > 1) {
+            return;
+        }
+
+        const relationships = this.relationshipSchemaService.getRelationshipsForResourceType(resourceType);
+        if (!relationships) {
+            return;
+        }
+
+        const schema = this.schemaRetriever.getDefault().schemas.get(resourceType);
+
+        for (const rel of relationships.relationships) {
+            // Only match direct top-level property names (no nested paths with /)
+            if (rel.property.includes('/')) {
+                continue;
+            }
+
+            // Skip if already added as a required property
+            if (requiredProps.has(rel.property)) {
+                continue;
+            }
+
+            // Skip array properties - don't auto-populate them with references
+            const propSchema = schema?.properties?.[rel.property];
+            if (propSchema?.type === 'array' || propSchema?.items !== undefined) {
+                continue;
+            }
+
+            const matchingType = rel.relatedResourceTypes.find((rt) => rt.typeName === parentResourceType);
+            if (matchingType) {
+                resource.Properties ??= {};
+
+                resource.Properties[rel.property] = this.buildIntrinsicReference(
+                    parentLogicalId,
+                    matchingType.attribute,
+                    parentResourceType,
+                    documentType,
+                );
+            }
+        }
+    }
+
+    /**
      * Determines the property value for a related resource property.
-     * If the property references the parent resource type, returns a !Ref reference.
+     * If the property references the parent resource type, returns a !Ref or !GetAtt reference.
+     * Only populates when exactly one top-level property references the parent.
      * Otherwise returns an empty string.
      */
     private getPropertyValueForRelatedResource(
@@ -152,6 +253,18 @@ export class RelatedResourcesSnippetProvider {
             return '';
         }
 
+        // Skip array properties - don't auto-populate them with references
+        const schema = this.schemaRetriever.getDefault().schemas.get(resourceType);
+        const propSchema = schema?.properties?.[propName];
+        if (propSchema?.type === 'array' || propSchema?.items !== undefined) {
+            return '';
+        }
+
+        // Don't auto-populate if multiple top-level properties reference the parent
+        if (this.countTopLevelParentReferences(resourceType, parentResourceType) > 1) {
+            return '';
+        }
+
         const relationships = this.relationshipSchemaService.getRelationshipsForResourceType(resourceType);
         if (!relationships) {
             return '';
@@ -162,15 +275,14 @@ export class RelatedResourcesSnippetProvider {
             // rel.property may contain nested paths like "VpcConfig/SecurityGroupIds"
             // We only match when the property path is exactly the propName (top-level)
             if (rel.property === propName) {
-                const matchesParent = rel.relatedResourceTypes.some((rt) => rt.typeName === parentResourceType);
-                if (matchesParent) {
-                    if (documentType === DocumentType.YAML) {
-                        // Use a placeholder that will be replaced after YAML serialization
-                        return `${REF_PLACEHOLDER_PREFIX}${parentLogicalId}${REF_PLACEHOLDER_SUFFIX}`;
-                    } else {
-                        // For JSON, return the intrinsic function object
-                        return { Ref: parentLogicalId };
-                    }
+                const matchingType = rel.relatedResourceTypes.find((rt) => rt.typeName === parentResourceType);
+                if (matchingType) {
+                    return this.buildIntrinsicReference(
+                        parentLogicalId,
+                        matchingType.attribute,
+                        parentResourceType,
+                        documentType,
+                    );
                 }
             }
         }
@@ -179,18 +291,87 @@ export class RelatedResourcesSnippetProvider {
     }
 
     /**
-     * Replaces Ref placeholders in the serialized YAML output with proper !Ref intrinsic functions.
-     * The YAML serializer quotes strings starting with !, so we use placeholders during serialization
-     * and then replace them with the unquoted !Ref syntax afterward.
+     * Builds the appropriate intrinsic function reference (!Ref or !GetAtt) based on
+     * whether the attribute matches the parent resource's primary identifier.
+     *
+     * - If the attribute is the primary identifier → !Ref ParentLogicalId
+     * - If the attribute is NOT the primary identifier → !GetAtt ParentLogicalId.AttributeName
+     *
+     * @param parentLogicalId - The logical ID of the parent resource in the template
+     * @param attribute - The attribute path from the relationship schema (e.g., "/properties/Arn")
+     * @param parentResourceType - The parent resource type (e.g., "AWS::IAM::Role")
+     * @param documentType - YAML or JSON
      */
-    private replaceRefPlaceholders(text: string): string {
-        // Match both quoted and unquoted placeholders
-        // The YAML serializer may produce: '__CFN_REF_MyVpc__' or __CFN_REF_MyVpc__
-        const placeholderRegex = new RegExp(
-            `['"]?${REF_PLACEHOLDER_PREFIX}([a-zA-Z0-9]+)${REF_PLACEHOLDER_SUFFIX}['"]?`,
+    private buildIntrinsicReference(
+        parentLogicalId: string,
+        attribute: string,
+        parentResourceType: string,
+        documentType: DocumentType,
+    ): unknown {
+        const useGetAtt = !this.isAttributePrimaryIdentifier(attribute, parentResourceType);
+        const attributeName = this.extractAttributeName(attribute);
+
+        if (useGetAtt && attributeName) {
+            if (documentType === DocumentType.YAML) {
+                return `${GETATT_PLACEHOLDER_PREFIX}${parentLogicalId}${GETATT_PLACEHOLDER_SEPARATOR}${attributeName}${GETATT_PLACEHOLDER_SUFFIX}`;
+            } else {
+                return { [IntrinsicFunction.GetAtt]: [parentLogicalId, attributeName] };
+            }
+        }
+
+        // Default to !Ref
+        if (documentType === DocumentType.YAML) {
+            return `${REF_PLACEHOLDER_PREFIX}${parentLogicalId}${REF_PLACEHOLDER_SUFFIX}`;
+        } else {
+            return { Ref: parentLogicalId };
+        }
+    }
+
+    /**
+     * Checks if the given attribute path matches the parent resource type's primary identifier.
+     * If the parent schema is not available, defaults to using !Ref (returns true).
+     */
+    private isAttributePrimaryIdentifier(attribute: string, parentResourceType: string): boolean {
+        try {
+            const parentSchema = this.schemaRetriever.getDefault().schemas.get(parentResourceType);
+            if (!parentSchema?.primaryIdentifier) {
+                return true; // Default to !Ref when schema is unavailable
+            }
+            return parentSchema.primaryIdentifier.includes(attribute);
+        } catch {
+            return true; // Default to !Ref on error
+        }
+    }
+
+    /**
+     * Extracts the attribute name from a JSON pointer path.
+     * e.g., "/properties/Arn" → "Arn"
+     *       "/properties/VpcId" → "VpcId"
+     */
+    private extractAttributeName(attribute: string): string | undefined {
+        const parts = attribute.split('/');
+        return parts.length > 0 ? parts[parts.length - 1] : undefined;
+    }
+
+    /**
+     * Replaces intrinsic function placeholders in the serialized YAML output with
+     * proper !Ref and !GetAtt syntax.
+     * The YAML serializer quotes strings starting with !, so we use placeholders during
+     * serialization and then replace them afterward.
+     */
+    private replaceIntrinsicPlaceholders(text: string): string {
+        // Replace !GetAtt placeholders: '__CFN_GETATT_MyRole_DOT_Arn__' → '!GetAtt MyRole.Arn'
+        const getAttRegex = new RegExp(
+            `['"]?${GETATT_PLACEHOLDER_PREFIX}([a-zA-Z0-9]+)${GETATT_PLACEHOLDER_SEPARATOR}([a-zA-Z0-9]+)${GETATT_PLACEHOLDER_SUFFIX}['"]?`,
             'g',
         );
-        return text.replaceAll(placeholderRegex, '!Ref $1');
+        text = text.replaceAll(getAttRegex, '!GetAtt $1.$2');
+
+        // Replace !Ref placeholders: '__CFN_REF_MyVpc__' → '!Ref MyVpc'
+        const refRegex = new RegExp(`['"]?${REF_PLACEHOLDER_PREFIX}([a-zA-Z0-9]+)${REF_PLACEHOLDER_SUFFIX}['"]?`, 'g');
+        text = text.replaceAll(refRegex, '!Ref $1');
+
+        return text;
     }
 
     /**

--- a/src/relatedResources/RelatedResourcesSnippetProvider.ts
+++ b/src/relatedResources/RelatedResourcesSnippetProvider.ts
@@ -220,7 +220,7 @@ export class RelatedResourcesSnippetProvider {
 
             // Skip array properties - don't auto-populate them with references
             const propSchema = schema?.properties?.[rel.property];
-            if (propSchema?.type === 'array' || propSchema?.items !== undefined) {
+            if (propSchema?.type === 'array') {
                 continue;
             }
 
@@ -258,7 +258,7 @@ export class RelatedResourcesSnippetProvider {
         // Skip array properties - don't auto-populate them with references
         const schema = this.schemaRetriever.getDefault().schemas.get(resourceType);
         const propSchema = schema?.properties?.[propName];
-        if (propSchema?.type === 'array' || propSchema?.items !== undefined) {
+        if (propSchema?.type === 'array') {
             return '';
         }
 

--- a/src/relatedResources/RelatedResourcesSnippetProvider.ts
+++ b/src/relatedResources/RelatedResourcesSnippetProvider.ts
@@ -46,6 +46,7 @@ export class RelatedResourcesSnippetProvider {
         templateUri: string,
         relatedResourceTypes: string[],
         parentResourceType: string,
+        providedParentLogicalId?: string,
     ): RelatedResourcesCodeAction {
         this.currentTemplateUri = templateUri;
 
@@ -59,7 +60,8 @@ export class RelatedResourcesSnippetProvider {
             const syntaxTree: SyntaxTree | undefined = this.syntaxTreeManager.getSyntaxTree(templateUri);
             const editorSettings = this.documentManager.getEditorSettingsForDocument(templateUri);
 
-            const parentLogicalId = this.findParentLogicalId(syntaxTree, parentResourceType);
+            // Use provided logical ID if available, otherwise find the first match
+            const parentLogicalId = providedParentLogicalId ?? this.findParentLogicalId(syntaxTree, parentResourceType);
 
             const resources = relatedResourceTypes.map((resourceType) =>
                 this.generateResourceObject(resourceType, parentResourceType, parentLogicalId, documentType),

--- a/src/relatedResources/RelatedResourcesSnippetProvider.ts
+++ b/src/relatedResources/RelatedResourcesSnippetProvider.ts
@@ -152,12 +152,6 @@ export class RelatedResourcesSnippetProvider {
         }
     }
 
-    /**
-     * Counts the number of top-level properties on the inserted resource type
-     * that reference the parent resource type. Used to determine whether to
-     * auto-populate: if multiple properties reference the same parent, we leave
-     * them empty since we can't determine which one the user intends.
-     */
     private countTopLevelParentReferences(resourceType: string, parentResourceType: string): number {
         const relationships = this.relationshipSchemaService.getRelationshipsForResourceType(resourceType);
         if (!relationships) {
@@ -177,12 +171,6 @@ export class RelatedResourcesSnippetProvider {
         return count;
     }
 
-    /**
-     * Adds non-required properties that reference the parent resource type.
-     * These properties are discovered from the relationship schema and are
-     * pre-populated with !Ref or !GetAtt to the parent logical ID.
-     * Only populates when exactly one top-level property references the parent.
-     */
     private addParentReferencingProperties(
         resource: { Type: string; Properties?: Record<string, unknown> },
         resourceType: string,
@@ -195,7 +183,6 @@ export class RelatedResourcesSnippetProvider {
             return;
         }
 
-        // Don't auto-populate if multiple top-level properties reference the parent
         if (this.countTopLevelParentReferences(resourceType, parentResourceType) > 1) {
             return;
         }
@@ -208,17 +195,14 @@ export class RelatedResourcesSnippetProvider {
         const schema = this.schemaRetriever.getDefault().schemas.get(resourceType);
 
         for (const rel of relationships.relationships) {
-            // Only match direct top-level property names (no nested paths with /)
             if (rel.property.includes('/')) {
                 continue;
             }
 
-            // Skip if already added as a required property
             if (requiredProps.has(rel.property)) {
                 continue;
             }
 
-            // Skip array properties - don't auto-populate them with references
             const propSchema = schema?.properties?.[rel.property];
             if (propSchema?.type === 'array') {
                 continue;
@@ -238,12 +222,6 @@ export class RelatedResourcesSnippetProvider {
         }
     }
 
-    /**
-     * Determines the property value for a related resource property.
-     * If the property references the parent resource type, returns a !Ref or !GetAtt reference.
-     * Only populates when exactly one top-level property references the parent.
-     * Otherwise returns an empty string.
-     */
     private getPropertyValueForRelatedResource(
         propName: string,
         resourceType: string,
@@ -255,14 +233,12 @@ export class RelatedResourcesSnippetProvider {
             return '';
         }
 
-        // Skip array properties - don't auto-populate them with references
         const schema = this.schemaRetriever.getDefault().schemas.get(resourceType);
         const propSchema = schema?.properties?.[propName];
         if (propSchema?.type === 'array') {
             return '';
         }
 
-        // Don't auto-populate if multiple top-level properties reference the parent
         if (this.countTopLevelParentReferences(resourceType, parentResourceType) > 1) {
             return '';
         }
@@ -273,9 +249,6 @@ export class RelatedResourcesSnippetProvider {
         }
 
         for (const rel of relationships.relationships) {
-            // Only match direct top-level property names
-            // rel.property may contain nested paths like "VpcConfig/SecurityGroupIds"
-            // We only match when the property path is exactly the propName (top-level)
             if (rel.property === propName) {
                 const matchingType = rel.relatedResourceTypes.find((rt) => rt.typeName === parentResourceType);
                 if (matchingType) {
@@ -292,32 +265,20 @@ export class RelatedResourcesSnippetProvider {
         return '';
     }
 
-    /**
-     * Builds the appropriate intrinsic function reference (!Ref or !GetAtt) based on
-     * whether the attribute matches the parent resource's primary identifier.
-     *
-     * - If the attribute is the primary identifier → !Ref ParentLogicalId
-     * - If the attribute is NOT the primary identifier → !GetAtt ParentLogicalId.AttributeName
-     *
-     * @param parentLogicalId - The logical ID of the parent resource in the template
-     * @param attribute - The attribute path from the relationship schema (e.g., "/properties/Arn")
-     * @param parentResourceType - The parent resource type (e.g., "AWS::IAM::Role")
-     * @param documentType - YAML or JSON
-     */
     private buildIntrinsicReference(
         parentLogicalId: string,
-        attribute: string,
+        attributePath: string,
         parentResourceType: string,
         documentType: DocumentType,
     ): unknown {
-        const useGetAtt = !this.isAttributePrimaryIdentifier(attribute, parentResourceType);
-        const attributeName = this.extractAttributeName(attribute);
+        const useGetAtt = !this.isAttributePrimaryIdentifier(attributePath, parentResourceType);
+        const attributePathName = this.extractAttributeName(attributePath);
 
-        if (useGetAtt && attributeName) {
+        if (useGetAtt && attributePathName) {
             if (documentType === DocumentType.YAML) {
-                return `${GETATT_PLACEHOLDER_PREFIX}${parentLogicalId}${GETATT_PLACEHOLDER_SEPARATOR}${attributeName}${GETATT_PLACEHOLDER_SUFFIX}`;
+                return `${GETATT_PLACEHOLDER_PREFIX}${parentLogicalId}${GETATT_PLACEHOLDER_SEPARATOR}${attributePathName}${GETATT_PLACEHOLDER_SUFFIX}`;
             } else {
-                return { [IntrinsicFunction.GetAtt]: [parentLogicalId, attributeName] };
+                return { [IntrinsicFunction.GetAtt]: [parentLogicalId, attributePathName] };
             }
         }
 
@@ -329,56 +290,36 @@ export class RelatedResourcesSnippetProvider {
         }
     }
 
-    /**
-     * Checks if the given attribute path matches the parent resource type's primary identifier.
-     * If the parent schema is not available, defaults to using !Ref (returns true).
-     */
-    private isAttributePrimaryIdentifier(attribute: string, parentResourceType: string): boolean {
+    private isAttributePrimaryIdentifier(attributePath: string, parentResourceType: string): boolean {
         try {
             const parentSchema = this.schemaRetriever.getDefault().schemas.get(parentResourceType);
             if (!parentSchema?.primaryIdentifier) {
-                return true; // Default to !Ref when schema is unavailable
+                return true;
             }
-            return parentSchema.primaryIdentifier.includes(attribute);
+            return parentSchema.primaryIdentifier.includes(attributePath);
         } catch {
-            return true; // Default to !Ref on error
+            return true;
         }
     }
 
-    /**
-     * Extracts the attribute name from a JSON pointer path.
-     * e.g., "/properties/Arn" → "Arn"
-     *       "/properties/VpcId" → "VpcId"
-     */
-    private extractAttributeName(attribute: string): string | undefined {
-        const parts = attribute.split('/');
+    private extractAttributeName(attributePath: string): string | undefined {
+        const parts = attributePath.split('/');
         return parts.length > 0 ? parts[parts.length - 1] : undefined;
     }
 
-    /**
-     * Replaces intrinsic function placeholders in the serialized YAML output with
-     * proper !Ref and !GetAtt syntax.
-     * The YAML serializer quotes strings starting with !, so we use placeholders during
-     * serialization and then replace them afterward.
-     */
     private replaceIntrinsicPlaceholders(text: string): string {
-        // Replace !GetAtt placeholders: '__CFN_GETATT_MyRole_DOT_Arn__' → '!GetAtt MyRole.Arn'
         const getAttRegex = new RegExp(
             `['"]?${GETATT_PLACEHOLDER_PREFIX}([a-zA-Z0-9]+)${GETATT_PLACEHOLDER_SEPARATOR}([a-zA-Z0-9]+)${GETATT_PLACEHOLDER_SUFFIX}['"]?`,
             'g',
         );
         text = text.replaceAll(getAttRegex, '!GetAtt $1.$2');
 
-        // Replace !Ref placeholders: '__CFN_REF_MyVpc__' → '!Ref MyVpc'
         const refRegex = new RegExp(`['"]?${REF_PLACEHOLDER_PREFIX}([a-zA-Z0-9]+)${REF_PLACEHOLDER_SUFFIX}['"]?`, 'g');
         text = text.replaceAll(refRegex, '!Ref $1');
 
         return text;
     }
 
-    /**
-     * Finds the logical ID of the first resource in the template that matches the given resource type.
-     */
     private findParentLogicalId(syntaxTree: SyntaxTree | undefined, parentResourceType: string): string | undefined {
         if (!syntaxTree) {
             return undefined;

--- a/src/server/CfnLspProviders.ts
+++ b/src/server/CfnLspProviders.ts
@@ -68,7 +68,12 @@ export class CfnLspProviders implements Configurables, Closeable {
         this.relationshipSchemaService = overrides.relationshipSchemaService ?? new RelationshipSchemaService();
         this.relatedResourcesSnippetProvider =
             overrides.relatedResourcesSnippetProvider ??
-            new RelatedResourcesSnippetProvider(core.documentManager, core.syntaxTreeManager, external.schemaRetriever);
+            new RelatedResourcesSnippetProvider(
+                core.documentManager,
+                core.syntaxTreeManager,
+                external.schemaRetriever,
+                this.relationshipSchemaService,
+            );
         this.s3Service = overrides.s3Service ?? new S3Service(external.awsClient);
 
         this.hoverRouter =

--- a/src/services/RelationshipSchemaService.ts
+++ b/src/services/RelationshipSchemaService.ts
@@ -25,6 +25,9 @@ export type RelationshipGroupData = Record<string, RelatedResourceType[]>;
 
 export class RelationshipSchemaService {
     private readonly relationshipCache: Map<string, ResourceTypeRelationships> = new Map();
+    // Reverse index: maps a referenced type to the set of types that reference it
+    // e.g., "AWS::IAM::Role" → Set { "AWS::Lambda::Function", "AWS::ECS::TaskDefinition", ... }
+    private readonly reverseRelationshipCache: Map<string, Set<string>> = new Map();
 
     constructor(private readonly schemaFilePath: string = join(__dirname, 'assets', 'relationship_schemas.json')) {
         this.loadAllSchemas();
@@ -38,6 +41,8 @@ export class RelationshipSchemaService {
             for (const [resourceTypeKey, relationships] of Object.entries(allSchemas)) {
                 try {
                     const processedRelationships: ResourceRelationship[] = [];
+                    // Convert key format: AWS-Lambda-Function → AWS::Lambda::Function
+                    const sourceType = this.convertKeyToResourceType(resourceTypeKey);
 
                     for (const relationshipGroup of relationships) {
                         for (const [property, relatedTypes] of Object.entries(relationshipGroup)) {
@@ -45,6 +50,20 @@ export class RelationshipSchemaService {
                                 property,
                                 relatedResourceTypes: relatedTypes,
                             });
+
+                            // Build reverse index only for top-level properties (no nested paths)
+                            // Nested properties (containing /) can't be populated with !Ref/!GetAtt
+                            if (!property.includes('/')) {
+                                for (const relatedType of relatedTypes) {
+                                    const referencedType = relatedType.typeName;
+                                    let existingSet = this.reverseRelationshipCache.get(referencedType);
+                                    if (!existingSet) {
+                                        existingSet = new Set();
+                                        this.reverseRelationshipCache.set(referencedType, existingSet);
+                                    }
+                                    existingSet.add(sourceType);
+                                }
+                            }
                         }
                     }
 
@@ -66,6 +85,10 @@ export class RelationshipSchemaService {
         return resourceType.replaceAll('::', '-');
     }
 
+    private convertKeyToResourceType(key: string): string {
+        return key.replaceAll('-', '::');
+    }
+
     getRelationshipsForResourceType(resourceType: string): ResourceTypeRelationships | undefined {
         const cacheKey = this.convertResourceTypeToKey(resourceType);
         const result = this.relationshipCache.get(cacheKey);
@@ -81,15 +104,23 @@ export class RelationshipSchemaService {
     }
 
     getAllRelatedResourceTypes(resourceType: string): Set<string> {
+        const relatedTypes = new Set<string>();
+
+        // Outgoing: types that this resource's properties reference
         const relationships = this.getRelationshipsForResourceType(resourceType);
-        if (!relationships) {
-            return new Set<string>();
+        if (relationships) {
+            for (const relationship of relationships.relationships) {
+                for (const relatedType of relationship.relatedResourceTypes) {
+                    relatedTypes.add(relatedType.typeName);
+                }
+            }
         }
 
-        const relatedTypes = new Set<string>();
-        for (const relationship of relationships.relationships) {
-            for (const relatedType of relationship.relatedResourceTypes) {
-                relatedTypes.add(relatedType.typeName);
+        // Incoming: types whose properties reference this resource
+        const incoming = this.reverseRelationshipCache.get(resourceType);
+        if (incoming) {
+            for (const type of incoming) {
+                relatedTypes.add(type);
             }
         }
 

--- a/tst/unit/handlers/RelatedResourcesHandler.test.ts
+++ b/tst/unit/handlers/RelatedResourcesHandler.test.ts
@@ -129,17 +129,47 @@ describe('RelatedResourcesHandler', () => {
     });
 
     describe('getRelatedResourceTypesHandler', () => {
-        it('should return related resource types for a given resource type', () => {
+        it('should return related resource types that have exactly one populatable relationship', () => {
             const handler = getRelatedResourceTypesHandler(mockComponents);
             const params = { parentResourceType: 'AWS::S3::Bucket' };
 
-            const relatedTypes = new Set(['AWS::Lambda::Function', 'AWS::IAM::Role']);
+            const relatedTypes = new Set(['AWS::Lambda::Function', 'AWS::CloudTrail::Trail']);
             relationshipSchemaService.getAllRelatedResourceTypes.withArgs('AWS::S3::Bucket').returns(relatedTypes);
+
+            // Lambda has exactly 1 non-array top-level reference to S3
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::Lambda::Function').returns({
+                resourceType: 'AWS::Lambda::Function',
+                relationships: [
+                    {
+                        property: 'Code/S3Bucket',
+                        relatedResourceTypes: [{ typeName: 'AWS::S3::Bucket', attribute: '/properties/BucketName' }],
+                    },
+                ],
+            });
+
+            // CloudTrail has exactly 1 non-array top-level reference to S3
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::CloudTrail::Trail').returns({
+                resourceType: 'AWS::CloudTrail::Trail',
+                relationships: [
+                    {
+                        property: 'S3BucketName',
+                        relatedResourceTypes: [{ typeName: 'AWS::S3::Bucket', attribute: '/properties/BucketName' }],
+                    },
+                ],
+            });
+
+            mockComponents.schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    ['AWS::Lambda::Function', { properties: {} }],
+                    ['AWS::CloudTrail::Trail', { properties: { S3BucketName: { type: 'string' } } }],
+                ]),
+            } as any);
 
             const result = handler(params, mockToken);
 
-            expect(result).toEqual(['AWS::Lambda::Function', 'AWS::IAM::Role']);
-            expect(relationshipSchemaService.getAllRelatedResourceTypes.calledWith('AWS::S3::Bucket')).toBe(true);
+            // Lambda only has nested ref (Code/S3Bucket), so 0 top-level → excluded
+            // CloudTrail has 1 top-level non-array ref → included
+            expect(result).toEqual(['AWS::CloudTrail::Trail']);
         });
 
         it('should return empty array when no related types found', () => {
@@ -161,6 +191,150 @@ describe('RelatedResourcesHandler', () => {
             relationshipSchemaService.getAllRelatedResourceTypes.withArgs('AWS::S3::Bucket').throws(error);
 
             expect(() => handler(params, mockToken)).toThrow('Relationship service error');
+        });
+
+        it('should filter out resource types that only have array-property relationships', () => {
+            const handler = getRelatedResourceTypesHandler(mockComponents);
+            const params = { parentResourceType: 'AWS::IAM::Role' };
+
+            const relatedTypes = new Set(['AWS::IAM::ManagedPolicy', 'AWS::Lambda::Function']);
+            relationshipSchemaService.getAllRelatedResourceTypes.withArgs('AWS::IAM::Role').returns(relatedTypes);
+
+            // ManagedPolicy has only array relationship (Roles)
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::IAM::ManagedPolicy').returns({
+                resourceType: 'AWS::IAM::ManagedPolicy',
+                relationships: [
+                    {
+                        property: 'Roles',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/RoleName' }],
+                    },
+                ],
+            });
+
+            // Lambda has exactly one non-array relationship (Role)
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::Lambda::Function').returns({
+                resourceType: 'AWS::Lambda::Function',
+                relationships: [
+                    {
+                        property: 'Role',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/Arn' }],
+                    },
+                ],
+            });
+
+            mockComponents.schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    ['AWS::IAM::ManagedPolicy', { properties: { Roles: { type: 'array' } } }],
+                    ['AWS::Lambda::Function', { properties: { Role: { type: 'string' } } }],
+                ]),
+            } as any);
+
+            const result = handler(params, mockToken);
+
+            expect(result).toEqual(['AWS::Lambda::Function']);
+            expect(result).not.toContain('AWS::IAM::ManagedPolicy');
+        });
+
+        it('should filter out resource types with 2 top-level refs to parent (including arrays)', () => {
+            const handler = getRelatedResourceTypesHandler(mockComponents);
+            const params = { parentResourceType: 'AWS::IAM::Role' };
+
+            const relatedTypes = new Set(['AWS::IAM::InstanceProfile']);
+            relationshipSchemaService.getAllRelatedResourceTypes.withArgs('AWS::IAM::Role').returns(relatedTypes);
+
+            // InstanceProfile has 2 top-level refs: Roles (array) + InstanceProfileName
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::IAM::InstanceProfile').returns({
+                resourceType: 'AWS::IAM::InstanceProfile',
+                relationships: [
+                    {
+                        property: 'Roles',
+                        relatedResourceTypes: [
+                            { typeName: 'AWS::IAM::Role', attribute: '/properties/RoleName' },
+                            { typeName: 'AWS::IAM::Role', attribute: '/properties/Arn' },
+                        ],
+                    },
+                    {
+                        property: 'InstanceProfileName',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/RoleName' }],
+                    },
+                ],
+            });
+
+            mockComponents.schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    [
+                        'AWS::IAM::InstanceProfile',
+                        { properties: { Roles: { type: 'array' }, InstanceProfileName: { type: 'string' } } },
+                    ],
+                ]),
+            } as any);
+
+            const result = handler(params, mockToken);
+
+            // 2 total top-level refs (Roles + InstanceProfileName) → excluded
+            expect(result).toEqual([]);
+        });
+
+        it('should filter out resource types with no relationships to parent', () => {
+            const handler = getRelatedResourceTypesHandler(mockComponents);
+            const params = { parentResourceType: 'AWS::IAM::Role' };
+
+            const relatedTypes = new Set(['AWS::EMR::Cluster']);
+            relationshipSchemaService.getAllRelatedResourceTypes.withArgs('AWS::IAM::Role').returns(relatedTypes);
+
+            // EMR::Cluster has no relationships (came from reverse lookup)
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::EMR::Cluster').returns(undefined);
+
+            const result = handler(params, mockToken);
+
+            // No relationships found → excluded
+            expect(result).toEqual([]);
+        });
+
+        it('should filter out resource types where all relationships to parent are arrays', () => {
+            const handler = getRelatedResourceTypesHandler(mockComponents);
+            const params = { parentResourceType: 'AWS::EC2::SecurityGroup' };
+
+            const relatedTypes = new Set(['AWS::EC2::Instance']);
+            relationshipSchemaService.getAllRelatedResourceTypes
+                .withArgs('AWS::EC2::SecurityGroup')
+                .returns(relatedTypes);
+
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::EC2::Instance').returns({
+                resourceType: 'AWS::EC2::Instance',
+                relationships: [
+                    {
+                        property: 'SecurityGroups',
+                        relatedResourceTypes: [
+                            { typeName: 'AWS::EC2::SecurityGroup', attribute: '/properties/GroupId' },
+                        ],
+                    },
+                    {
+                        property: 'SecurityGroupIds',
+                        relatedResourceTypes: [
+                            { typeName: 'AWS::EC2::SecurityGroup', attribute: '/properties/GroupId' },
+                        ],
+                    },
+                ],
+            });
+
+            mockComponents.schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    [
+                        'AWS::EC2::Instance',
+                        {
+                            properties: {
+                                SecurityGroups: { type: 'array' },
+                                SecurityGroupIds: { type: 'array' },
+                            },
+                        },
+                    ],
+                ]),
+            } as any);
+
+            const result = handler(params, mockToken);
+
+            expect(result).toEqual([]);
         });
     });
 

--- a/tst/unit/handlers/RelatedResourcesHandler.test.ts
+++ b/tst/unit/handlers/RelatedResourcesHandler.test.ts
@@ -37,7 +37,7 @@ describe('RelatedResourcesHandler', () => {
     });
 
     describe('getAuthoredResourceTypesHandler', () => {
-        it('should return unique resource types from template', () => {
+        it('should return authored resources with logical IDs and types', () => {
             const handler = getAuthoredResourceTypesHandler(mockComponents);
             const templateUri = 'file:///test/template.yaml';
 
@@ -48,7 +48,7 @@ describe('RelatedResourcesHandler', () => {
                 entity: { Type: 'AWS::Lambda::Function' },
             };
             const mockResourceContext3 = {
-                entity: { Type: 'AWS::S3::Bucket' }, // Duplicate
+                entity: { Type: 'AWS::S3::Bucket' },
             };
 
             syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns({} as any);
@@ -62,7 +62,11 @@ describe('RelatedResourcesHandler', () => {
 
             const result = handler(templateUri, mockToken);
 
-            expect(result).toEqual(['AWS::S3::Bucket', 'AWS::Lambda::Function']);
+            expect(result).toEqual([
+                { logicalId: 'Bucket1', type: 'AWS::S3::Bucket' },
+                { logicalId: 'Function1', type: 'AWS::Lambda::Function' },
+                { logicalId: 'Bucket2', type: 'AWS::S3::Bucket' },
+            ]);
             expect(syntaxTreeManager.getSyntaxTree.calledWith(templateUri)).toBe(true);
         });
 
@@ -114,7 +118,7 @@ describe('RelatedResourcesHandler', () => {
 
             const result = handler(templateUri, mockToken);
 
-            expect(result).toEqual(['AWS::S3::Bucket']);
+            expect(result).toEqual([{ logicalId: 'Bucket1', type: 'AWS::S3::Bucket' }]);
         });
 
         it('should handle errors and rethrow them', () => {
@@ -339,7 +343,7 @@ describe('RelatedResourcesHandler', () => {
     });
 
     describe('insertRelatedResourcesHandler', () => {
-        it('should insert related resources and return code action', () => {
+        it('should insert related resources and return code action without parentLogicalId', () => {
             const handler = insertRelatedResourcesHandler(mockComponents);
             const params = {
                 templateUri: 'file:///test/template.yaml',
@@ -358,19 +362,52 @@ describe('RelatedResourcesHandler', () => {
             };
 
             mockComponents.relatedResourcesSnippetProvider.insertRelatedResources
-                .withArgs('file:///test/template.yaml', ['AWS::Lambda::Function', 'AWS::IAM::Role'], 'AWS::S3::Bucket')
+                .withArgs(
+                    'file:///test/template.yaml',
+                    ['AWS::Lambda::Function', 'AWS::IAM::Role'],
+                    'AWS::S3::Bucket',
+                    undefined,
+                )
                 .returns(mockCodeAction);
 
             const result = handler(params, mockToken);
 
             expect(result).toEqual(mockCodeAction);
-            expect(
-                mockComponents.relatedResourcesSnippetProvider.insertRelatedResources.calledWith(
-                    'file:///test/template.yaml',
-                    ['AWS::Lambda::Function', 'AWS::IAM::Role'],
-                    'AWS::S3::Bucket',
-                ),
-            ).toBe(true);
+        });
+
+        it('should insert related resources with parentLogicalId when provided', () => {
+            const handler = insertRelatedResourcesHandler(mockComponents);
+            const params = {
+                templateUri: 'file:///test/template.yaml',
+                relatedResourceTypes: ['AWS::Lambda::Function'],
+                parentResourceType: 'AWS::IAM::Role',
+                parentLogicalId: 'MyRole',
+            };
+
+            const mockCodeAction = {
+                title: 'Insert 1 related resources',
+                kind: 'refactor',
+                edit: {
+                    changes: {
+                        'file:///test/template.yaml': [],
+                    },
+                },
+            };
+
+            mockComponents.relatedResourcesSnippetProvider.insertRelatedResources.returns(mockCodeAction);
+
+            const result = handler(params, mockToken);
+
+            expect(result).toEqual(mockCodeAction);
+            // Verify it was called with the parentLogicalId
+            expect(mockComponents.relatedResourcesSnippetProvider.insertRelatedResources.calledOnce).toBe(true);
+            const call = mockComponents.relatedResourcesSnippetProvider.insertRelatedResources.getCall(0);
+            expect(call.args).toEqual([
+                'file:///test/template.yaml',
+                ['AWS::Lambda::Function'],
+                'AWS::IAM::Role',
+                'MyRole',
+            ]);
         });
 
         it('should handle errors and rethrow them', () => {

--- a/tst/unit/protocol/LspRelatedResourcesHandlers.test.ts
+++ b/tst/unit/protocol/LspRelatedResourcesHandlers.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Connection, RequestHandler } from 'vscode-languageserver/node';
 import { LspRelatedResourcesHandlers } from '../../../src/protocol/LspRelatedResourcesHandlers';
 import {
+    AuthoredResource,
     GetAuthoredResourceTypesRequest,
     GetRelatedResourceTypesParams,
     GetRelatedResourceTypesRequest,
@@ -22,7 +23,7 @@ describe('LspRelatedResourcesHandlers', () => {
     });
 
     it('should register onGetAuthoredResourceTypes handler', () => {
-        const mockHandler: RequestHandler<TemplateUri, string[], void> = vi.fn();
+        const mockHandler: RequestHandler<TemplateUri, AuthoredResource[], void> = vi.fn();
 
         relatedResourcesHandlers.onGetAuthoredResourceTypes(mockHandler);
 

--- a/tst/unit/relatedResources/RelatedResourcesSnippetProvider.test.ts
+++ b/tst/unit/relatedResources/RelatedResourcesSnippetProvider.test.ts
@@ -337,7 +337,7 @@ Resources:
             }).toThrow('Document manager error');
         });
 
-        it('should populate !Ref for YAML when property relates to parent resource type', () => {
+        it('should populate !Ref for YAML when attribute matches primary identifier', () => {
             const templateUri = 'file:///test/template.yaml';
             const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
 Resources:
@@ -363,7 +363,10 @@ Resources:
             syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
             mockGetEntityMap.mockReturnValue(new Map([['MyVpc', { entity: { Type: 'AWS::EC2::VPC' } }]]));
             schemaRetriever.getDefault.returns({
-                schemas: new Map([['AWS::EC2::Subnet', { required: ['VpcId', 'AvailabilityZone'] }]]),
+                schemas: new Map([
+                    ['AWS::EC2::Subnet', { required: ['VpcId', 'AvailabilityZone'] }],
+                    ['AWS::EC2::VPC', { primaryIdentifier: ['/properties/VpcId'] }],
+                ]),
             } as any);
             relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::EC2::Subnet').returns({
                 resourceType: 'AWS::EC2::Subnet',
@@ -383,7 +386,7 @@ Resources:
             expect(textEdit?.newText).toContain('AvailabilityZone: ""');
         });
 
-        it('should populate {"Ref": ...} for JSON when property relates to parent resource type', () => {
+        it('should populate {"Ref": ...} for JSON when attribute matches primary identifier', () => {
             const templateUri = 'file:///test/template.json';
             const jsonContent = `{
   "AWSTemplateFormatVersion": "2010-09-09",
@@ -412,7 +415,10 @@ Resources:
             syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
             mockGetEntityMap.mockReturnValue(new Map([['MyVpc', { entity: { Type: 'AWS::EC2::VPC' } }]]));
             schemaRetriever.getDefault.returns({
-                schemas: new Map([['AWS::EC2::Subnet', { required: ['VpcId', 'AvailabilityZone'] }]]),
+                schemas: new Map([
+                    ['AWS::EC2::Subnet', { required: ['VpcId', 'AvailabilityZone'] }],
+                    ['AWS::EC2::VPC', { primaryIdentifier: ['/properties/VpcId'] }],
+                ]),
             } as any);
             relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::EC2::Subnet').returns({
                 resourceType: 'AWS::EC2::Subnet',
@@ -429,6 +435,161 @@ Resources:
             expect(result).toBeDefined();
             const textEdit = result.edit?.changes![templateUri][0];
             expect(textEdit?.newText).toContain('"Ref": "MyVpc"');
+        });
+
+        it('should populate !GetAtt for YAML when attribute does not match primary identifier', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyRole:
+    Type: AWS::IAM::Role
+`;
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 3, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyRole', { entity: { Type: 'AWS::IAM::Role' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    ['AWS::Lambda::Function', { required: ['Code', 'Role', 'Runtime'] }],
+                    ['AWS::IAM::Role', { primaryIdentifier: ['/properties/RoleName'] }],
+                ]),
+            } as any);
+            // Role property references IAM::Role with attribute /properties/Arn
+            // which is NOT the primary identifier (/properties/RoleName)
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::Lambda::Function').returns({
+                resourceType: 'AWS::Lambda::Function',
+                relationships: [
+                    {
+                        property: 'Role',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/Arn' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::Lambda::Function'], 'AWS::IAM::Role');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            expect(textEdit?.newText).toContain('Role: !GetAtt MyRole.Arn');
+            expect(textEdit?.newText).toContain('Code: ""');
+            expect(textEdit?.newText).toContain('Runtime: ""');
+        });
+
+        it('should populate Fn::GetAtt for JSON when attribute does not match primary identifier', () => {
+            const templateUri = 'file:///test/template.json';
+            const jsonContent = `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyRole": {
+      "Type": "AWS::IAM::Role"
+    }
+  }
+}`;
+            const document = new Document(TextDocument.create(templateUri, 'json', 1, jsonContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 6, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyRole', { entity: { Type: 'AWS::IAM::Role' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    ['AWS::Lambda::Function', { required: ['Code', 'Role', 'Runtime'] }],
+                    ['AWS::IAM::Role', { primaryIdentifier: ['/properties/RoleName'] }],
+                ]),
+            } as any);
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::Lambda::Function').returns({
+                resourceType: 'AWS::Lambda::Function',
+                relationships: [
+                    {
+                        property: 'Role',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/Arn' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::Lambda::Function'], 'AWS::IAM::Role');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            expect(textEdit?.newText).toContain('"Fn::GetAtt"');
+            expect(textEdit?.newText).toContain('"MyRole"');
+            expect(textEdit?.newText).toContain('"Arn"');
+        });
+
+        it('should use !GetAtt for non-required properties when attribute is not primary identifier', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyRole:
+    Type: AWS::IAM::Role
+`;
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 3, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyRole', { entity: { Type: 'AWS::IAM::Role' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    ['AWS::CloudTrail::Trail', { required: ['IsLogging', 'S3BucketName'] }],
+                    ['AWS::IAM::Role', { primaryIdentifier: ['/properties/RoleName'] }],
+                ]),
+            } as any);
+            // CloudWatchLogsRoleArn is NOT required but references IAM::Role with /properties/Arn
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::CloudTrail::Trail').returns({
+                resourceType: 'AWS::CloudTrail::Trail',
+                relationships: [
+                    {
+                        property: 'CloudWatchLogsRoleArn',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/Arn' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::CloudTrail::Trail'], 'AWS::IAM::Role');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            // Non-required property should use !GetAtt since /properties/Arn != primaryIdentifier
+            expect(textEdit?.newText).toContain('CloudWatchLogsRoleArn: !GetAtt MyRole.Arn');
         });
 
         it('should leave property empty when it does not relate to parent resource type', () => {
@@ -481,6 +642,215 @@ Resources:
             expect(textEdit?.newText).toContain('Runtime: ""');
         });
 
+        it('should add non-required properties with Ref when they reference the parent type in YAML', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyPolicy:
+    Type: AWS::IAM::ManagedPolicy
+`;
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 3, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyPolicy', { entity: { Type: 'AWS::IAM::ManagedPolicy' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([['AWS::IAM::Role', { required: ['AssumeRolePolicyDocument'] }]]),
+            } as any);
+            // ManagedPolicyArns is NOT required but references the parent
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::IAM::Role').returns({
+                resourceType: 'AWS::IAM::Role',
+                relationships: [
+                    {
+                        property: 'ManagedPolicyArns',
+                        relatedResourceTypes: [
+                            { typeName: 'AWS::IAM::ManagedPolicy', attribute: '/properties/PolicyArn' },
+                        ],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::IAM::Role'], 'AWS::IAM::ManagedPolicy');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            // ManagedPolicyArns should be added with !Ref even though it's not required
+            expect(textEdit?.newText).toContain('ManagedPolicyArns: !Ref MyPolicy');
+            // Required property should still be present as empty
+            expect(textEdit?.newText).toContain('AssumeRolePolicyDocument: ""');
+        });
+
+        it('should add non-required properties with Ref in JSON when they reference the parent type', () => {
+            const templateUri = 'file:///test/template.json';
+            const jsonContent = `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyPolicy": {
+      "Type": "AWS::IAM::ManagedPolicy"
+    }
+  }
+}`;
+            const document = new Document(TextDocument.create(templateUri, 'json', 1, jsonContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 6, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyPolicy', { entity: { Type: 'AWS::IAM::ManagedPolicy' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([['AWS::IAM::Role', { required: ['AssumeRolePolicyDocument'] }]]),
+            } as any);
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::IAM::Role').returns({
+                resourceType: 'AWS::IAM::Role',
+                relationships: [
+                    {
+                        property: 'ManagedPolicyArns',
+                        relatedResourceTypes: [
+                            { typeName: 'AWS::IAM::ManagedPolicy', attribute: '/properties/PolicyArn' },
+                        ],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::IAM::Role'], 'AWS::IAM::ManagedPolicy');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            expect(textEdit?.newText).toContain('"ManagedPolicyArns"');
+            expect(textEdit?.newText).toContain('"Ref": "MyPolicy"');
+        });
+
+        it('should not add non-required properties with nested paths', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyVpc:
+    Type: AWS::EC2::VPC
+`;
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 3, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyVpc', { entity: { Type: 'AWS::EC2::VPC' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([['AWS::Lambda::Function', { required: ['Code', 'Role', 'Runtime'] }]]),
+            } as any);
+            // VpcConfig/SecurityGroupIds is a nested path - should NOT be added
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::Lambda::Function').returns({
+                resourceType: 'AWS::Lambda::Function',
+                relationships: [
+                    {
+                        property: 'VpcConfig/SecurityGroupIds',
+                        relatedResourceTypes: [
+                            { typeName: 'AWS::EC2::VPC', attribute: '/properties/DefaultSecurityGroup' },
+                        ],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::Lambda::Function'], 'AWS::EC2::VPC');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            // Nested path properties should NOT be added
+            expect(textEdit?.newText).not.toContain('VpcConfig');
+            expect(textEdit?.newText).not.toContain('SecurityGroupIds');
+        });
+
+        it('should not auto-populate when multiple top-level properties reference the same parent', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyRole:
+    Type: AWS::IAM::Role
+`;
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 3, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyRole', { entity: { Type: 'AWS::IAM::Role' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    ['AWS::ECS::TaskDefinition', { required: ['TaskRoleArn', 'ExecutionRoleArn'] }],
+                    ['AWS::IAM::Role', { primaryIdentifier: ['/properties/RoleName'] }],
+                ]),
+            } as any);
+            // Both TaskRoleArn AND ExecutionRoleArn reference IAM::Role → 2 refs → don't populate
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::ECS::TaskDefinition').returns({
+                resourceType: 'AWS::ECS::TaskDefinition',
+                relationships: [
+                    {
+                        property: 'TaskRoleArn',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/Arn' }],
+                    },
+                    {
+                        property: 'ExecutionRoleArn',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/Arn' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::ECS::TaskDefinition'], 'AWS::IAM::Role');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            // Neither property should be populated since there are multiple references
+            expect(textEdit?.newText).not.toContain('!Ref');
+            expect(textEdit?.newText).not.toContain('!GetAtt');
+            expect(textEdit?.newText).toContain('TaskRoleArn: ""');
+            expect(textEdit?.newText).toContain('ExecutionRoleArn: ""');
+        });
+
         it('should leave property empty when parent logical ID is not found in template', () => {
             const templateUri = 'file:///test/template.yaml';
             const yamlContent = 'AWSTemplateFormatVersion: "2010-09-09"\n';
@@ -509,6 +879,68 @@ Resources:
             // No parent found, so VpcId should be empty
             expect(textEdit?.newText).not.toContain('!Ref');
             expect(textEdit?.newText).toContain('VpcId: ""');
+        });
+
+        it('should skip array properties and not populate them with references', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyRole:
+    Type: AWS::IAM::Role
+`;
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 3, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyRole', { entity: { Type: 'AWS::IAM::Role' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([
+                    [
+                        'AWS::IAM::ManagedPolicy',
+                        {
+                            required: ['PolicyDocument', 'Roles'],
+                            properties: {
+                                PolicyDocument: { type: 'object' },
+                                Roles: { type: 'array' }, // Array property
+                            },
+                        },
+                    ],
+                    ['AWS::IAM::Role', { primaryIdentifier: ['/properties/RoleName'] }],
+                ]),
+            } as any);
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::IAM::ManagedPolicy').returns({
+                resourceType: 'AWS::IAM::ManagedPolicy',
+                relationships: [
+                    {
+                        property: 'Roles',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/RoleName' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::IAM::ManagedPolicy'], 'AWS::IAM::Role');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            // Roles is an array property, should NOT be populated with !Ref
+            expect(textEdit?.newText).toContain('Roles: ""');
+            expect(textEdit?.newText).not.toContain('Roles: !Ref');
+            expect(textEdit?.newText).not.toContain('Roles: !GetAtt');
+            // Non-array property should still work
+            expect(textEdit?.newText).toContain('PolicyDocument: ""');
         });
     });
 });

--- a/tst/unit/relatedResources/RelatedResourcesSnippetProvider.test.ts
+++ b/tst/unit/relatedResources/RelatedResourcesSnippetProvider.test.ts
@@ -35,6 +35,7 @@ describe('RelatedResourcesSnippetProvider', () => {
         mockComponents.documentManager,
         mockComponents.syntaxTreeManager,
         mockComponents.schemaRetriever,
+        mockComponents.relationshipSchemaService,
     );
     const mockGetEntityMap = vi.mocked(getEntityMap) as any;
 
@@ -334,6 +335,180 @@ Resources:
             expect(() => {
                 provider.insertRelatedResources(templateUri, ['AWS::Lambda::Function'], 'AWS::S3::Bucket');
             }).toThrow('Document manager error');
+        });
+
+        it('should populate !Ref for YAML when property relates to parent resource type', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyVpc:
+    Type: AWS::EC2::VPC
+`;
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 3, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyVpc', { entity: { Type: 'AWS::EC2::VPC' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([['AWS::EC2::Subnet', { required: ['VpcId', 'AvailabilityZone'] }]]),
+            } as any);
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::EC2::Subnet').returns({
+                resourceType: 'AWS::EC2::Subnet',
+                relationships: [
+                    {
+                        property: 'VpcId',
+                        relatedResourceTypes: [{ typeName: 'AWS::EC2::VPC', attribute: '/properties/VpcId' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::EC2::Subnet'], 'AWS::EC2::VPC');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            expect(textEdit?.newText).toContain('VpcId: !Ref MyVpc');
+            expect(textEdit?.newText).toContain('AvailabilityZone: ""');
+        });
+
+        it('should populate {"Ref": ...} for JSON when property relates to parent resource type', () => {
+            const templateUri = 'file:///test/template.json';
+            const jsonContent = `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyVpc": {
+      "Type": "AWS::EC2::VPC"
+    }
+  }
+}`;
+            const document = new Document(TextDocument.create(templateUri, 'json', 1, jsonContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 6, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyVpc', { entity: { Type: 'AWS::EC2::VPC' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([['AWS::EC2::Subnet', { required: ['VpcId', 'AvailabilityZone'] }]]),
+            } as any);
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::EC2::Subnet').returns({
+                resourceType: 'AWS::EC2::Subnet',
+                relationships: [
+                    {
+                        property: 'VpcId',
+                        relatedResourceTypes: [{ typeName: 'AWS::EC2::VPC', attribute: '/properties/VpcId' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::EC2::Subnet'], 'AWS::EC2::VPC');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            expect(textEdit?.newText).toContain('"Ref": "MyVpc"');
+        });
+
+        it('should leave property empty when it does not relate to parent resource type', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = `AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  MyBucket:
+    Type: AWS::S3::Bucket
+`;
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            const mockSyntaxTree = {
+                findTopLevelSections: vi.fn().mockReturnValue(
+                    new Map([
+                        [
+                            'Resources',
+                            {
+                                endPosition: { row: 3, column: 0 },
+                            },
+                        ],
+                    ]),
+                ),
+            };
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(mockSyntaxTree as any);
+            mockGetEntityMap.mockReturnValue(new Map([['MyBucket', { entity: { Type: 'AWS::S3::Bucket' } }]]));
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([['AWS::Lambda::Function', { required: ['Code', 'Role', 'Runtime'] }]]),
+            } as any);
+            // Role relates to IAM::Role, not S3::Bucket
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::Lambda::Function').returns({
+                resourceType: 'AWS::Lambda::Function',
+                relationships: [
+                    {
+                        property: 'Role',
+                        relatedResourceTypes: [{ typeName: 'AWS::IAM::Role', attribute: '/properties/Arn' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::Lambda::Function'], 'AWS::S3::Bucket');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            // None of the properties should have !Ref since none relate to S3::Bucket
+            expect(textEdit?.newText).not.toContain('!Ref');
+            expect(textEdit?.newText).toContain('Role: ""');
+            expect(textEdit?.newText).toContain('Code: ""');
+            expect(textEdit?.newText).toContain('Runtime: ""');
+        });
+
+        it('should leave property empty when parent logical ID is not found in template', () => {
+            const templateUri = 'file:///test/template.yaml';
+            const yamlContent = 'AWSTemplateFormatVersion: "2010-09-09"\n';
+            const document = new Document(TextDocument.create(templateUri, 'yaml', 1, yamlContent));
+
+            documentManager.get.withArgs(templateUri).returns(document);
+            syntaxTreeManager.getSyntaxTree.withArgs(templateUri).returns(undefined);
+
+            schemaRetriever.getDefault.returns({
+                schemas: new Map([['AWS::EC2::Subnet', { required: ['VpcId'] }]]),
+            } as any);
+            relationshipSchemaService.getRelationshipsForResourceType.withArgs('AWS::EC2::Subnet').returns({
+                resourceType: 'AWS::EC2::Subnet',
+                relationships: [
+                    {
+                        property: 'VpcId',
+                        relatedResourceTypes: [{ typeName: 'AWS::EC2::VPC', attribute: '/properties/VpcId' }],
+                    },
+                ],
+            });
+
+            const result = provider.insertRelatedResources(templateUri, ['AWS::EC2::Subnet'], 'AWS::EC2::VPC');
+
+            expect(result).toBeDefined();
+            const textEdit = result.edit?.changes![templateUri][0];
+            // No parent found, so VpcId should be empty
+            expect(textEdit?.newText).not.toContain('!Ref');
+            expect(textEdit?.newText).toContain('VpcId: ""');
         });
     });
 });

--- a/tst/unit/services/RelationshipSchemaService.test.ts
+++ b/tst/unit/services/RelationshipSchemaService.test.ts
@@ -35,6 +35,38 @@ describe('RelationshipSchemaService', () => {
             expect(result).toBeInstanceOf(Set);
             expect(result.size).toBe(0);
         });
+
+        it('should include incoming references (types that reference the given type)', () => {
+            // AWS::IAM::Role is referenced by many types (Lambda, ECS, etc.)
+            // but IAM::Role's own properties only reference a few types
+            const result = service.getAllRelatedResourceTypes('AWS::IAM::Role');
+
+            expect(result).toBeInstanceOf(Set);
+            // Lambda::Function references IAM::Role in its Role property
+            expect(result.has('AWS::Lambda::Function')).toBe(true);
+        });
+
+        it('should include both outgoing and incoming references', () => {
+            // IAM::Role's own properties reference ManagedPolicy (outgoing)
+            // AND Lambda::Function references IAM::Role (incoming)
+            const result = service.getAllRelatedResourceTypes('AWS::IAM::Role');
+
+            // Outgoing: IAM::Role -> ManagedPolicyArns -> ManagedPolicy
+            expect(result.has('AWS::IAM::ManagedPolicy')).toBe(true);
+            // Incoming: Lambda::Function -> Role -> IAM::Role
+            expect(result.has('AWS::Lambda::Function')).toBe(true);
+        });
+
+        it('should include incoming references for types with no outgoing relationships', () => {
+            // AWS::EC2::VPC has no entry in relationship_schemas.json (no outgoing)
+            // but many types reference it (Subnet, SecurityGroup, etc.)
+            const result = service.getAllRelatedResourceTypes('AWS::EC2::VPC');
+
+            expect(result).toBeInstanceOf(Set);
+            expect(result.size).toBeGreaterThan(0);
+            // EC2::Subnet references VPC in its VpcId property
+            expect(result.has('AWS::EC2::Subnet')).toBe(true);
+        });
     });
 
     describe('getRelationshipContext', () => {


### PR DESCRIPTION
- **related resources**
- **implement getAtt for related resources**

*Issue #, if available:*

*Description of changes:*
*Auto-populate `!Ref` and `!GetAtt` in related resource snippets*

When inserting related resources, properties that reference the parent resource type are now pre-populated with `!Ref` or `!GetAtt` intrinsic functions instead of empty strings.

#### Changes

**`src/relatedResources/RelatedResourcesSnippetProvider.ts`**
- Added `RelationshipSchemaService` as a constructor dependency
- Added `findParentLogicalId()` to resolve the parent resource's logical ID from the template syntax tree
- Added `getPropertyValueForRelatedResource()` to check if a required property references the parent type and generate the appropriate intrinsic function
- Added `buildIntrinsicReference()` to decide between `!Ref` (primary identifier match) and `!GetAtt` (non-primary attribute like `Arn`)
- Added `replaceIntrinsicPlaceholders()` to handle YAML serialization (the YAML library quotes `!` prefixed values, so placeholders are used during serialization and replaced afterward)
- Added `addParentReferencingProperties()` to also populate non-required properties that reference the parent
- Added `countTopLevelParentReferences()` guard: when multiple top-level properties reference the same parent (ambiguous), none are auto-populated
- Array properties are skipped

**`src/handlers/RelatedResourcesHandler.ts`**
- Added `hasExactlyOnePopulatableRelationship()` filter to the `getRelatedResourceTypes` handler
- The dropdown now only includes resource types that have exactly **one** non-array, top-level property referencing the parent, matching the snippet provider's population logic. Only one to avoid a scenario where we arbitrarily choose which property will reference the parent resource:
```
ServiceCatalogStackSetConstraintRelatedToIAMRole:
    Type: AWS::ServiceCatalog::StackSetConstraint
    Properties:
      Description: ""
      StackInstanceControl: ""
      PortfolioId: ""
      ProductId: ""
      RegionList: ""
      AdminRole: !GetAtt MyRole.Arn
      AccountList: ""
      ExecutionRole: ""
```
In this example, the reference can go in AdminRole or ExecutionRole, but the code populates AdminRole because it is a top-level property.  
- Excludes resources with: no top-level refs, all-array refs, or multiple top-level refs to the parent

**`src/server/CfnLspProviders.ts`**
- Passes `relationshipSchemaService` to the `RelatedResourcesSnippetProvider` constructor

**`src/services/RelationshipSchemaService.ts`**
- Added reverse relationship cache for incoming lookups. This is the case where the child resource schema contains the reference to the parent. Right now the code only considers the resources that the parent resource schema has references to. For instance, the relationship schema for IAM::Role itself only has outgoing references to `AWS::IAM::ManagedPolicy`. But `AWS::Lambda::Function` has a `Role` property that points *back* to IAM::Role. The reverse cache captures this incoming direction

#### Example

Before:
```yaml
LambdaFunctionRelatedToIAMRole:
  Type: AWS::Lambda::Function
  Properties:
    Code: ""
    Role: ""
    Runtime: ""
```

After:
```yaml
LambdaFunctionRelatedToIAMRole:
  Type: AWS::Lambda::Function
  Properties:
    Code: ""
    Role: !GetAtt MyRole.Arn
    Runtime: ""
```

For JSON templates, produces `{"Ref": "LogicalId"}` or `{"Fn::GetAtt": ["LogicalId", "Attribute"]}`.

#### Testing

- **36 unit tests passing** (22 snippet provider + 14 handler)
- Snippet provider coverage: 96.37% statements, 89.7% branches
- Handler coverage: 97.72% statements, 93.75% branches
- Manual testing performed against `AWS::IAM::Role`, `AWS::EC2::VPC`, and `AWS::S3::Bucket` parent types with full related resource insertion

#### Known limitations

These are pre-existing data quality issues in `relationship_schemas.json`, not introduced by this PR:
- `ServiceCatalog::StackSetConstraint` — Missing `ExecutionRole → IAM::Role` relationship; only `AdminRole` is declared
- `SSM::Parameter` Value — Maps to 100+ resource types; overly broad relationship
- `EC2::EIP` Domain — Incorrectly maps to `AWS::EC2::VPC`; Domain is an enum, not a VPC ID
- `Glue::Crawler` DatabaseName — Incorrectly maps to `AWS::S3::Bucket`; expects a Glue Database name
- When multiple resources of the same parent type exist in the template, the first one found is used for the `!Ref`/`!GetAtt` (future enhancement: let user choose which)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
