### PR TITLE
Add sizeCategory attribute to lint.workspaceFile.duration metric

### DIFF
--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -417,6 +417,8 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         content: string,
     ): Promise<void> {
         const startTime = performance.now();
+        const doc = this.documentManager.get(uri);
+        const sizeCategory = doc?.getTemplateSizeCategory() ?? 'unknown';
         try {
             // Ensure folder is mounted before linting
             try {
@@ -487,6 +489,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
                 (performance.now() - startTime) / byteSize(content),
                 {
                     unit: 'ms/byte',
+                    attributes: { sizeCategory },
                 },
             );
         }


### PR DESCRIPTION
The `lint.standaloneFile.duration` metric already included `sizeCategory` as an attribute, but `lint.workspaceFile.duration` did not. This adds the same `sizeCategory` attribute for consistency, enabling CloudWatch metric filtering by template size category on both lint code paths.

### Changes

**`src/services/cfnLint/CfnLintService.ts`**
- Added `doc` and `sizeCategory` lookup at the start of `lintWorkspaceFile`
- Added `attributes: { sizeCategory }` to the `lint.workspaceFile.duration` histogram call

### Testing

This is a telemetry-only change. The `sizeCategory` value comes from `Document.getTemplateSizeCategory()` which is already tested and used by the standalone file path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.