### PR TITLE
Add long running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "test:integration": "cross-env NODE_ENV=test vitest run --config vitest.integration.config.ts",
         "test:unit": "cross-env NODE_ENV=test vitest run --config vitest.unit.config.ts",
         "test:leaks": "cross-env NODE_ENV=test vitest run --pool=forks --logHeapUsage",
-        "test:long-running": "cross-env NODE_ENV=test LONG_RUNNING_DURATION=${LONG_RUNNING_DURATION:-4h} vitest run --config vitest.long-running.config.ts",
+        "test:long-running": "cross-env NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=2048\" LONG_RUNNING_DURATION=${LONG_RUNNING_DURATION:-4h} vitest run --config vitest.long-running.config.ts",
         "lint": "eslint --cache --cache-location node_modules/.cache/eslint --max-warnings 0 .",
         "lint:fix": "npm run lint -- --fix",
         "build:go:dev": "GOPROXY=direct go build -C cfn-init/cmd -v -o ../../bundle/development/bin/cfn-init",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "test:integration": "cross-env NODE_ENV=test vitest run --config vitest.integration.config.ts",
         "test:unit": "cross-env NODE_ENV=test vitest run --config vitest.unit.config.ts",
         "test:leaks": "cross-env NODE_ENV=test vitest run --pool=forks --logHeapUsage",
+        "test:long-running": "cross-env NODE_ENV=test LONG_RUNNING_DURATION=${LONG_RUNNING_DURATION:-4h} vitest run --config vitest.long-running.config.ts",
         "lint": "eslint --cache --cache-location node_modules/.cache/eslint --max-warnings 0 .",
         "lint:fix": "npm run lint -- --fix",
         "build:go:dev": "GOPROXY=direct go build -C cfn-init/cmd -v -o ../../bundle/development/bin/cfn-init",

--- a/tst/long-running/LongRunning.test.ts
+++ b/tst/long-running/LongRunning.test.ts
@@ -1,167 +1,19 @@
-/* eslint-disable no-console */
 /* eslint-disable vitest/expect-expect */
 import { test } from 'vitest';
