### PR TITLE
fix: JSON resource type value completion formatted as key

### DIFF
--- a/src/autocomplete/CompletionFormatter.ts
+++ b/src/autocomplete/CompletionFormatter.ts
@@ -95,7 +95,7 @@ export class CompletionFormatter {
 
         // Set filterText for ALL items (including snippets) when in JSON with quotes
         const isInJsonString = documentType === DocumentType.JSON && context.syntaxNode.type === 'string';
-        const isJsonValueNode = isInJsonString && this.isJsonValuePosition(context);
+        const isJsonValueNode = isInJsonString && context.isJsonPairValue();
         if (isJsonValueNode) {
             formattedItem.filterText = `"${item.label}"`;
         } else if (isInJsonString) {
@@ -176,7 +176,7 @@ export class CompletionFormatter {
 
         // When completing a value (e.g. resource type "AWS::S3::Bucket"), just replace the value text
         // Check the syntax tree: if the node is the value child of a JSON pair, it's a value completion
-        const isValueCompletion = this.isJsonValuePosition(context);
+        const isValueCompletion = context.isJsonPairValue();
         if (isValueCompletion) {
             // Include surrounding quotes in the range so VS Code matches the full token
             const startCol = Math.max(0, context.startPosition.column - 1);
@@ -365,15 +365,5 @@ export class CompletionFormatter {
     private isArrayType(item?: CompletionItem): boolean {
         const data = item?.data as CompletionItemData | undefined;
         return data?.type === 'array';
-    }
-
-    /**
-     * Check if the cursor is at a JSON value position using the syntax tree.
-     * A node is a value if it's the value child of a pair node.
-     */
-    private isJsonValuePosition(context: Context): boolean {
-        const node = context.syntaxNode;
-        const parent = node.parent;
-        return parent?.type === 'pair' && parent.childForFieldName('value') === node;
     }
 }

--- a/src/autocomplete/CompletionFormatter.ts
+++ b/src/autocomplete/CompletionFormatter.ts
@@ -95,7 +95,10 @@ export class CompletionFormatter {
 
         // Set filterText for ALL items (including snippets) when in JSON with quotes
         const isInJsonString = documentType === DocumentType.JSON && context.syntaxNode.type === 'string';
-        if (isInJsonString) {
+        const isJsonValueCompletion = documentType === DocumentType.JSON && item.kind === CompletionItemKind.Class;
+        if (isJsonValueCompletion) {
+            formattedItem.filterText = `"${item.label}"`;
+        } else if (isInJsonString) {
             formattedItem.filterText = `"${context.text}"`;
         }
 
@@ -170,6 +173,20 @@ export class CompletionFormatter {
 
         const indentation = ' '.repeat(context.startPosition.column);
         const indentString = getIndentationString(editorSettings, DocumentType.JSON);
+
+        // When completing a value (e.g. resource type "AWS::S3::Bucket"), just replace the value text
+        // Resource types use CompletionItemKind.Class and are always value completions in JSON
+        const isValueCompletion = item.kind === CompletionItemKind.Class;
+        if (isValueCompletion) {
+            // Include surrounding quotes in the range so VS Code matches the full token
+            const startCol = Math.max(0, context.startPosition.column - 1);
+            const endCol = context.endPosition.column + 1;
+            const range = Range.create(
+                Position.create(context.startPosition.row, startCol),
+                Position.create(context.endPosition.row, endCol),
+            );
+            return { text: `"${label}"`, range, isSnippet: false };
+        }
 
         let replacementText = `${indentation}"${label}":`;
         let isSnippet = false;

--- a/src/autocomplete/CompletionFormatter.ts
+++ b/src/autocomplete/CompletionFormatter.ts
@@ -95,8 +95,8 @@ export class CompletionFormatter {
 
         // Set filterText for ALL items (including snippets) when in JSON with quotes
         const isInJsonString = documentType === DocumentType.JSON && context.syntaxNode.type === 'string';
-        const isJsonValueCompletion = documentType === DocumentType.JSON && item.kind === CompletionItemKind.Class;
-        if (isJsonValueCompletion) {
+        const isJsonValueNode = isInJsonString && this.isJsonValuePosition(context);
+        if (isJsonValueNode) {
             formattedItem.filterText = `"${item.label}"`;
         } else if (isInJsonString) {
             formattedItem.filterText = `"${context.text}"`;
@@ -175,8 +175,8 @@ export class CompletionFormatter {
         const indentString = getIndentationString(editorSettings, DocumentType.JSON);
 
         // When completing a value (e.g. resource type "AWS::S3::Bucket"), just replace the value text
-        // Resource types use CompletionItemKind.Class and are always value completions in JSON
-        const isValueCompletion = item.kind === CompletionItemKind.Class;
+        // Check the syntax tree: if the node is the value child of a JSON pair, it's a value completion
+        const isValueCompletion = this.isJsonValuePosition(context);
         if (isValueCompletion) {
             // Include surrounding quotes in the range so VS Code matches the full token
             const startCol = Math.max(0, context.startPosition.column - 1);
@@ -365,5 +365,15 @@ export class CompletionFormatter {
     private isArrayType(item?: CompletionItem): boolean {
         const data = item?.data as CompletionItemData | undefined;
         return data?.type === 'array';
+    }
+
+    /**
+     * Check if the cursor is at a JSON value position using the syntax tree.
+     * A node is a value if it's the value child of a pair node.
+     */
+    private isJsonValuePosition(context: Context): boolean {
+        const node = context.syntaxNode;
+        const parent = node.parent;
+        return parent?.type === 'pair' && parent.childForFieldName('value') === node;
     }
 }

--- a/src/context/Context.ts
+++ b/src/context/Context.ts
@@ -19,7 +19,7 @@ import { entityTypeFromSection, nodeToEntity } from './semantic/EntityBuilder';
 import { normalizeIntrinsicFunction } from './semantic/Intrinsics';
 import { PropertyPath } from './syntaxtree/SyntaxTree';
 import { NodeType } from './syntaxtree/utils/NodeType';
-import { YamlNodeTypes, CommonNodeTypes } from './syntaxtree/utils/TreeSitterTypes';
+import { YamlNodeTypes, CommonNodeTypes, JsonNodeTypes, FieldNames } from './syntaxtree/utils/TreeSitterTypes';
 import { TransformContext } from './TransformContext';
 
 type QuoteCharacter = '"' | "'";
@@ -177,6 +177,18 @@ export class Context {
 
         // If we're positioned on the property name itself, it's a key not a value
         return !(this.propertyPath.at(-1) === this.text);
+    }
+
+    /**
+     * Check if the cursor is at a JSON value position using the syntax tree.
+     * Uses the tree-sitter pair node structure: a node is a value when it is
+     * the value child of a pair node.
+     */
+    public isJsonPairValue(): boolean {
+        return (
+            this.node.parent?.type === JsonNodeTypes.PAIR &&
+            this.node.parent.childForFieldName(FieldNames.VALUE) === this.node
+        );
     }
 
     public isResourceAttributeProperty(): boolean {

--- a/tools/debug_tree.ts
+++ b/tools/debug_tree.ts
@@ -143,7 +143,7 @@ class DebugTreeTool {
                 path: filePath,
                 extension: fileExtension,
                 size: content.length,
-                cloudFormationFileType: cloudFormationFileType!.toString(),
+                cloudFormationFileType: cloudFormationFileType?.toString() ?? 'unknown',
             },
             syntaxTree: {
                 rootNodeType: '',

--- a/tst/e2e/Completion.test.ts
+++ b/tst/e2e/Completion.test.ts
@@ -2542,6 +2542,41 @@ Resources:
             });
         });
 
+        describe('Enum Value Completions', () => {
+            it('should provide enum value completions for DeletionPolicy in JSON', async () => {
+                const template = getSimpleJsonTemplateText();
+                const updatedTemplate = `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyBucket": {
+      "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": ""
+    }
+  }
+}`;
+                const uri = await client.openJsonTemplate(template);
+
+                await client.changeDocument({
+                    textDocument: { uri, version: 2 },
+                    contentChanges: [{ text: updatedTemplate }],
+                });
+
+                const completions: any = await client.completion({
+                    textDocument: { uri },
+                    position: { line: 5, character: 24 },
+                });
+
+                expect(completions).toBeDefined();
+                expect(completions?.items).toBeDefined();
+                expect(completions.items.length).toBeGreaterThan(0);
+
+                const labels = completions.items.map((item: any) => item.label);
+                expect(labels).toContain('Retain');
+                expect(labels).toContain('Delete');
+
+                await client.closeDocument({ textDocument: { uri } });
+            });
+        });
         describe('Resource Attributes', () => {
             it('should provide Type attribute completion', async () => {
                 const template = getSimpleJsonTemplateText();

--- a/tst/e2e/Completion.test.ts
+++ b/tst/e2e/Completion.test.ts
@@ -2508,6 +2508,40 @@ Resources:
             });
         });
 
+        describe('Resource Type Value', () => {
+            it('should provide resource type value completions when typing in Type field', async () => {
+                const template = getSimpleJsonTemplateText();
+                const updatedTemplate = `{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Resources": {
+    "MyBucket": {
+      "Type": "AWS::S3::B"
+    }
+  }
+}`;
+                const uri = await client.openJsonTemplate(template);
+
+                await client.changeDocument({
+                    textDocument: { uri, version: 2 },
+                    contentChanges: [{ text: updatedTemplate }],
+                });
+
+                const completions: any = await client.completion({
+                    textDocument: { uri },
+                    position: { line: 4, character: 23 },
+                });
+
+                expect(completions).toBeDefined();
+                expect(completions?.items).toBeDefined();
+                expect(completions.items.length).toBeGreaterThan(0);
+
+                const labels = completions.items.map((item: any) => item.label);
+                expect(labels).toContain('AWS::S3::Bucket');
+
+                await client.closeDocument({ textDocument: { uri } });
+            });
+        });
+
         describe('Resource Attributes', () => {
             it('should provide Type attribute completion', async () => {
                 const template = getSimpleJsonTemplateText();

--- a/tst/unit/autocomplete/CompletionFormatter.test.ts
+++ b/tst/unit/autocomplete/CompletionFormatter.test.ts
@@ -542,7 +542,7 @@ describe('CompletionFormatAdapter', () => {
             const mockContext = createResourceContext('MyBucket', {
                 type: DocumentType.JSON,
                 text: 'BucketEncryption',
-                propertyPath: ['Resources', 'MyBucket', 'Properties'],
+                propertyPath: ['Resources', 'MyBucket', 'Properties', 'BucketEncryption'],
                 data: { Type: 'AWS::S3::Bucket' },
                 nodeType: 'string',
             });
@@ -779,10 +779,11 @@ describe('CompletionFormatAdapter', () => {
 
     describe('JSON filterText handling', () => {
         test('should set filterText with quotes when in JSON string context', () => {
-            const mockContext = createTopLevelContext('Resources', {
+            const mockContext = createTopLevelContext('Unknown', {
                 type: DocumentType.JSON,
                 nodeType: 'string',
                 text: 'Res',
+                propertyPath: ['Res'],
             });
             const completions: CompletionList = {
                 isIncomplete: false,
@@ -867,6 +868,67 @@ describe('CompletionFormatAdapter', () => {
             expect(result.items[0].textEdit).toBeDefined();
             // First type is 'string', so should format as string
             expect(result.items[0].textEdit?.newText).toContain('"MultiTypeProperty": "$0"');
+        });
+    });
+
+    describe('JSON value completions', () => {
+        test('should format resource type value completion without colon', () => {
+            const mockContext = createResourceContext('MyBucket', {
+                type: DocumentType.JSON,
+                text: 'AWS::S3::B',
+                propertyPath: ['Resources', 'MyBucket', 'Type'],
+                data: { Type: 'AWS::S3::B' },
+                nodeType: 'string',
+            });
+
+            const completions: CompletionList = {
+                isIncomplete: false,
+                items: [
+                    {
+                        label: 'AWS::S3::Bucket',
+                        kind: CompletionItemKind.Class,
+                    },
+                ],
+            };
+
+            const lineContent = '      "Type": "AWS::S3::B"';
+            const result = formatter.format(completions, mockContext, defaultEditorSettings, lineContent);
+
+            expect(result.items[0].textEdit).toBeDefined();
+            // Value completions should not append a colon after the value
+            expect(result.items[0].textEdit?.newText).not.toMatch(/:$/);
+            expect(result.items[0].textEdit?.newText).not.toMatch(/:\s*$/);
+            // Should include quotes around the value
+            expect(result.items[0].textEdit?.newText).toContain('"AWS::S3::Bucket"');
+            // filterText should include quotes for VS Code matching
+            expect(result.items[0].filterText).toBe('"AWS::S3::Bucket"');
+        });
+
+        test('should not replace the key when completing a value', () => {
+            const mockContext = createResourceContext('MyBucket', {
+                type: DocumentType.JSON,
+                text: 'AWS::S3::B',
+                propertyPath: ['Resources', 'MyBucket', 'Type'],
+                data: { Type: 'AWS::S3::B' },
+                nodeType: 'string',
+            });
+
+            const completions: CompletionList = {
+                isIncomplete: false,
+                items: [
+                    {
+                        label: 'AWS::S3::Bucket',
+                        kind: CompletionItemKind.Class,
+                    },
+                ],
+            };
+
+            const lineContent = '      "Type": "AWS::S3::B"';
+            const result = formatter.format(completions, mockContext, defaultEditorSettings, lineContent);
+
+            // Range should start near the value, not at column 0
+            const textEdit = result.items[0].textEdit as any;
+            expect(textEdit.range.start.character).toBeGreaterThan(0);
         });
     });
 });

--- a/tst/unit/autocomplete/CompletionFormatter.test.ts
+++ b/tst/unit/autocomplete/CompletionFormatter.test.ts
@@ -874,7 +874,10 @@ describe('CompletionFormatAdapter', () => {
     describe('JSON value completions', () => {
         function mockValueNode(context: any) {
             const node = context.syntaxNode;
-            const pairParent = { type: 'pair', childForFieldName: (name: string) => (name === 'value' ? node : null) };
+            const pairParent = {
+                type: 'pair',
+                childForFieldName: (name: string) => (name === 'value' ? node : null),
+            };
             Object.defineProperty(node, 'parent', { value: pairParent, writable: true });
         }
 

--- a/tst/unit/autocomplete/CompletionFormatter.test.ts
+++ b/tst/unit/autocomplete/CompletionFormatter.test.ts
@@ -872,6 +872,12 @@ describe('CompletionFormatAdapter', () => {
     });
 
     describe('JSON value completions', () => {
+        function mockValueNode(context: any) {
+            const node = context.syntaxNode;
+            const pairParent = { type: 'pair', childForFieldName: (name: string) => (name === 'value' ? node : null) };
+            Object.defineProperty(node, 'parent', { value: pairParent, writable: true });
+        }
+
         test('should format resource type value completion without colon', () => {
             const mockContext = createResourceContext('MyBucket', {
                 type: DocumentType.JSON,
@@ -880,6 +886,7 @@ describe('CompletionFormatAdapter', () => {
                 data: { Type: 'AWS::S3::B' },
                 nodeType: 'string',
             });
+            mockValueNode(mockContext);
 
             const completions: CompletionList = {
                 isIncomplete: false,
@@ -912,6 +919,7 @@ describe('CompletionFormatAdapter', () => {
                 data: { Type: 'AWS::S3::B' },
                 nodeType: 'string',
             });
+            mockValueNode(mockContext);
 
             const completions: CompletionList = {
                 isIncomplete: false,


### PR DESCRIPTION
CompletionFormatter.formatForJson treated all completions as key insertions — wrapping in quotes with trailing colon and replacing from column 0. This broke resource type value completion in JSON (e.g. typing AWS::S3::B inside "Type": "") because:

1. newText was '"AWS::S3::Bucket":' (colon appended to value)
2. textEdit range started at column 0, wiping out the "Type" key
3. filterText was '"AWS::S3::Bu"' which VS Code couldn't match

Fix: detect value completions (nodeType=string, isValue && !isKey) and replace only the quoted value token with the correct text.

Also fixes debug_tree.ts crash on undefined cfnFileType.

Adds e2e and unit tests for JSON resource type value completion.

fixes #450 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
