### PR TITLE
Add schema readiness handler

### DIFF
--- a/src/handlers/SchemaHandler.ts
+++ b/src/handlers/SchemaHandler.ts
@@ -1,13 +1,13 @@
 import { ErrorCodes, ResponseError, RequestHandler } from 'vscode-languageserver';
 import { parseSchemaReadinessRequest } from '../schema/SchemaRequestParser';
-import { SchemaReadinessRequest, SchemaReadinessResponse } from '../schema/SchemaRequestType';
+import { GetSchemaReadinessRequest, GetSchemaReadinessResponse } from '../schema/SchemaRequestType';
 import { ServerComponents } from '../server/ServerComponents';
 import { extractErrorMessage } from '../utils/Errors';
 import { parseWithPrettyError } from '../utils/ZodErrorWrapper';
 
 export function schemaReadinessHandler(
     components: ServerComponents,
-): RequestHandler<SchemaReadinessRequest, SchemaReadinessResponse, void> {
+): RequestHandler<GetSchemaReadinessRequest, GetSchemaReadinessResponse, void> {
     return (rawParams) => {
         try {
             const params = parseWithPrettyError(parseSchemaReadinessRequest, rawParams);

--- a/src/handlers/SchemaHandler.ts
+++ b/src/handlers/SchemaHandler.ts
@@ -5,7 +5,7 @@ import { ServerComponents } from '../server/ServerComponents';
 import { extractErrorMessage } from '../utils/Errors';
 import { parseWithPrettyError } from '../utils/ZodErrorWrapper';
 
-export function schemaReadinessHandler(
+export function getSchemaReadinessHandler(
     components: ServerComponents,
 ): RequestHandler<GetSchemaReadinessRequest, GetSchemaReadinessResponse, void> {
     return (rawParams) => {

--- a/src/handlers/SchemaHandler.ts
+++ b/src/handlers/SchemaHandler.ts
@@ -1,0 +1,29 @@
+import { ErrorCodes, ResponseError, RequestHandler } from 'vscode-languageserver';
+import { parseSchemaReadinessRequest } from '../schema/SchemaRequestParser';
+import { SchemaReadinessRequest, SchemaReadinessResponse } from '../schema/SchemaRequestType';
+import { ServerComponents } from '../server/ServerComponents';
+import { extractErrorMessage } from '../utils/Errors';
+import { parseWithPrettyError } from '../utils/ZodErrorWrapper';
+
+export function schemaReadinessHandler(
+    components: ServerComponents,
+): RequestHandler<SchemaReadinessRequest, SchemaReadinessResponse, void> {
+    return (rawParams) => {
+        try {
+            const params = parseWithPrettyError(parseSchemaReadinessRequest, rawParams);
+            const publicSchemas = components.schemaStore.getPublicSchemas(params.region);
+            return {
+                region: params.region,
+                schemasReady: publicSchemas !== undefined && publicSchemas.schemas.length > 0,
+            };
+        } catch (error) {
+            if (error instanceof ResponseError) {
+                throw error;
+            }
+            throw new ResponseError(
+                ErrorCodes.InternalError,
+                `Failed to check schema readiness: ${extractErrorMessage(error)}`,
+            );
+        }
+    };
+}

--- a/src/protocol/LspComponents.ts
+++ b/src/protocol/LspComponents.ts
@@ -7,6 +7,7 @@ import { LspHandlers } from './LspHandlers';
 import { LspRelatedResourcesHandlers } from './LspRelatedResourcesHandlers';
 import { LspResourceHandlers } from './LspResourceHandlers';
 import { LspS3Handlers } from './LspS3Handlers';
+import { LspSchemaHandlers } from './LspSchemaHandlers';
 import { LspStackHandlers } from './LspStackHandlers';
 import { LspWorkspace } from './LspWorkspace';
 
@@ -23,5 +24,6 @@ export class LspComponents {
         public readonly resourceHandlers: LspResourceHandlers,
         public readonly relatedResourcesHandlers: LspRelatedResourcesHandlers,
         public readonly s3Handlers: LspS3Handlers,
+        public readonly schemaHandlers: LspSchemaHandlers,
     ) {}
 }

--- a/src/protocol/LspConnection.ts
+++ b/src/protocol/LspConnection.ts
@@ -12,6 +12,7 @@ import { LspHandlers } from './LspHandlers';
 import { LspRelatedResourcesHandlers } from './LspRelatedResourcesHandlers';
 import { LspResourceHandlers } from './LspResourceHandlers';
 import { LspS3Handlers } from './LspS3Handlers';
+import { LspSchemaHandlers } from './LspSchemaHandlers';
 import { LspStackHandlers } from './LspStackHandlers';
 import { LspWorkspace } from './LspWorkspace';
 
@@ -34,6 +35,7 @@ export class LspConnection {
     private readonly resourceHandlers: LspResourceHandlers;
     private readonly relatedResourcesHandlers: LspRelatedResourcesHandlers;
     private readonly s3Handlers: LspS3Handlers;
+    private readonly schemaHandlers: LspSchemaHandlers;
 
     private initializeParams?: InitializeParams;
 
@@ -59,6 +61,7 @@ export class LspConnection {
         this.resourceHandlers = new LspResourceHandlers(this.connection);
         this.relatedResourcesHandlers = new LspRelatedResourcesHandlers(this.connection);
         this.s3Handlers = new LspS3Handlers(this.connection);
+        this.schemaHandlers = new LspSchemaHandlers(this.connection);
 
         this.communication.console.info(`${ExtensionName} launched from ${__dirname}`);
 
@@ -94,6 +97,7 @@ export class LspConnection {
             this.resourceHandlers,
             this.relatedResourcesHandlers,
             this.s3Handlers,
+            this.schemaHandlers,
         );
     }
 

--- a/src/protocol/LspSchemaHandlers.ts
+++ b/src/protocol/LspSchemaHandlers.ts
@@ -1,0 +1,14 @@
+import { Connection, ServerRequestHandler } from 'vscode-languageserver';
+import {
+    SchemaReadinessRequestType,
+    SchemaReadinessRequest,
+    SchemaReadinessResponse,
+} from '../schema/SchemaRequestType';
+
+export class LspSchemaHandlers {
+    constructor(private readonly connection: Connection) {}
+
+    onGetSchemaReadiness(handler: ServerRequestHandler<SchemaReadinessRequest, SchemaReadinessResponse, never, void>) {
+        this.connection.onRequest(SchemaReadinessRequestType.method, handler);
+    }
+}

--- a/src/protocol/LspSchemaHandlers.ts
+++ b/src/protocol/LspSchemaHandlers.ts
@@ -1,14 +1,16 @@
 import { Connection, ServerRequestHandler } from 'vscode-languageserver';
 import {
-    SchemaReadinessRequestType,
-    SchemaReadinessRequest,
-    SchemaReadinessResponse,
+    GetSchemaReadinessRequestType,
+    GetSchemaReadinessRequest,
+    GetSchemaReadinessResponse,
 } from '../schema/SchemaRequestType';
 
 export class LspSchemaHandlers {
     constructor(private readonly connection: Connection) {}
 
-    onGetSchemaReadiness(handler: ServerRequestHandler<SchemaReadinessRequest, SchemaReadinessResponse, never, void>) {
-        this.connection.onRequest(SchemaReadinessRequestType.method, handler);
+    onGetSchemaReadiness(
+        handler: ServerRequestHandler<GetSchemaReadinessRequest, GetSchemaReadinessResponse, never, void>,
+    ) {
+        this.connection.onRequest(GetSchemaReadinessRequestType.method, handler);
     }
 }

--- a/src/schema/SchemaRequestParser.ts
+++ b/src/schema/SchemaRequestParser.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { AwsRegion } from '../utils/Region';
+import { SchemaReadinessRequest } from './SchemaRequestType';
+
+const SchemaReadinessRequestSchema = z.object({
+    region: z.enum(Object.values(AwsRegion) as [AwsRegion, ...AwsRegion[]]),
+});
+
+export function parseSchemaReadinessRequest(input: unknown): SchemaReadinessRequest {
+    return SchemaReadinessRequestSchema.parse(input);
+}

--- a/src/schema/SchemaRequestParser.ts
+++ b/src/schema/SchemaRequestParser.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import { AwsRegion } from '../utils/Region';
-import { SchemaReadinessRequest } from './SchemaRequestType';
+import { GetSchemaReadinessRequest } from './SchemaRequestType';
 
 const SchemaReadinessRequestSchema = z.object({
     region: z.enum(Object.values(AwsRegion) as [AwsRegion, ...AwsRegion[]]),
 });
 
-export function parseSchemaReadinessRequest(input: unknown): SchemaReadinessRequest {
+export function parseSchemaReadinessRequest(input: unknown): GetSchemaReadinessRequest {
     return SchemaReadinessRequestSchema.parse(input);
 }

--- a/src/schema/SchemaRequestType.ts
+++ b/src/schema/SchemaRequestType.ts
@@ -1,0 +1,15 @@
+import { RequestType } from 'vscode-languageserver-protocol';
+import { AwsRegion } from '../utils/Region';
+
+export interface SchemaReadinessRequest {
+    region: AwsRegion;
+}
+
+export interface SchemaReadinessResponse {
+    region: AwsRegion;
+    schemasReady: boolean;
+}
+
+export const SchemaReadinessRequestType = new RequestType<SchemaReadinessRequest, SchemaReadinessResponse, void>(
+    'aws/cfn/schema/readiness',
+);

--- a/src/schema/SchemaRequestType.ts
+++ b/src/schema/SchemaRequestType.ts
@@ -1,15 +1,17 @@
 import { RequestType } from 'vscode-languageserver-protocol';
 import { AwsRegion } from '../utils/Region';
 
-export interface SchemaReadinessRequest {
+export interface GetSchemaReadinessRequest {
     region: AwsRegion;
 }
 
-export interface SchemaReadinessResponse {
+export interface GetSchemaReadinessResponse {
     region: AwsRegion;
     schemasReady: boolean;
 }
 
-export const SchemaReadinessRequestType = new RequestType<SchemaReadinessRequest, SchemaReadinessResponse, void>(
-    'aws/cfn/schema/readiness',
-);
+export const GetSchemaReadinessRequestType = new RequestType<
+    GetSchemaReadinessRequest,
+    GetSchemaReadinessResponse,
+    void
+>('aws/cfn/schema/readiness');

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -27,7 +27,7 @@ import {
     removeResourceTypeHandler,
 } from '../handlers/ResourceHandler';
 import { uploadFileToS3Handler } from '../handlers/S3Handler';
-import { schemaReadinessHandler } from '../handlers/SchemaHandler';
+import { getSchemaReadinessHandler } from '../handlers/SchemaHandler';
 import {
     listStacksHandler,
     listChangeSetsHandler,
@@ -117,7 +117,7 @@ export class CfnServer {
         this.lsp.handlers.onCodeLens(withTelemetryContext('CodeLens', codeLensHandler(this.components)));
 
         this.lsp.schemaHandlers.onGetSchemaReadiness(
-            withTelemetryContext('SchemaReadiness', schemaReadinessHandler(this.components)),
+            withTelemetryContext('SchemaReadiness', getSchemaReadinessHandler(this.components)),
         );
 
         this.lsp.authHandlers.onIamCredentialsUpdate(

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -27,6 +27,7 @@ import {
     removeResourceTypeHandler,
 } from '../handlers/ResourceHandler';
 import { uploadFileToS3Handler } from '../handlers/S3Handler';
+import { schemaReadinessHandler } from '../handlers/SchemaHandler';
 import {
     listStacksHandler,
     listChangeSetsHandler,
@@ -114,6 +115,10 @@ export class CfnServer {
             withTelemetryContext('Configuration', configurationHandler(this.components)),
         );
         this.lsp.handlers.onCodeLens(withTelemetryContext('CodeLens', codeLensHandler(this.components)));
+
+        this.lsp.schemaHandlers.onGetSchemaReadiness(
+            withTelemetryContext('SchemaReadiness', schemaReadinessHandler(this.components)),
+        );
 
         this.lsp.authHandlers.onIamCredentialsUpdate(
             withTelemetryContext('Auth.Update', iamCredentialsUpdateHandler(this.components)),

--- a/tst/unit/handlers/SchemaHandler.test.ts
+++ b/tst/unit/handlers/SchemaHandler.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CancellationToken, ResponseError } from 'vscode-languageserver';
+import { schemaReadinessHandler } from '../../../src/handlers/SchemaHandler';
+import { RegionalSchemasType } from '../../../src/schema/RegionalSchemas';
+import { SchemaReadinessRequest } from '../../../src/schema/SchemaRequestType';
+import { AwsRegion } from '../../../src/utils/Region';
+import { createMockComponents } from '../../utils/MockServerComponents';
+
+describe('SchemaReadinessHandler', () => {
+    let mockComponents: ReturnType<typeof createMockComponents>;
+
+    beforeEach(() => {
+        mockComponents = createMockComponents();
+    });
+
+    describe('schemaReadinessHandler', () => {
+        it('should return schemasReady true when schemas exist', async () => {
+            const region = AwsRegion.US_EAST_1;
+            const mockSchemas: RegionalSchemasType = {
+                version: 'v1',
+                region,
+                schemas: [{ name: 'test-schema', content: '{}', createdMs: Date.now() }],
+                firstCreatedMs: Date.now(),
+                lastModifiedMs: Date.now(),
+            };
+            mockComponents.schemaStore.getPublicSchemas.returns(mockSchemas);
+
+            const handler = schemaReadinessHandler(mockComponents);
+            const request: SchemaReadinessRequest = { region };
+
+            const result = await handler(request, CancellationToken.None);
+
+            expect(result).toEqual({
+                region,
+                schemasReady: true,
+            });
+            expect(mockComponents.schemaStore.getPublicSchemas.calledWith(region)).toBe(true);
+        });
+
+        it('should return schemasReady false when schemas are undefined', async () => {
+            const region = AwsRegion.US_WEST_2;
+            mockComponents.schemaStore.getPublicSchemas.returns(undefined);
+
+            const handler = schemaReadinessHandler(mockComponents);
+            const request: SchemaReadinessRequest = { region };
+
+            const result = await handler(request, CancellationToken.None);
+
+            expect(result).toEqual({
+                region,
+                schemasReady: false,
+            });
+        });
+
+        it('should return schemasReady false when schemas array is empty', async () => {
+            const region = AwsRegion.EU_WEST_1;
+            const mockSchemas: RegionalSchemasType = {
+                version: 'v1',
+                region,
+                schemas: [],
+                firstCreatedMs: Date.now(),
+                lastModifiedMs: Date.now(),
+            };
+            mockComponents.schemaStore.getPublicSchemas.returns(mockSchemas);
+
+            const handler = schemaReadinessHandler(mockComponents);
+            const request: SchemaReadinessRequest = { region };
+
+            const result = await handler(request, CancellationToken.None);
+
+            expect(result).toEqual({
+                region,
+                schemasReady: false,
+            });
+        });
+
+        it('should handle errors gracefully', async () => {
+            const region = AwsRegion.US_EAST_1;
+            mockComponents.schemaStore.getPublicSchemas.throws(new Error('Database error'));
+
+            const handler = schemaReadinessHandler(mockComponents);
+            const request: SchemaReadinessRequest = { region };
+
+            await expect(handler(request, CancellationToken.None)).rejects.toThrow(ResponseError);
+            await expect(handler(request, CancellationToken.None)).rejects.toThrow(
+                'Failed to check schema readiness: Database error',
+            );
+        });
+    });
+});

--- a/tst/unit/handlers/SchemaHandler.test.ts
+++ b/tst/unit/handlers/SchemaHandler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CancellationToken, ResponseError } from 'vscode-languageserver';
-import { schemaReadinessHandler } from '../../../src/handlers/SchemaHandler';
+import { getSchemaReadinessHandler } from '../../../src/handlers/SchemaHandler';
 import { RegionalSchemasType } from '../../../src/schema/RegionalSchemas';
 import { GetSchemaReadinessRequest } from '../../../src/schema/SchemaRequestType';
 import { AwsRegion } from '../../../src/utils/Region';
@@ -25,7 +25,7 @@ describe('SchemaReadinessHandler', () => {
             };
             mockComponents.schemaStore.getPublicSchemas.returns(mockSchemas);
 
-            const handler = schemaReadinessHandler(mockComponents);
+            const handler = getSchemaReadinessHandler(mockComponents);
             const request: GetSchemaReadinessRequest = { region };
 
             const result = await handler(request, CancellationToken.None);
@@ -41,7 +41,7 @@ describe('SchemaReadinessHandler', () => {
             const region = AwsRegion.US_WEST_2;
             mockComponents.schemaStore.getPublicSchemas.returns(undefined);
 
-            const handler = schemaReadinessHandler(mockComponents);
+            const handler = getSchemaReadinessHandler(mockComponents);
             const request: GetSchemaReadinessRequest = { region };
 
             const result = await handler(request, CancellationToken.None);
@@ -63,7 +63,7 @@ describe('SchemaReadinessHandler', () => {
             };
             mockComponents.schemaStore.getPublicSchemas.returns(mockSchemas);
 
-            const handler = schemaReadinessHandler(mockComponents);
+            const handler = getSchemaReadinessHandler(mockComponents);
             const request: GetSchemaReadinessRequest = { region };
 
             const result = await handler(request, CancellationToken.None);
@@ -78,7 +78,7 @@ describe('SchemaReadinessHandler', () => {
             const region = AwsRegion.US_EAST_1;
             mockComponents.schemaStore.getPublicSchemas.throws(new Error('Database error'));
 
-            const handler = schemaReadinessHandler(mockComponents);
+            const handler = getSchemaReadinessHandler(mockComponents);
             const request: GetSchemaReadinessRequest = { region };
 
             await expect(handler(request, CancellationToken.None)).rejects.toThrow(ResponseError);

--- a/tst/unit/handlers/SchemaHandler.test.ts
+++ b/tst/unit/handlers/SchemaHandler.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { CancellationToken, ResponseError } from 'vscode-languageserver';
 import { schemaReadinessHandler } from '../../../src/handlers/SchemaHandler';
 import { RegionalSchemasType } from '../../../src/schema/RegionalSchemas';
-import { SchemaReadinessRequest } from '../../../src/schema/SchemaRequestType';
+import { GetSchemaReadinessRequest } from '../../../src/schema/SchemaRequestType';
 import { AwsRegion } from '../../../src/utils/Region';
 import { createMockComponents } from '../../utils/MockServerComponents';
 
@@ -26,7 +26,7 @@ describe('SchemaReadinessHandler', () => {
             mockComponents.schemaStore.getPublicSchemas.returns(mockSchemas);
 
             const handler = schemaReadinessHandler(mockComponents);
-            const request: SchemaReadinessRequest = { region };
+            const request: GetSchemaReadinessRequest = { region };
 
             const result = await handler(request, CancellationToken.None);
 
@@ -42,7 +42,7 @@ describe('SchemaReadinessHandler', () => {
             mockComponents.schemaStore.getPublicSchemas.returns(undefined);
 
             const handler = schemaReadinessHandler(mockComponents);
-            const request: SchemaReadinessRequest = { region };
+            const request: GetSchemaReadinessRequest = { region };
 
             const result = await handler(request, CancellationToken.None);
 
@@ -64,7 +64,7 @@ describe('SchemaReadinessHandler', () => {
             mockComponents.schemaStore.getPublicSchemas.returns(mockSchemas);
 
             const handler = schemaReadinessHandler(mockComponents);
-            const request: SchemaReadinessRequest = { region };
+            const request: GetSchemaReadinessRequest = { region };
 
             const result = await handler(request, CancellationToken.None);
 
@@ -79,7 +79,7 @@ describe('SchemaReadinessHandler', () => {
             mockComponents.schemaStore.getPublicSchemas.throws(new Error('Database error'));
 
             const handler = schemaReadinessHandler(mockComponents);
-            const request: SchemaReadinessRequest = { region };
+            const request: GetSchemaReadinessRequest = { region };
 
             await expect(handler(request, CancellationToken.None)).rejects.toThrow(ResponseError);
             await expect(handler(request, CancellationToken.None)).rejects.toThrow(

--- a/tst/unit/protocol/LspSchemaHandlers.test.ts
+++ b/tst/unit/protocol/LspSchemaHandlers.test.ts
@@ -2,7 +2,7 @@ import { StubbedInstance, stubInterface } from 'ts-sinon';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Connection } from 'vscode-languageserver/node';
 import { LspSchemaHandlers } from '../../../src/protocol/LspSchemaHandlers';
-import { SchemaReadinessRequestType } from '../../../src/schema/SchemaRequestType';
+import { GetSchemaReadinessRequestType } from '../../../src/schema/SchemaRequestType';
 
 describe('LspSchemaHandlers', () => {
     let lspSchemaHandlers: LspSchemaHandlers;
@@ -26,7 +26,7 @@ describe('LspSchemaHandlers', () => {
 
             lspSchemaHandlers.onGetSchemaReadiness(mockHandler);
 
-            expect(mockConnection.onRequest.calledWith(SchemaReadinessRequestType.method)).toBe(true);
+            expect(mockConnection.onRequest.calledWith(GetSchemaReadinessRequestType.method)).toBe(true);
         });
     });
 });

--- a/tst/unit/protocol/LspSchemaHandlers.test.ts
+++ b/tst/unit/protocol/LspSchemaHandlers.test.ts
@@ -1,0 +1,32 @@
+import { StubbedInstance, stubInterface } from 'ts-sinon';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Connection } from 'vscode-languageserver/node';
+import { LspSchemaHandlers } from '../../../src/protocol/LspSchemaHandlers';
+import { SchemaReadinessRequestType } from '../../../src/schema/SchemaRequestType';
+
+describe('LspSchemaHandlers', () => {
+    let lspSchemaHandlers: LspSchemaHandlers;
+    let mockConnection: StubbedInstance<Connection>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockConnection = stubInterface<Connection>();
+        lspSchemaHandlers = new LspSchemaHandlers(mockConnection);
+    });
+
+    describe('constructor', () => {
+        it('should initialize with connection', () => {
+            expect(lspSchemaHandlers).toBeDefined();
+        });
+    });
+
+    describe('handler registration', () => {
+        it('should register schema readiness handler', () => {
+            const mockHandler = vi.fn();
+
+            lspSchemaHandlers.onGetSchemaReadiness(mockHandler);
+
+            expect(mockConnection.onRequest.calledWith(SchemaReadinessRequestType.method)).toBe(true);
+        });
+    });
+});

--- a/tst/unit/schema/SchemaRequestParser.test.ts
+++ b/tst/unit/schema/SchemaRequestParser.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+import { parseSchemaReadinessRequest } from '../../../src/schema/SchemaRequestParser';
+
+describe('SchemaRequestParser', () => {
+    describe('parseSchemaReadinessRequest', () => {
+        it('should parse valid schema readiness request', () => {
+            const input = {
+                region: 'us-east-1',
+            };
+
+            const result = parseSchemaReadinessRequest(input);
+
+            expect(result).toEqual({
+                region: 'us-east-1',
+            });
+        });
+
+        it('should throw ZodError for missing region', () => {
+            const input = {};
+
+            expect(() => parseSchemaReadinessRequest(input)).toThrow(ZodError);
+        });
+
+        it('should throw ZodError for null input', () => {
+            expect(() => parseSchemaReadinessRequest(null)).toThrow(ZodError);
+        });
+
+        it('should throw ZodError for undefined input', () => {
+            expect(() => parseSchemaReadinessRequest(undefined)).toThrow(ZodError);
+        });
+    });
+});

--- a/tst/utils/MockServerComponents.ts
+++ b/tst/utils/MockServerComponents.ts
@@ -29,6 +29,7 @@ import { LspHandlers } from '../../src/protocol/LspHandlers';
 import { LspRelatedResourcesHandlers } from '../../src/protocol/LspRelatedResourcesHandlers';
 import { LspResourceHandlers } from '../../src/protocol/LspResourceHandlers';
 import { LspS3Handlers } from '../../src/protocol/LspS3Handlers';
+import { LspSchemaHandlers } from '../../src/protocol/LspSchemaHandlers';
 import { LspStackHandlers } from '../../src/protocol/LspStackHandlers';
 import { LspWorkspace } from '../../src/protocol/LspWorkspace';
 import { RelatedResourcesSnippetProvider } from '../../src/relatedResources/RelatedResourcesSnippetProvider';
@@ -353,6 +354,7 @@ export function createMockComponents(o: Partial<CfnLspServerComponentsType> = {}
         resourceHandlers: overrides.resourceHandlers ?? stubInterface<LspResourceHandlers>(),
         relatedResourcesHandlers: overrides.relatedResourcesHandlers ?? stubInterface<LspRelatedResourcesHandlers>(),
         s3Handlers: overrides.s3Handlers ?? stubInterface<LspS3Handlers>(),
+        schemaHandlers: overrides.schemaHandlers ?? stubInterface<LspSchemaHandlers>(),
     };
 
     const core: MockInfraCoreComponents = {


### PR DESCRIPTION
*Description of changes:*
- Currently, the only way to tell if the schemas are successfully loaded is by checking the logs (in the event that the schemas had to be downloaded) or by directly using an lsp request that uses the schemas
- Added an LSP request to determine if the schemas for a particular region are loaded into the LMDB
  - This allows for more granular testing by decoupling the schema retrieval logic from the lsp request that is being tested


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