-import { DocumentHelper } from '../utils/DocumentHelper';
-import { TestExtension } from '../utils/TestExtension';
-import { WaitFor } from '../utils/Utils';
-import { parseConfig, parseDuration } from './LongRunningConfig';
-import { checkMemoryUsage, getMetrics, logProgress } from './LongRunningMonitoring';
-import { TEMPLATE_CONFIGS, TemplateConfig } from './LongRunningTypes';
-import { CompletionTester } from './testers/CompletionTester';
-import { HoverTester } from './testers/HoverTester';
-
-const config = parseConfig();
-const DURATION_MS = parseDuration(config.duration);
-const PROGRESS_INTERVAL = 1 * 60 * 1000; // 1 minute
-
-let lastProgressLog = Date.now();
-
-class LongRunningTest {
-    public testExtension!: TestExtension;
-    private templates: TemplateConfig[] = [];
-    private readonly startTime: number;
-    private readonly endTime: number;
-    private readonly openTemplates: Array<{ template: TemplateConfig; uri: string }> = [];
-
-    private hoverTester!: HoverTester;
-    private completionTester!: CompletionTester;
-
-    constructor() {
-        this.startTime = Date.now();
-        this.endTime = this.startTime + DURATION_MS;
-    }
-
-    async initialize(): Promise<void> {
-        console.log('Starting CloudFormation Language Server Long-Running Tests');
-        console.log(`Duration: ${config.duration} (${DURATION_MS}ms)`);
-        console.log(`Max retries: ${config.maxRetries}`);
-        console.log(`Response timeout: ${config.responseTimeout}ms`);
-
-        this.testExtension = new TestExtension();
-
-        await this.testExtension.ready();
-
-        const testConfig = { maxRetries: config.maxRetries, responseTimeout: config.responseTimeout };
-        this.hoverTester = new HoverTester(this.testExtension, testConfig);
-        this.completionTester = new CompletionTester(this.testExtension, testConfig);
-
-        this.templates = TEMPLATE_CONFIGS;
-        console.log(`Loaded ${this.templates.length} templates`);
-
-        console.log('Initialization complete');
-    }
-
-    async runTests(): Promise<void> {
-        console.log('Starting test execution phase');
-
-        let cycleCount = 0;
-
-        while (Date.now() < this.endTime) {
-            cycleCount++;
-
-            try {
-                await this.executeTestCycle();
-
-                checkMemoryUsage();
-
-                if (Date.now() - lastProgressLog > PROGRESS_INTERVAL) {
-                    logProgress();
-                    lastProgressLog = Date.now();
-                }
-
-                // Brief pause between cycles
-                await WaitFor.waitFor(async () => {}, 5000, 1000);
-            } catch (error) {
-                console.error('Test cycle failed:', error);
-                throw error; // Fail fast
-            }
-        }
-
-        console.log(`Test execution completed after ${cycleCount} cycles`);
-
-        // Close all files at the end
-        for (const { uri } of this.openTemplates) {
-            await this.testExtension.closeDocument({ textDocument: { uri } });
-        }
-    }
-
-    private async executeTestCycle(): Promise<void> {
-        if (this.openTemplates.length === 0) {
-            for (const template of this.templates) {
-                const uri = template.name.endsWith('.json')
-                    ? await this.testExtension.openJsonTemplate(template.content, template.name)
-                    : await this.testExtension.openYamlTemplate(template.content, template.name);
-
-                this.openTemplates.push({ template, uri });
-            }
-        }
-
-        // Test LSP operations on all open templates
-        for (const { uri } of this.openTemplates) {
-            await this.validateLsp(uri);
-        }
-    }
-
-    private async validateLsp(uri: string): Promise<void> {
-        const originalContent = this.testExtension.components.documentManager.get(uri)?.contents() ?? '';
-
-        await this.hoverTester.testAllScenarios(uri);
-        await this.completionTester.testAllScenarios(uri);
-
-        // Revert to original content
-        const version = Date.now();
-        await DocumentHelper.replaceDocumentContent(this.testExtension, uri, version, originalContent);
-    }
-
-    generateReport(): void {
-        console.log('Final Test Report');
-        console.log('='.repeat(50));
-
-        const runtime = Date.now() - this.startTime;
-        const metrics = getMetrics();
-        const avgResponseTime = metrics.averageDuration ?? 0;
-        const maxResponseTime = metrics.maxDuration ?? 0;
-        const minResponseTime = metrics.minDuration ?? 0;
-        const lastResponseTime = metrics.lastDuration ?? 0;
-        const memory = process.memoryUsage();
-
-        console.log(`Runtime: ${Math.round(runtime / 1000 / 60)} minutes`);
-        console.log(`Total Operations: ${metrics.operationsAttempted}`);
-        console.log(`Successful: ${metrics.operationsAttempted - metrics.operationsFailed}`);
-        console.log(`Failed: ${metrics.operationsFailed}`);
-        console.log(
-            `Success Rate: ${metrics.operationsAttempted > 0 ? (((metrics.operationsAttempted - metrics.operationsFailed) / metrics.operationsAttempted) * 100).toFixed(2) : 0}%`,
-        );
-        console.log(`Average Duration: ${avgResponseTime > 0 ? avgResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
-        console.log(`Max Duration: ${maxResponseTime > 0 ? maxResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
-        console.log(
-            `Min Duration: ${minResponseTime !== null && minResponseTime >= 0 ? minResponseTime.toFixed(2) + 'ms' : 'N/A'}`,
-        );
-        console.log(`Final Duration: ${lastResponseTime > 0 ? lastResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
-        console.log(`Final Memory Usage: ${Math.round(memory.heapUsed / 1024 / 1024)}MB`);
-        console.log(`Max Memory Usage: ${metrics.maxMemoryMB}MB`);
-
-        console.log('='.repeat(50));
-    }
-}
+import { generateFinalReport } from './LongRunningMonitoring';
+import { LongRunningTestOrchestrator } from './LongRunningTestOrchestrator';
 
 test('CloudFormation Language Server Long-Running Test', async () => {
-    const longRunningTest = new LongRunningTest();
+    const orchestrator = new LongRunningTestOrchestrator();
 
     try {
-        await longRunningTest.initialize();
-        await longRunningTest.runTests();
-        longRunningTest.generateReport();
-
-        console.log('Long-running tests completed successfully');
+        await orchestrator.initialize();
+        await orchestrator.runTests();
+        generateFinalReport(orchestrator.startTime);
     } catch (error) {
-        console.error('Long-running tests failed:', error);
-        longRunningTest.generateReport();
+        generateFinalReport(orchestrator.startTime);
         throw error; // Re-throw to fail the test
     } finally {
-        // Clean up TestExtension
-        if (longRunningTest.testExtension) {
-            await longRunningTest.testExtension.close();
-        }
+        await orchestrator.cleanup();
     }
 });

--- a/tst/long-running/LongRunning.test.ts
+++ b/tst/long-running/LongRunning.test.ts
@@ -1,0 +1,167 @@
+/* eslint-disable no-console */
+/* eslint-disable vitest/expect-expect */
+import { test } from 'vitest';
+import { DocumentHelper } from '../utils/DocumentHelper';
+import { TestExtension } from '../utils/TestExtension';
+import { WaitFor } from '../utils/Utils';
+import { parseConfig, parseDuration } from './LongRunningConfig';
+import { checkMemoryUsage, getMetrics, logProgress } from './LongRunningMonitoring';
+import { TEMPLATE_CONFIGS, TemplateConfig } from './LongRunningTypes';
+import { CompletionTester } from './testers/CompletionTester';
+import { HoverTester } from './testers/HoverTester';
+
+const config = parseConfig();
+const DURATION_MS = parseDuration(config.duration);
+const PROGRESS_INTERVAL = 1 * 60 * 1000; // 1 minute
+
+let lastProgressLog = Date.now();
+
+class LongRunningTest {
+    public testExtension!: TestExtension;
+    private templates: TemplateConfig[] = [];
+    private readonly startTime: number;
+    private readonly endTime: number;
+    private readonly openTemplates: Array<{ template: TemplateConfig; uri: string }> = [];
+
+    private hoverTester!: HoverTester;
+    private completionTester!: CompletionTester;
+
+    constructor() {
+        this.startTime = Date.now();
+        this.endTime = this.startTime + DURATION_MS;
+    }
+
+    async initialize(): Promise<void> {
+        console.log('Starting CloudFormation Language Server Long-Running Tests');
+        console.log(`Duration: ${config.duration} (${DURATION_MS}ms)`);
+        console.log(`Max retries: ${config.maxRetries}`);
+        console.log(`Response timeout: ${config.responseTimeout}ms`);
+
+        this.testExtension = new TestExtension();
+
+        await this.testExtension.ready();
+
+        const testConfig = { maxRetries: config.maxRetries, responseTimeout: config.responseTimeout };
+        this.hoverTester = new HoverTester(this.testExtension, testConfig);
+        this.completionTester = new CompletionTester(this.testExtension, testConfig);
+
+        this.templates = TEMPLATE_CONFIGS;
+        console.log(`Loaded ${this.templates.length} templates`);
+
+        console.log('Initialization complete');
+    }
+
+    async runTests(): Promise<void> {
+        console.log('Starting test execution phase');
+
+        let cycleCount = 0;
+
+        while (Date.now() < this.endTime) {
+            cycleCount++;
+
+            try {
+                await this.executeTestCycle();
+
+                checkMemoryUsage();
+
+                if (Date.now() - lastProgressLog > PROGRESS_INTERVAL) {
+                    logProgress();
+                    lastProgressLog = Date.now();
+                }
+
+                // Brief pause between cycles
+                await WaitFor.waitFor(async () => {}, 5000, 1000);
+            } catch (error) {
+                console.error('Test cycle failed:', error);
+                throw error; // Fail fast
+            }
+        }
+
+        console.log(`Test execution completed after ${cycleCount} cycles`);
+
+        // Close all files at the end
+        for (const { uri } of this.openTemplates) {
+            await this.testExtension.closeDocument({ textDocument: { uri } });
+        }
+    }
+
+    private async executeTestCycle(): Promise<void> {
+        if (this.openTemplates.length === 0) {
+            for (const template of this.templates) {
+                const uri = template.name.endsWith('.json')
+                    ? await this.testExtension.openJsonTemplate(template.content, template.name)
+                    : await this.testExtension.openYamlTemplate(template.content, template.name);
+
+                this.openTemplates.push({ template, uri });
+            }
+        }
+
+        // Test LSP operations on all open templates
+        for (const { uri } of this.openTemplates) {
+            await this.validateLsp(uri);
+        }
+    }
+
+    private async validateLsp(uri: string): Promise<void> {
+        const originalContent = this.testExtension.components.documentManager.get(uri)?.contents() ?? '';
+
+        await this.hoverTester.testAllScenarios(uri);
+        await this.completionTester.testAllScenarios(uri);
+
+        // Revert to original content
+        const version = Date.now();
+        await DocumentHelper.replaceDocumentContent(this.testExtension, uri, version, originalContent);
+    }
+
+    generateReport(): void {
+        console.log('Final Test Report');
+        console.log('='.repeat(50));
+
+        const runtime = Date.now() - this.startTime;
+        const metrics = getMetrics();
+        const avgResponseTime = metrics.averageDuration ?? 0;
+        const maxResponseTime = metrics.maxDuration ?? 0;
+        const minResponseTime = metrics.minDuration ?? 0;
+        const lastResponseTime = metrics.lastDuration ?? 0;
+        const memory = process.memoryUsage();
+
+        console.log(`Runtime: ${Math.round(runtime / 1000 / 60)} minutes`);
+        console.log(`Total Operations: ${metrics.operationsAttempted}`);
+        console.log(`Successful: ${metrics.operationsAttempted - metrics.operationsFailed}`);
+        console.log(`Failed: ${metrics.operationsFailed}`);
+        console.log(
+            `Success Rate: ${metrics.operationsAttempted > 0 ? (((metrics.operationsAttempted - metrics.operationsFailed) / metrics.operationsAttempted) * 100).toFixed(2) : 0}%`,
+        );
+        console.log(`Average Duration: ${avgResponseTime > 0 ? avgResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
+        console.log(`Max Duration: ${maxResponseTime > 0 ? maxResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
+        console.log(
+            `Min Duration: ${minResponseTime !== null && minResponseTime >= 0 ? minResponseTime.toFixed(2) + 'ms' : 'N/A'}`,
+        );
+        console.log(`Final Duration: ${lastResponseTime > 0 ? lastResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
+        console.log(`Final Memory Usage: ${Math.round(memory.heapUsed / 1024 / 1024)}MB`);
+        console.log(`Max Memory Usage: ${metrics.maxMemoryMB}MB`);
+
+        console.log('='.repeat(50));
+    }
+}
+
+test('CloudFormation Language Server Long-Running Test', async () => {
+    const longRunningTest = new LongRunningTest();
+
+    try {
+        await longRunningTest.initialize();
+        await longRunningTest.runTests();
+        longRunningTest.generateReport();
+
+        console.log('Long-running tests completed successfully');
+    } catch (error) {
+        console.error('Long-running tests failed:', error);
+        longRunningTest.generateReport();
+        throw error; // Re-throw to fail the test
+    } finally {
+        // Clean up TestExtension
+        if (longRunningTest.testExtension) {
+            await longRunningTest.testExtension.close();
+        }
+    }
+});

--- a/tst/long-running/LongRunningConfig.ts
+++ b/tst/long-running/LongRunningConfig.ts
@@ -1,0 +1,59 @@
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+export interface LongRunningConfig {
+    duration: string;
+    maxRetries: number;
+    responseTimeout: number;
+}
+
+export function parseConfig(): LongRunningConfig {
+    const isVitest = process.argv.some((arg) => arg.includes('vitest'));
+
+    if (isVitest) {
+        return {
+            duration: process.env.LONG_RUNNING_DURATION ?? '4h',
+            maxRetries: Number.parseInt(process.env.LONG_RUNNING_MAX_RETRIES ?? '3'),
+            responseTimeout: Number.parseInt(process.env.LONG_RUNNING_RESPONSE_TIMEOUT ?? '2000'),
+        };
+    } else {
+        return yargs(hideBin(process.argv))
+            .option('duration', {
+                alias: 'd',
+                type: 'string',
+                default: '4h',
+                description: 'Test duration (e.g., 4h, 300m, 18000s)',
+            })
+            .option('max-retries', {
+                type: 'number',
+                default: 3,
+                description: 'Maximum retry attempts per request',
+            })
+            .option('response-timeout', {
+                type: 'number',
+                default: 2000,
+                description: 'Response time threshold in milliseconds',
+            })
+            .help()
+            .parseSync() as LongRunningConfig;
+    }
+}
+
+export function parseDuration(duration: string): number {
+    const match = duration.match(/^(\d+)([hms])$/);
+    if (!match) throw new Error('Invalid duration format. Use format like 4h, 300m, or 18000s');
+
+    const value = Number.parseInt(match[1]);
+    const unit = match[2];
+
+    switch (unit) {
+        case 'h':
+            return value * 60 * 60 * 1000;
+        case 'm':
+            return value * 60 * 1000;
+        case 's':
+            return value * 1000;
+        default:
+            throw new Error('Invalid duration unit');
+    }
+}

--- a/tst/long-running/LongRunningConfig.ts
+++ b/tst/long-running/LongRunningConfig.ts
@@ -1,11 +1,11 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
-export interface LongRunningConfig {
+export type LongRunningConfig = {
     duration: string;
     maxRetries: number;
     responseTimeout: number;
-}
+};
 
 export function parseConfig(): LongRunningConfig {
     const isVitest = process.argv.some((arg) => arg.includes('vitest'));

--- a/tst/long-running/LongRunningLspClient.ts
+++ b/tst/long-running/LongRunningLspClient.ts
@@ -1,0 +1,39 @@
+import { WaitFor } from '../utils/Utils';
+import { recordOperation } from './LongRunningMonitoring';
+
+export async function executeWithRetry<T>(
+    operation: () => Promise<T>,
+    operationName: string,
+    maxRetries: number,
+    responseTimeout: number,
+): Promise<T> {
+    let result: T;
+    let responseTime: number;
+
+    try {
+        await WaitFor.waitFor(
+            async () => {
+                const startTime = performance.now();
+                result = await operation();
+                responseTime = performance.now() - startTime;
+
+                if (result === undefined) {
+                    throw new Error(`${operationName} should return a result (not undefined)`);
+                }
+                if (responseTime > responseTimeout) {
+                    throw new Error(`${operationName} response time ${responseTime}ms exceeds ${responseTimeout}ms`);
+                }
+            },
+            maxRetries * 1000,
+            1000,
+        );
+
+        recordOperation(responseTime!, true);
+        return result!;
+    } catch (error) {
+        recordOperation(0, false);
+        throw new Error(
+            `${operationName} failed after retries: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+}

--- a/tst/long-running/LongRunningMonitoring.ts
+++ b/tst/long-running/LongRunningMonitoring.ts
@@ -1,17 +1,14 @@
 /* eslint-disable no-console */
-const MEMORY_LIMIT_MB = 2048;
+const AVG_DURATION_LIMIT_MS = 200;
 
-export interface LspTestMetrics {
+export type LspTestMetrics = {
     operationsAttempted: number;
     operationsFailed: number;
     averageDuration: number | null;
     minDuration: number | null;
     maxDuration: number | null;
     lastDuration: number | null;
-    currentMemoryMB: number;
-    maxMemoryMB: number;
-    minMemoryMB: number;
-}
+};
 
 const metrics: LspTestMetrics = {
     operationsAttempted: 0,
@@ -20,14 +17,7 @@ const metrics: LspTestMetrics = {
     minDuration: null,
     maxDuration: null,
     lastDuration: null,
-    currentMemoryMB: 0,
-    maxMemoryMB: 0,
-    minMemoryMB: Number.MAX_VALUE,
 };
-
-function getCurrentMemory(): number {
-    return Math.round(process.memoryUsage().heapUsed / 1024 / 1024);
-}
 
 export function recordOperation(duration: number, success: boolean): void {
     metrics.operationsAttempted++;
@@ -44,22 +34,13 @@ export function recordOperation(duration: number, success: boolean): void {
     } else {
         metrics.operationsFailed++;
     }
-
-    // Update memory metrics
-    const currentMem = getCurrentMemory();
-    metrics.currentMemoryMB = currentMem;
-    metrics.maxMemoryMB = Math.max(metrics.maxMemoryMB, currentMem);
-    metrics.minMemoryMB = Math.min(metrics.minMemoryMB, currentMem);
 }
 
-export function checkMemoryUsage(): void {
-    const currentMem = getCurrentMemory();
-    metrics.currentMemoryMB = currentMem;
-    metrics.maxMemoryMB = Math.max(metrics.maxMemoryMB, currentMem);
-    metrics.minMemoryMB = Math.min(metrics.minMemoryMB, currentMem);
-
-    if (currentMem > MEMORY_LIMIT_MB) {
-        throw new Error(`Memory usage ${currentMem}MB exceeds limit ${MEMORY_LIMIT_MB}MB`);
+export function checkPerformanceDegradation(): void {
+    if (metrics.averageDuration !== null && metrics.averageDuration > AVG_DURATION_LIMIT_MS) {
+        throw new Error(
+            `Average duration ${metrics.averageDuration.toFixed(1)}ms exceeds limit ${AVG_DURATION_LIMIT_MS}ms`,
+        );
     }
 }
 
@@ -78,6 +59,31 @@ export function logProgress() {
         `   Success Rate: ${metrics.operationsAttempted > 0 ? (((metrics.operationsAttempted - metrics.operationsFailed) / metrics.operationsAttempted) * 100).toFixed(1) : 0}%`,
     );
     console.log(`   Avg Duration: ${avgResponseTime.toFixed(1)}ms`);
-    console.log(`   Memory (Heap): ${metrics.currentMemoryMB}MB`);
-    console.log(`   Max Memory: ${metrics.maxMemoryMB}MB`);
+}
+
+export function generateFinalReport(startTime: number): void {
+    console.log('Final Test Report');
+    console.log('='.repeat(50));
+
+    const runtime = Date.now() - startTime;
+    const avgResponseTime = metrics.averageDuration ?? 0;
+    const maxResponseTime = metrics.maxDuration ?? 0;
+    const minResponseTime = metrics.minDuration ?? 0;
+    const lastResponseTime = metrics.lastDuration ?? 0;
+
+    console.log(`Runtime: ${Math.round(runtime / 1000 / 60)} minutes`);
+    console.log(`Total Operations: ${metrics.operationsAttempted}`);
+    console.log(`Successful: ${metrics.operationsAttempted - metrics.operationsFailed}`);
+    console.log(`Failed: ${metrics.operationsFailed}`);
+    console.log(
+        `Success Rate: ${metrics.operationsAttempted > 0 ? (((metrics.operationsAttempted - metrics.operationsFailed) / metrics.operationsAttempted) * 100).toFixed(2) : 0}%`,
+    );
+    console.log(`Average Duration: ${avgResponseTime > 0 ? avgResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
+    console.log(`Max Duration: ${maxResponseTime > 0 ? maxResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
+    console.log(
+        `Min Duration: ${minResponseTime !== null && minResponseTime >= 0 ? minResponseTime.toFixed(2) + 'ms' : 'N/A'}`,
+    );
+    console.log(`Final Duration: ${lastResponseTime > 0 ? lastResponseTime.toFixed(2) + 'ms' : 'N/A'}`);
+
+    console.log('='.repeat(50));
 }

--- a/tst/long-running/LongRunningMonitoring.ts
+++ b/tst/long-running/LongRunningMonitoring.ts
@@ -1,0 +1,83 @@
+/* eslint-disable no-console */
+const MEMORY_LIMIT_MB = 2048;
+
+export interface LspTestMetrics {
+    operationsAttempted: number;
+    operationsFailed: number;
+    averageDuration: number | null;
+    minDuration: number | null;
+    maxDuration: number | null;
+    lastDuration: number | null;
+    currentMemoryMB: number;
+    maxMemoryMB: number;
+    minMemoryMB: number;
+}
+
+const metrics: LspTestMetrics = {
+    operationsAttempted: 0,
+    operationsFailed: 0,
+    averageDuration: null,
+    minDuration: null,
+    maxDuration: null,
+    lastDuration: null,
+    currentMemoryMB: 0,
+    maxMemoryMB: 0,
+    minMemoryMB: Number.MAX_VALUE,
+};
+
+function getCurrentMemory(): number {
+    return Math.round(process.memoryUsage().heapUsed / 1024 / 1024);
+}
+
+export function recordOperation(duration: number, success: boolean): void {
+    metrics.operationsAttempted++;
+
+    if (success) {
+        const successfulOps = metrics.operationsAttempted - metrics.operationsFailed;
+        metrics.averageDuration =
+            metrics.averageDuration === null
+                ? duration
+                : (metrics.averageDuration * (successfulOps - 1) + duration) / successfulOps;
+        metrics.minDuration = metrics.minDuration === null ? duration : Math.min(metrics.minDuration, duration);
+        metrics.maxDuration = metrics.maxDuration === null ? duration : Math.max(metrics.maxDuration, duration);
+        metrics.lastDuration = duration;
+    } else {
+        metrics.operationsFailed++;
+    }
+
+    // Update memory metrics
+    const currentMem = getCurrentMemory();
+    metrics.currentMemoryMB = currentMem;
+    metrics.maxMemoryMB = Math.max(metrics.maxMemoryMB, currentMem);
+    metrics.minMemoryMB = Math.min(metrics.minMemoryMB, currentMem);
+}
+
+export function checkMemoryUsage(): void {
+    const currentMem = getCurrentMemory();
+    metrics.currentMemoryMB = currentMem;
+    metrics.maxMemoryMB = Math.max(metrics.maxMemoryMB, currentMem);
+    metrics.minMemoryMB = Math.min(metrics.minMemoryMB, currentMem);
+
+    if (currentMem > MEMORY_LIMIT_MB) {
+        throw new Error(`Memory usage ${currentMem}MB exceeds limit ${MEMORY_LIMIT_MB}MB`);
+    }
+}
+
+export function getMetrics(): LspTestMetrics {
+    return { ...metrics };
+}
+
+export function logProgress() {
+    const avgResponseTime = metrics.averageDuration ?? 0;
+
+    console.log('Progress Report');
+    console.log(`   Total Operations: ${metrics.operationsAttempted}`);
+    console.log(`   Successful: ${metrics.operationsAttempted - metrics.operationsFailed}`);
+    console.log(`   Failed: ${metrics.operationsFailed}`);
+    console.log(
+        `   Success Rate: ${metrics.operationsAttempted > 0 ? (((metrics.operationsAttempted - metrics.operationsFailed) / metrics.operationsAttempted) * 100).toFixed(1) : 0}%`,
+    );
+    console.log(`   Avg Duration: ${avgResponseTime.toFixed(1)}ms`);
+    console.log(`   Memory (Heap): ${metrics.currentMemoryMB}MB`);
+    console.log(`   Max Memory: ${metrics.maxMemoryMB}MB`);
+}

--- a/tst/long-running/LongRunningTestExtension.ts
+++ b/tst/long-running/LongRunningTestExtension.ts
@@ -1,0 +1,92 @@
+import { DidChangeConfigurationParams } from 'vscode-languageserver';
+import { ConfigurationParams, ConfigurationItem } from 'vscode-languageserver-protocol';
+import { getRemotePublicSchemas } from '../../src/schema/GetSchemaTask';
+import { SchemaRetriever } from '../../src/schema/SchemaRetriever';
+import { AwsRegion } from '../../src/utils/Region';
+import { getTestPrivateSchemas, samFileType, SamSchemaFiles } from '../utils/SchemaUtils';
+import { TestExtension, TestExtensionConfig } from '../utils/TestExtension';
+import { WaitFor } from '../utils/Utils';
+
+export class LongRunningTestExtension extends TestExtension {
+    private currentWorkspaceConfig: Record<string, unknown>[] = [{}];
+
+    constructor(config: TestExtensionConfig = {}) {
+        super({
+            ...config,
+            schemaRetrieverFactory: (schemaStore) =>
+                new SchemaRetriever(
+                    schemaStore,
+                    getRemotePublicSchemas,
+                    () => Promise.resolve(getTestPrivateSchemas()),
+                    () => Promise.resolve(samFileType(Object.values(SamSchemaFiles))),
+                ),
+        });
+
+        // Override workspace/configuration handler to return stored config
+        this.clientConnection.onRequest('workspace/configuration', (params: ConfigurationParams) => {
+            // Extract the specific configuration section requested
+            if (params?.items?.length > 0) {
+                const results = params.items.map((item: ConfigurationItem) => {
+                    if (item.section === 'aws.cloudformation') {
+                        // Return just the CloudFormation config part
+                        const fullConfig = this.currentWorkspaceConfig[0] ?? {};
+                        return fullConfig['aws.cloudformation'] ?? {};
+                    }
+                    return {};
+                });
+                return results;
+            }
+            return this.currentWorkspaceConfig;
+        });
+    }
+
+    // Additional helpers
+
+    override changeConfiguration(params: DidChangeConfigurationParams) {
+        // Store the new configuration
+        if (params.settings) {
+            const currentConfig = this.currentWorkspaceConfig[0] ?? {};
+            this.currentWorkspaceConfig = [{ ...currentConfig, ...params.settings }];
+        }
+        return super.changeConfiguration(params);
+    }
+
+    async loadAllRegionSchemas(regions: AwsRegion[]): Promise<void> {
+        // Switch to each region and wait for schemas to be downloaded
+        for (const region of regions) {
+            await this.changeConfiguration({
+                settings: {
+                    'aws.cloudformation': {
+                        profile: {
+                            region,
+                        },
+                    },
+                },
+            });
+
+            await WaitFor.waitFor(() => {
+                const schemas = this.components.schemaStore.getPublicSchemas(region);
+                if (!schemas) {
+                    throw new Error(`Regional schemas not loaded for ${region}`);
+                }
+            }, 10000); // Longer timeout for schema downloads
+        }
+    }
+
+    async switchToRegion(region: AwsRegion): Promise<void> {
+        await this.changeConfiguration({
+            settings: {
+                'aws.cloudformation': {
+                    profile: {
+                        region,
+                    },
+                },
+            },
+        });
+
+        const schemas = this.components.schemaStore.getPublicSchemas(region);
+        if (!schemas) {
+            throw new Error(`Expected preloaded schemas for ${region} but none found`);
+        }
+    }
+}

--- a/tst/long-running/LongRunningTestOrchestrator.ts
+++ b/tst/long-running/LongRunningTestOrchestrator.ts
@@ -1,0 +1,133 @@
+/* eslint-disable no-console */
+import { AwsRegion } from '../../src/utils/Region';
+import { DocumentHelper } from '../utils/DocumentHelper';
+import { WaitFor } from '../utils/Utils';
+import { parseConfig, parseDuration } from './LongRunningConfig';
+import { checkPerformanceDegradation, logProgress } from './LongRunningMonitoring';
+import { LongRunningTestExtension } from './LongRunningTestExtension';
+import { TEMPLATE_CONFIGS, TemplateConfig } from './LongRunningTypes';
+import { CompletionTester } from './testers/CompletionTester';
+import { HoverTester } from './testers/HoverTester';
+
+const config = parseConfig();
+const DURATION_MS = parseDuration(config.duration);
+const PROGRESS_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+// Test all supported regions
+const TEST_REGIONS = Object.values(AwsRegion);
+
+let lastProgressLog = Date.now();
+
+export class LongRunningTestOrchestrator {
+    public testExtension!: LongRunningTestExtension;
+    public startTime!: number;
+    private templates: TemplateConfig[] = [];
+    private readonly openTemplates: Array<{ template: TemplateConfig; uri: string }> = [];
+    private endTime!: number;
+    private hoverTester!: HoverTester;
+    private completionTester!: CompletionTester;
+
+    constructor() {
+        // Timer will be started after preloading
+    }
+
+    async initialize(): Promise<void> {
+        console.log('Starting CloudFormation Language Server Long-Running Tests');
+        console.log(`Duration: ${config.duration} (${DURATION_MS}ms)`);
+        console.log(`Max retries: ${config.maxRetries}`);
+        console.log(`Response timeout: ${config.responseTimeout}ms`);
+
+        this.testExtension = new LongRunningTestExtension();
+
+        await this.testExtension.ready();
+
+        const testConfig = { maxRetries: config.maxRetries, responseTimeout: config.responseTimeout };
+        this.hoverTester = new HoverTester(this.testExtension, testConfig);
+        this.completionTester = new CompletionTester(this.testExtension, testConfig);
+
+        this.templates = TEMPLATE_CONFIGS;
+        console.log(`Loaded ${this.templates.length} templates`);
+
+        await this.testExtension.loadAllRegionSchemas(TEST_REGIONS);
+
+        console.log('Initialization complete');
+    }
+
+    async runTests(): Promise<void> {
+        console.log('Starting test execution phase');
+
+        // Start test timer
+        this.startTime = Date.now();
+        this.endTime = this.startTime + DURATION_MS;
+
+        let cycleCount = 0;
+
+        while (Date.now() < this.endTime) {
+            cycleCount++;
+
+            try {
+                await this.executeTestCycle();
+
+                checkPerformanceDegradation();
+
+                if (Date.now() - lastProgressLog > PROGRESS_INTERVAL) {
+                    logProgress();
+                    lastProgressLog = Date.now();
+                }
+
+                // Brief pause between cycles
+                await WaitFor.waitFor(async () => {}, 5000, 1000);
+            } catch (error) {
+                console.error('Test cycle failed:', error);
+                throw error; // Fail fast
+            }
+        }
+
+        console.log(`Test execution completed after ${cycleCount} cycles`);
+
+        // Close all files at the end
+        for (const { uri } of this.openTemplates) {
+            await this.testExtension.closeDocument({ textDocument: { uri } });
+        }
+    }
+
+    async cleanup(): Promise<void> {
+        if (this.testExtension) {
+            await this.testExtension.close();
+        }
+    }
+
+    private async executeTestCycle(): Promise<void> {
+        // Open templates once and keep them open
+        if (this.openTemplates.length === 0) {
+            for (const template of this.templates) {
+                const uri = template.name.endsWith('.json')
+                    ? await this.testExtension.openJsonTemplate(template.content, template.name)
+                    : await this.testExtension.openYamlTemplate(template.content, template.name);
+
+                this.openTemplates.push({ template, uri });
+            }
+        }
+
+        // Test LSP operations on all regions
+        for (const region of TEST_REGIONS) {
+            await this.testExtension.switchToRegion(region);
+
+            // Test all open templates for this region
+            for (const { uri } of this.openTemplates) {
+                await this.validateLsp(uri);
+            }
+        }
+    }
+
+    private async validateLsp(uri: string): Promise<void> {
+        const originalContent = this.testExtension.components.documentManager.get(uri)?.contents() ?? '';
+
+        await this.hoverTester.testAllScenarios(uri);
+        await this.completionTester.testAllScenarios(uri);
+
+        // Revert template to original content
+        const version = Date.now();
+        await DocumentHelper.replaceDocumentContent(this.testExtension, uri, version, originalContent);
+    }
+}

--- a/tst/long-running/LongRunningTypes.ts
+++ b/tst/long-running/LongRunningTypes.ts
@@ -1,0 +1,30 @@
+import { getYamlTemplate, getSimpleYamlTemplateText, Templates } from '../utils/TemplateUtils';
+
+export interface TesterConfig {
+    maxRetries: number;
+    responseTimeout: number;
+}
+
+export interface TemplateConfig {
+    name: string;
+    content: string;
+}
+
+export const TEMPLATE_CONFIGS: TemplateConfig[] = [
+    {
+        name: 'sample.yaml',
+        content: getYamlTemplate(),
+    },
+    {
+        name: 'simple.yaml',
+        content: getSimpleYamlTemplateText(),
+    },
+    {
+        name: 'comprehensive.yaml',
+        content: Templates.comprehensive.yaml.contents,
+    },
+    {
+        name: 'condition-usage.yaml',
+        content: Templates.conditionUsage.yaml.contents,
+    },
+];

--- a/tst/long-running/LongRunningTypes.ts
+++ b/tst/long-running/LongRunningTypes.ts
@@ -1,14 +1,14 @@
 import { getYamlTemplate, getSimpleYamlTemplateText, Templates } from '../utils/TemplateUtils';
 
-export interface TesterConfig {
+export type TesterConfig = {
     maxRetries: number;
     responseTimeout: number;
-}
+};
 
-export interface TemplateConfig {
+export type TemplateConfig = {
     name: string;
     content: string;
-}
+};
 
 export const TEMPLATE_CONFIGS: TemplateConfig[] = [
     {

--- a/tst/long-running/setup.ts
+++ b/tst/long-running/setup.ts
@@ -1,0 +1,9 @@
+import { randomUUID as v4 } from 'crypto';
+import { join } from 'path';
+import { staticInitialize } from '../../src/app/initialize';
+
+staticInitialize(undefined, {
+    telemetryEnabled: false,
+    logLevel: 'info', // Enable info-level logging for long-running tests
+    storageDir: join(process.cwd(), 'node_modules', '.cache', 'long-running-tests', v4()),
+});

--- a/tst/long-running/testers/CompletionTester.ts
+++ b/tst/long-running/testers/CompletionTester.ts
@@ -3,10 +3,10 @@ import { expect } from 'vitest';
 import { CompletionTriggerKind } from 'vscode-languageserver-protocol';
 import { DocumentHelper } from '../../utils/DocumentHelper';
 import { TestExtension } from '../../utils/TestExtension';
-import { executeWithRetry } from '../LongRunningLspClient';
 import { TesterConfig } from '../LongRunningTypes';
+import { Tester, executeWithRetry } from './TesterCommon';
 
-export class CompletionTester {
+export class CompletionTester implements Tester {
     constructor(
         private readonly testExtension: TestExtension,
         private readonly config: TesterConfig,
@@ -30,8 +30,7 @@ export class CompletionTester {
                     context: { triggerKind: CompletionTriggerKind.Invoked },
                 }),
             'completion',
-            this.config.maxRetries,
-            this.config.responseTimeout,
+            this.config,
         );
 
         expect(result1).toBeDefined();
@@ -61,8 +60,7 @@ export class CompletionTester {
                     context: { triggerKind: CompletionTriggerKind.Invoked },
                 }),
             'completion',
-            this.config.maxRetries,
-            this.config.responseTimeout,
+            this.config,
         );
 
         expect(result2).toBeDefined();

--- a/tst/long-running/testers/CompletionTester.ts
+++ b/tst/long-running/testers/CompletionTester.ts
@@ -1,0 +1,77 @@
+/* eslint-disable vitest/no-standalone-expect */
+import { expect } from 'vitest';
+import { CompletionTriggerKind } from 'vscode-languageserver-protocol';
+import { DocumentHelper } from '../../utils/DocumentHelper';
+import { TestExtension } from '../../utils/TestExtension';
+import { executeWithRetry } from '../LongRunningLspClient';
+import { TesterConfig } from '../LongRunningTypes';
+
+export class CompletionTester {
+    constructor(
+        private readonly testExtension: TestExtension,
+        private readonly config: TesterConfig,
+    ) {}
+
+    async testAllScenarios(uri: string): Promise<void> {
+        // Test 1: Full document replacement
+        const version1 = Date.now();
+        await DocumentHelper.replaceDocumentContent(
+            this.testExtension,
+            uri,
+            version1,
+            `AWSTemplateFormatVersion: '2010-09-09'\n`,
+        );
+
+        const result1: any = await executeWithRetry(
+            () =>
+                this.testExtension.completion({
+                    textDocument: { uri },
+                    position: { line: 1, character: 0 },
+                    context: { triggerKind: CompletionTriggerKind.Invoked },
+                }),
+            'completion',
+            this.config.maxRetries,
+            this.config.responseTimeout,
+        );
+
+        expect(result1).toBeDefined();
+        expect(result1?.items).toBeDefined();
+        expect(Array.isArray(result1.items)).toBe(true);
+        expect(result1.items.length).toBeGreaterThan(0);
+
+        const topLevelLabels = result1.items.map((item: any) => item.label);
+        expect(topLevelLabels).toContain('Resources');
+        expect(topLevelLabels).toContain('Parameters');
+
+        // Test 2: Incremental update - add Resources section
+        await DocumentHelper.appendDocumentContent(
+            this.testExtension,
+            uri,
+            version1 + 1,
+            1,
+            `Resources:\n  MyBucket:\n    Type: AWS::S3::Bucket\n    Properties:\n`,
+            ['Resources:', 'MyBucket:', 'AWS::S3::Bucket', 'Properties:'],
+        );
+
+        const result2: any = await executeWithRetry(
+            () =>
+                this.testExtension.completion({
+                    textDocument: { uri },
+                    position: { line: 5, character: 6 },
+                    context: { triggerKind: CompletionTriggerKind.Invoked },
+                }),
+            'completion',
+            this.config.maxRetries,
+            this.config.responseTimeout,
+        );
+
+        expect(result2).toBeDefined();
+        expect(result2?.items).toBeDefined();
+        expect(Array.isArray(result2.items)).toBe(true);
+        expect(result2.items.length).toBeGreaterThan(0);
+
+        const propertyLabels = result2.items.map((item: any) => item.label);
+        expect(propertyLabels).toContain('BucketName');
+        expect(propertyLabels).toContain('Tags');
+    }
+}

--- a/tst/long-running/testers/HoverTester.ts
+++ b/tst/long-running/testers/HoverTester.ts
@@ -2,10 +2,10 @@
 import { expect } from 'vitest';
 import { DocumentHelper } from '../../utils/DocumentHelper';
 import { TestExtension } from '../../utils/TestExtension';
-import { executeWithRetry } from '../LongRunningLspClient';
 import { TesterConfig } from '../LongRunningTypes';
+import { Tester, executeWithRetry } from './TesterCommon';
 
-export class HoverTester {
+export class HoverTester implements Tester {
     constructor(
         private readonly testExtension: TestExtension,
         private readonly config: TesterConfig,
@@ -53,8 +53,7 @@ Resources:
                     position: { line: 3, character: 15 },
                 }),
             'hover',
-            this.config.maxRetries,
-            this.config.responseTimeout,
+            this.config,
         );
 
         expect(result1).toBeDefined();
@@ -83,8 +82,7 @@ Parameters:
                     position: { line: 9, character: 10 },
                 }),
             'hover',
-            this.config.maxRetries,
-            this.config.responseTimeout,
+            this.config,
         );
 
         expect(result2).toBeDefined();

--- a/tst/long-running/testers/HoverTester.ts
+++ b/tst/long-running/testers/HoverTester.ts
@@ -1,0 +1,95 @@
+/* eslint-disable vitest/no-standalone-expect */
+import { expect } from 'vitest';
+import { DocumentHelper } from '../../utils/DocumentHelper';
+import { TestExtension } from '../../utils/TestExtension';
+import { executeWithRetry } from '../LongRunningLspClient';
+import { TesterConfig } from '../LongRunningTypes';
+
+export class HoverTester {
+    constructor(
+        private readonly testExtension: TestExtension,
+        private readonly config: TesterConfig,
+    ) {}
+
+    private extractHoverContent(hoverResult: any): string {
+        if (typeof hoverResult.contents === 'string') {
+            return hoverResult.contents;
+        } else if (Array.isArray(hoverResult.contents)) {
+            return hoverResult.contents.length > 0 ? JSON.stringify(hoverResult.contents) : '';
+        } else if (
+            hoverResult.contents &&
+            typeof hoverResult.contents === 'object' &&
+            'value' in hoverResult.contents
+        ) {
+            return hoverResult.contents.value;
+        }
+        return '';
+    }
+
+    private validateHoverContent(content: string, patterns: string[]): void {
+        expect(content).toBeDefined();
+        expect(content.length).toBeGreaterThan(0);
+        const lowerContent = content.toLowerCase();
+        for (const pattern of patterns) expect(lowerContent).toContain(pattern);
+    }
+
+    async testAllScenarios(uri: string): Promise<void> {
+        // Test 1: Full document replacement
+        const version1 = Date.now();
+        const s3Template = `AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  MyResource:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: TestName
+`;
+
+        await DocumentHelper.replaceDocumentContent(this.testExtension, uri, version1, s3Template);
+
+        const result1: any = await executeWithRetry(
+            () =>
+                this.testExtension.hover({
+                    textDocument: { uri },
+                    position: { line: 3, character: 15 },
+                }),
+            'hover',
+            this.config.maxRetries,
+            this.config.responseTimeout,
+        );
+
+        expect(result1).toBeDefined();
+        expect(result1.contents).toBeDefined();
+        const content1 = this.extractHoverContent(result1);
+        this.validateHoverContent(content1, ['aws::s3::bucket', 'bucket', 's3', 'aws']);
+
+        // Test 2: Incremental update - add Parameters section
+        await DocumentHelper.appendDocumentContent(
+            this.testExtension,
+            uri,
+            version1 + 1,
+            6,
+            `
+Parameters:
+  MyParam:
+    Type: String
+`,
+            ['Parameters:', 'MyParam:'],
+        );
+
+        const result2: any = await executeWithRetry(
+            () =>
+                this.testExtension.hover({
+                    textDocument: { uri },
+                    position: { line: 9, character: 10 },
+                }),
+            'hover',
+            this.config.maxRetries,
+            this.config.responseTimeout,
+        );
+
+        expect(result2).toBeDefined();
+        expect(result2.contents).toBeDefined();
+        const content2 = this.extractHoverContent(result2);
+        this.validateHoverContent(content2, ['type', 'parameter', 'string']);
+    }
+}

--- a/tst/long-running/testers/TesterCommon.ts
+++ b/tst/long-running/testers/TesterCommon.ts
@@ -1,11 +1,15 @@
-import { WaitFor } from '../utils/Utils';
-import { recordOperation } from './LongRunningMonitoring';
+import { WaitFor } from '../../utils/Utils';
+import { recordOperation } from '../LongRunningMonitoring';
+import { TesterConfig } from '../LongRunningTypes';
+
+export interface Tester {
+    testAllScenarios(uri: string): Promise<void>;
+}
 
 export async function executeWithRetry<T>(
     operation: () => Promise<T>,
     operationName: string,
-    maxRetries: number,
-    responseTimeout: number,
+    config: TesterConfig,
 ): Promise<T> {
     let result: T;
     let responseTime: number;
@@ -20,11 +24,13 @@ export async function executeWithRetry<T>(
                 if (result === undefined) {
                     throw new Error(`${operationName} should return a result (not undefined)`);
                 }
-                if (responseTime > responseTimeout) {
-                    throw new Error(`${operationName} response time ${responseTime}ms exceeds ${responseTimeout}ms`);
+                if (responseTime > config.responseTimeout) {
+                    throw new Error(
+                        `${operationName} response time ${responseTime}ms exceeds ${config.responseTimeout}ms`,
+                    );
                 }
             },
-            maxRetries * 1000,
+            config.maxRetries * 1000,
             1000,
         );
 

--- a/tst/utils/DocumentHelper.ts
+++ b/tst/utils/DocumentHelper.ts
@@ -1,0 +1,49 @@
+import { TestExtension } from './TestExtension';
+import { WaitFor } from './Utils';
+
+export const DocumentHelper = {
+    async replaceDocumentContent(
+        testExtension: TestExtension,
+        uri: string,
+        version: number,
+        content: string,
+    ): Promise<void> {
+        await testExtension.changeDocument({
+            textDocument: { uri, version },
+            contentChanges: [{ text: content }],
+        });
+
+        await WaitFor.waitFor(() => {
+            const docContent = testExtension.components.documentManager.get(uri)?.contents() ?? '';
+            if (docContent !== content) {
+                throw new Error('Document not updated');
+            }
+        }, 2500);
+    },
+
+    async appendDocumentContent(
+        testExtension: TestExtension,
+        uri: string,
+        version: number,
+        line: number,
+        text: string,
+        expectedTexts: string[],
+    ): Promise<void> {
+        await testExtension.changeDocument({
+            textDocument: { uri, version },
+            contentChanges: [
+                {
+                    range: { start: { line, character: 0 }, end: { line, character: 0 } },
+                    text,
+                },
+            ],
+        });
+
+        await WaitFor.waitFor(() => {
+            const content = testExtension.components.documentManager.get(uri)?.contents() ?? '';
+            if (!expectedTexts.every((expected) => content.includes(expected))) {
+                throw new Error('Document not updated');
+            }
+        }, 2500);
+    },
+};

--- a/tst/utils/TestExtension.ts
+++ b/tst/utils/TestExtension.ts
@@ -71,11 +71,12 @@ import { createMockCfnLintService } from './MockServerComponents';
 import { getTestPrivateSchemas, samFileType, SamSchemaFiles, schemaFileType, Schemas } from './SchemaUtils';
 import { flushAllPromises, WaitFor } from './Utils';
 
-type TestExtensionConfig = {
+export type TestExtensionConfig = {
     id?: string;
     initializeParams?: Partial<InitializeParams>;
     workspaceConfig?: Record<string, unknown>[];
     awsClientFactory?: (credentials: AwsCredentials, endpoint?: string) => AwsClient;
+    schemaRetrieverFactory?: (schemaStore: SchemaStore) => SchemaRetriever;
 };
 
 export class TestExtension implements Closeable {
@@ -84,7 +85,7 @@ export class TestExtension implements Closeable {
 
     private readonly readStream = new PassThrough();
     private readonly writeStream = new PassThrough();
-    private readonly clientConnection = createMessageConnection(
+    protected readonly clientConnection = createMessageConnection(
         new StreamMessageReader(this.writeStream),
         new StreamMessageWriter(this.readStream),
     );
@@ -139,16 +140,18 @@ export class TestExtension implements Closeable {
                     });
 
                     const schemaStore = new SchemaStore(dataStoreFactory);
-                    const schemaRetriever = new SchemaRetriever(
-                        schemaStore,
-                        (_region) => {
-                            return Promise.resolve(schemaFileType(Object.values(Schemas)));
-                        },
-                        () => Promise.resolve(getTestPrivateSchemas()),
-                        () => {
-                            return Promise.resolve(samFileType(Object.values(SamSchemaFiles)));
-                        },
-                    );
+                    const schemaRetriever =
+                        config.schemaRetrieverFactory?.(schemaStore) ??
+                        new SchemaRetriever(
+                            schemaStore,
+                            (_region) => {
+                                return Promise.resolve(schemaFileType(Object.values(Schemas)));
+                            },
+                            () => Promise.resolve(getTestPrivateSchemas()),
+                            () => {
+                                return Promise.resolve(samFileType(Object.values(SamSchemaFiles)));
+                            },
+                        );
 
                     const ffFile = join(__dirname, '..', '..', 'assets', 'featureFlag', 'alpha.json');
                     this.external = new CfnExternal(lsp, this.core, {
@@ -212,7 +215,7 @@ export class TestExtension implements Closeable {
                 if (pbSchemas === undefined || samSchemas === undefined) {
                     throw new Error('Schemas not loaded yet');
                 }
-            }, 5_000);
+            }, 30_000); // Increased timeout for real schema downloads
 
             await flushAllPromises();
             this.isReady = true;

--- a/vitest.long-running.config.ts
+++ b/vitest.long-running.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    testTimeout: 6 * 60 * 60 * 1000,
+    hookTimeout: 60 * 1000,
+    coverage: {
+      enabled: false, // Disable coverage for performance tests
+    },
+    pool: 'forks',
+    logHeapUsage: true,
+    reporters: ['verbose'],
+    include: ['tst/long-running/**/*.test.ts'],
+    setupFiles: ['tst/long-running/setup.ts'],
+  },
+});


### PR DESCRIPTION
*Description of changes:*
- Added long running test package to monitor performance and the lsp's ability to run and make requests over extended periods of time
- The tests assert the following:
  - LSP can keep multiple files opened and edited repeatedly for extended periods
  - LSP can continue to perform completion and hover
  - LSP will not leak memory nor will the lsp operations exceed thresholds after running for extended periods
  - **Note**: will add region switching logic (to ensure every region can be used) in a follow-up
- Added package.json command to run tests, by default it's 4 hours but can be configurable
- Also added some helper document util methods for modifying document content
  -  These can be used in other tests such as e2e

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
