### PR TITLE
Add init.count telemetry metric for availability tracking

### DIFF
--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -161,6 +161,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         this.status = STATUS.Initializing;
 
         const startTime = performance.now();
+        this.telemetry.count('init.count', 1);
         try {
             // Initialize the worker manager
             await this.workerManager.initialize();


### PR DESCRIPTION
## Problem

The cfn-lint setup availability dashboard uses `init.success` as the denominator in the availability formula. Since `init.success` only counts successful inits (not total attempts), the formula `100 * (1 - fault/count)` produces negative percentages when faults exceed successes (e.g. -4,300%).

## Fix

Emit an `init.count` metric on every initialization attempt, before the try/catch block. This gives the dashboard a correct total-attempts denominator so the availability formula works as intended:

```
availability = 100 * (1 - init.fault / init.count)
```

## Changes

- Added `this.telemetry.count('init.count', 1)` in `CfnLintService.initialize()` before the try block

## Note

The dashboard config will also need to be updated to use `count: ['init.count']` once this metric is available in production.