### PR TITLE
Fix filestore bugs

### DIFF
--- a/src/datastore/FileStore.ts
+++ b/src/datastore/FileStore.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
+import { readdir, rm } from 'fs/promises';
 import { join } from 'path';
 import { Logger } from 'pino';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
@@ -44,7 +45,7 @@ export class FileStoreFactory implements DataStoreFactory {
 
         this.timeout = setTimeout(
             () => {
-                this.cleanupOldVersions();
+                void this.cleanupOldVersions();
             },
             2 * 60 * 1000,
         );
@@ -65,7 +66,7 @@ export class FileStoreFactory implements DataStoreFactory {
         this.closed = true;
         clearTimeout(this.timeout);
         clearInterval(this.metricsInterval);
-        return Promise.resolve();
+        return Promise.all([...this.stores.values()].map((store) => store.close())).then(() => {});
     }
 
     private emitMetrics(): void {
@@ -88,20 +89,20 @@ export class FileStoreFactory implements DataStoreFactory {
         });
     }
 
-    private cleanupOldVersions(): void {
+    private async cleanupOldVersions(): Promise<void> {
         if (this.closed || !existsSync(this.fileDbRoot)) return;
 
-        const entries = readdirSync(this.fileDbRoot, { withFileTypes: true });
-        for (const entry of entries) {
-            try {
+        try {
+            const entries = await readdir(this.fileDbRoot, { withFileTypes: true });
+            for (const entry of entries) {
                 if (entry.name !== Version) {
                     this.telemetry.count('oldVersion.cleanup.count', 1);
-                    rmSync(join(this.fileDbRoot, entry.name), { recursive: true, force: true });
+                    await rm(join(this.fileDbRoot, entry.name), { recursive: true, force: true });
                 }
-            } catch (error) {
-                this.log.error(error, 'Failed to cleanup old FileDB versions');
-                this.telemetry.count('oldVersion.cleanup.error', 1);
             }
+        } catch (error) {
+            this.log.error(error, 'Failed to cleanup old FileDB versions');
+            this.telemetry.count('oldVersion.cleanup.error', 1);
         }
     }
 

--- a/src/datastore/file/EncryptedFileStore.ts
+++ b/src/datastore/file/EncryptedFileStore.ts
@@ -6,17 +6,29 @@ import { lock, LockOptions, lockSync } from 'proper-lockfile';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../../telemetry/ScopedTelemetry';
 import { TelemetryService } from '../../telemetry/TelemetryService';
+import { extractErrorMessage } from '../../utils/Errors';
 import { DataStore } from '../DataStore';
 import { decrypt, encrypt } from './Encryption';
 
 const LOCK_OPTIONS_SYNC: LockOptions = { stale: 10_000 };
 const LOCK_OPTIONS: LockOptions = { ...LOCK_OPTIONS_SYNC, retries: { retries: 20, minTimeout: 50, maxTimeout: 1000 } };
 
+const LOCK_SYNC_MAX_RETRIES = 10;
+const LOCK_SYNC_INITIAL_DELAY_MS = 100;
+const LOCK_SYNC_MAX_DELAY_MS = 1000;
+
+const RENAME_MAX_RETRIES = 5;
+const RENAME_INITIAL_DELAY_MS = 50;
+
 export class EncryptedFileStore implements DataStore {
     private readonly log: Logger;
     private readonly file: string;
     private content: Record<string, unknown> = {};
     private readonly telemetry: ScopedTelemetry;
+    private lastMtimeMs = 0;
+    private lastSizeBytes = 0;
+    private inFlightOperations = 0;
+    private pendingClose: (() => void) | undefined;
 
     constructor(
         private readonly KEY: Buffer,
@@ -27,26 +39,35 @@ export class EncryptedFileStore implements DataStore {
         this.file = join(fileDbDir, `${name}.enc`);
         this.telemetry = TelemetryService.instance.get(`FileStore.${name}`);
 
-        if (existsSync(this.file)) {
-            const release = lockSync(this.file, LOCK_OPTIONS_SYNC);
+        // Create the file first if it doesn't exist so we can lock it.
+        // Another process may also be creating it — the lock serializes the read/write.
+        if (!existsSync(this.file)) {
+            this.saveSync();
+        }
+
+        this.acquireLockSyncWithRetry(() => {
             try {
                 this.content = this.readFile();
+                this.recordFileSnapshot();
             } catch (error) {
                 this.log.error(error, 'Failed to decrypt file store, recreating store');
                 this.telemetry.count('filestore.recreate', 1);
                 this.saveSync();
-            } finally {
-                release();
             }
-        } else {
-            this.saveSync();
-        }
+        });
     }
 
     get<T>(key: string): T | undefined {
-        return this.telemetry.countExecution('get', () => this.content[key] as T | undefined, {
-            captureErrorAttributes: true,
-        });
+        return this.telemetry.countExecution(
+            'get',
+            () => {
+                this.refreshIfStale();
+                return this.content[key] as T | undefined;
+            },
+            {
+                captureErrorAttributes: true,
+            },
+        );
     }
 
     put<T>(key: string, value: T): Promise<boolean> {
@@ -89,20 +110,88 @@ export class EncryptedFileStore implements DataStore {
         };
     }
 
+    /** Waits for in-flight lock operations to complete before resolving. */
+    close(): Promise<void> {
+        if (this.inFlightOperations === 0) return Promise.resolve();
+        return new Promise((resolve) => {
+            this.pendingClose = resolve;
+        });
+    }
+
     private async withLock<T>(operation: string, fn: () => Promise<T>): Promise<T> {
-        return await this.telemetry.measureAsync(
-            operation,
-            async () => {
-                const release = await lock(this.file, LOCK_OPTIONS);
+        this.inFlightOperations++;
+        try {
+            return await this.telemetry.measureAsync(
+                operation,
+                async () => {
+                    const release = await lock(this.file, LOCK_OPTIONS);
+                    try {
+                        this.content = this.readFile();
+                        this.recordFileSnapshot();
+                        return await fn();
+                    } finally {
+                        await release();
+                    }
+                },
+                { captureErrorAttributes: true },
+            );
+        } finally {
+            this.inFlightOperations--;
+            if (this.inFlightOperations === 0 && this.pendingClose) {
+                this.pendingClose();
+            }
+        }
+    }
+
+    /** Retries lockSync with exponential backoff using synchronous sleep for constructor use. */
+    private acquireLockSyncWithRetry(fn: () => void): void {
+        let delayMs = LOCK_SYNC_INITIAL_DELAY_MS;
+        for (let attempt = 0; attempt <= LOCK_SYNC_MAX_RETRIES; attempt++) {
+            try {
+                const release = lockSync(this.file, LOCK_OPTIONS_SYNC);
                 try {
-                    this.content = this.readFile();
-                    return await fn();
+                    fn();
                 } finally {
-                    await release();
+                    release();
                 }
-            },
-            { captureErrorAttributes: true },
-        );
+                return;
+            } catch (err: unknown) {
+                const isLocked =
+                    err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ELOCKED';
+                if (!isLocked || attempt === LOCK_SYNC_MAX_RETRIES) throw err;
+
+                this.log.warn(
+                    `Constructor lock contention, retry ${attempt + 1}/${LOCK_SYNC_MAX_RETRIES}: ${extractErrorMessage(err)}`,
+                );
+                this.telemetry.count('constructor.lock.retry', 1);
+
+                // Synchronous sleep — blocks the event loop, only acceptable in constructor path
+                const jitter = Math.random() * delayMs;
+                busyWaitSync(delayMs + jitter);
+                delayMs = Math.min(delayMs * 2, LOCK_SYNC_MAX_DELAY_MS);
+            }
+        }
+    }
+
+    /** Re-reads from disk if the file has been modified by another process since our last read. */
+    private refreshIfStale(): void {
+        try {
+            const stat = statSync(this.file);
+            if (stat.mtimeMs > this.lastMtimeMs || stat.size !== this.lastSizeBytes) {
+                this.content = this.readFile();
+                this.lastMtimeMs = stat.mtimeMs;
+                this.lastSizeBytes = stat.size;
+            }
+        } catch {
+            // stat or decrypt can fail if another process is mid-rename — use cached content
+            this.telemetry.count('get.refresh.failed', 1);
+        }
+    }
+
+    private recordFileSnapshot(): void {
+        const stat = statSync(this.file);
+        this.lastMtimeMs = stat.mtimeMs;
+        this.lastSizeBytes = stat.size;
     }
 
     private readFile(): Record<string, unknown> {
@@ -112,13 +201,60 @@ export class EncryptedFileStore implements DataStore {
     private saveSync() {
         const tmp = `${this.file}.${process.pid}.tmp`;
         writeFileSync(tmp, encrypt(this.KEY, JSON.stringify(this.content)));
-        renameSync(tmp, this.file);
+        this.renameSyncWithRetry(tmp, this.file);
+        this.recordFileSnapshot();
     }
 
     private async save() {
         const tmp = `${this.file}.${process.pid}.tmp`;
         await writeFile(tmp, encrypt(this.KEY, JSON.stringify(this.content)));
-        await rename(tmp, this.file);
+        await this.renameWithRetry(tmp, this.file);
+        this.recordFileSnapshot();
+    }
+
+    /** Retries rename to handle Windows EPERM when another process has the file open. */
+    private async renameWithRetry(source: string, destination: string): Promise<void> {
+        for (let attempt = 0; attempt <= RENAME_MAX_RETRIES; attempt++) {
+            try {
+                await rename(source, destination);
+                return;
+            } catch (err: unknown) {
+                const isEperm =
+                    err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EPERM';
+                if (!isEperm || attempt === RENAME_MAX_RETRIES) throw err;
+
+                this.log.warn(`Rename EPERM, retry ${attempt + 1}/${RENAME_MAX_RETRIES}`);
+                this.telemetry.count('rename.eperm.retry', 1);
+                await new Promise<void>((resolve) =>
+                    setTimeout(resolve, RENAME_INITIAL_DELAY_MS * Math.pow(2, attempt)),
+                );
+            }
+        }
+    }
+
+    private renameSyncWithRetry(source: string, destination: string): void {
+        for (let attempt = 0; attempt <= RENAME_MAX_RETRIES; attempt++) {
+            try {
+                renameSync(source, destination);
+                return;
+            } catch (err: unknown) {
+                const isEperm =
+                    err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EPERM';
+                if (!isEperm || attempt === RENAME_MAX_RETRIES) throw err;
+
+                this.log.warn(`Rename EPERM, retry ${attempt + 1}/${RENAME_MAX_RETRIES}`);
+                this.telemetry.count('rename.eperm.retry', 1);
+                busyWaitSync(RENAME_INITIAL_DELAY_MS * Math.pow(2, attempt));
+            }
+        }
+    }
+}
+
+/** Portable synchronous sleep — blocks via busy-wait. Only for constructor/sync paths. */
+function busyWaitSync(ms: number): void {
+    const end = Date.now() + ms;
+    while (Date.now() < end) {
+        /* spin */
     }
 }
 

--- a/tst/unit/datastore/FileStore.test.ts
+++ b/tst/unit/datastore/FileStore.test.ts
@@ -35,7 +35,7 @@ describe('FileStore', () => {
             expect(fileStore.get<typeof testValue>('test-key')).toEqual(testValue);
         });
 
-        it('should read from in-memory cache without hitting disk', async () => {
+        it('should detect cross-process writes via file mtime', async () => {
             const encTestDir = join(testDir, 'get-cache-test');
             mkdirSync(encTestDir, { recursive: true });
             const key = encryptionKey(2);
@@ -47,13 +47,9 @@ describe('FileStore', () => {
             const store2 = new EncryptedFileStore(key, 'test', encTestDir);
             expect(store2.get('key1')).toBe('value1');
 
-            // store1 writes key2 to disk — store2 doesn't see it via get()
-            // because get() reads from in-memory cache only
+            // store1 writes key2 to disk — store2 sees it via get()
+            // because refreshIfStale detects the mtime change
             await store1.put('key2', 'value2');
-            expect(store2.get('key2')).toBeUndefined();
-
-            // But after store2 does a write (which re-reads disk under lock), it sees key2
-            await store2.put('key3', 'value3');
             expect(store2.get('key2')).toBe('value2');
         });
     });
@@ -433,7 +429,7 @@ describe('FileStore', () => {
             clearTimeoutSpy.mockRestore();
         });
 
-        it('should cleanup old version directories', () => {
+        it('should cleanup old version directories', async () => {
             const fileDbRoot = join(testDir, 'filedb');
 
             // Create old version directories
@@ -445,7 +441,7 @@ describe('FileStore', () => {
             expect(existsSync(join(fileDbRoot, 'v1'))).toBe(true);
 
             // Trigger cleanup directly (normally runs after 2min timeout)
-            (fileFactory as any).cleanupOldVersions();
+            await (fileFactory as any).cleanupOldVersions();
 
             expect(existsSync(join(fileDbRoot, 'v1'))).toBe(false);
             expect(existsSync(join(fileDbRoot, 'v2'))).toBe(true);
@@ -457,7 +453,7 @@ describe('FileStore', () => {
 
             const newFactory = new FileStoreFactory(testDir);
             rmSync(join(testDir, 'filedb'), { recursive: true, force: true });
-            (newFactory as any).cleanupOldVersions();
+            await (newFactory as any).cleanupOldVersions();
 
             expect(existsSync(join(testDir, 'filedb'))).toBe(false);
             await newFactory.close();
@@ -526,6 +522,98 @@ describe('FileStore', () => {
             expect(result).toBeDefined();
             expect(Object.keys(result!.schemas)).toHaveLength(200);
             expect(result!.schemas['AWS::Service0::Resource']).toContain('Service0');
+            await newFactory.close();
+        });
+    });
+
+    describe('stale cache detection', () => {
+        it('should return fresh data when another instance writes to disk', async () => {
+            const encTestDir = join(testDir, 'stale-detect-test');
+            mkdirSync(encTestDir, { recursive: true });
+            const key = encryptionKey(2);
+
+            const store1 = new EncryptedFileStore(key, 'test', encTestDir);
+            const store2 = new EncryptedFileStore(key, 'test', encTestDir);
+
+            await store1.put('key1', 'value1');
+
+            // store2.get() should detect the mtime change and re-read
+            expect(store2.get('key1')).toBe('value1');
+        });
+
+        it('should not re-read when file has not changed', async () => {
+            const encTestDir = join(testDir, 'no-reread-test');
+            mkdirSync(encTestDir, { recursive: true });
+            const key = encryptionKey(2);
+
+            const store = new EncryptedFileStore(key, 'test', encTestDir);
+            await store.put('key1', 'value1');
+
+            // Multiple gets without external writes should not cause re-reads
+            expect(store.get('key1')).toBe('value1');
+            expect(store.get('key1')).toBe('value1');
+            expect(store.get('key1')).toBe('value1');
+        });
+    });
+
+    describe('graceful shutdown', () => {
+        it('should resolve close immediately when no operations are in-flight', async () => {
+            const encTestDir = join(testDir, 'close-idle-test');
+            mkdirSync(encTestDir, { recursive: true });
+            const key = encryptionKey(2);
+
+            const store = new EncryptedFileStore(key, 'test', encTestDir);
+            await expect(store.close()).resolves.toBeUndefined();
+        });
+
+        it('should wait for in-flight put to complete before close resolves', async () => {
+            const encTestDir = join(testDir, 'close-inflight-test');
+            mkdirSync(encTestDir, { recursive: true });
+            const key = encryptionKey(2);
+
+            const store = new EncryptedFileStore(key, 'test', encTestDir);
+
+            // Start a put (in-flight) and close concurrently
+            const putPromise = store.put('key', 'value');
+            const closePromise = store.close();
+
+            await Promise.all([putPromise, closePromise]);
+
+            // Data should be persisted
+            const store2 = new EncryptedFileStore(key, 'test', encTestDir);
+            expect(store2.get('key')).toBe('value');
+        });
+
+        it('should wait for all concurrent operations before close resolves', async () => {
+            const encTestDir = join(testDir, 'close-multi-test');
+            mkdirSync(encTestDir, { recursive: true });
+            const key = encryptionKey(2);
+
+            const store = new EncryptedFileStore(key, 'test', encTestDir);
+
+            const puts = Array.from({ length: 3 }, (_, i) => store.put(`key${i}`, `value${i}`));
+            const closePromise = store.close();
+
+            await Promise.all([...puts, closePromise]);
+
+            const store2 = new EncryptedFileStore(key, 'test', encTestDir);
+            for (let i = 0; i < 3; i++) {
+                expect(store2.get(`key${i}`)).toBe(`value${i}`);
+            }
+        });
+    });
+
+    describe('factory close', () => {
+        it('should await in-flight store operations on factory close', async () => {
+            const putPromise = fileStore.put('inflight-key', 'inflight-value');
+            const closePromise = fileFactory.close();
+
+            await Promise.all([putPromise, closePromise]);
+
+            // Verify data was persisted before close completed
+            const newFactory = new FileStoreFactory(testDir);
+            const newStore = newFactory.get(StoreName.public_schemas);
+            expect(newStore.get('inflight-key')).toBe('inflight-value');
             await newFactory.close();
         });
     });


### PR DESCRIPTION
## Bug 1: Constructor crashes under multi-process contention

**Problem:** `lockSync` in the constructor used `{ stale: 10_000 }` with zero retries. When two LSP servers started simultaneously (e.g., opening VSCode and IntelliJ at the same time), one acquired the lock and the other threw `ELOCKED` immediately, crashing the language server. This was the primary cause of flaky multiprocess tests.

**Fix:** `acquireLockSyncWithRetry` — retries up to 10 times with exponential backoff and jitter.

## Bug 2: `fs.rename` throws EPERM on Windows

**Problem:** Node.js `rename` uses `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING` on Windows, which throws `EPERM` when another process has the target file open for reading. This is a known Node.js issue (nodejs/node#29481, wontfix). Since `save()` is called under a file lock but `get()` reads without a lock, a concurrent `readFileSync` in another process's `refreshIfStale` could trigger this. The `EPERM` caused `save()` to throw after the in-memory content was already mutated — data loss.

**Fix:** `renameWithRetry` / `renameSyncWithRetry` — retries up to 5 times with exponential backoff on `EPERM`.

## Bug 3: `get()` returned stale data across processes

**Problem:** `get()` only read from an in-memory cache populated at construction time or during `put()`/`remove()`. If process A wrote a key and process B called `get()` without doing a write first, process B silently returned stale data indefinitely.

**Fix:** `refreshIfStale` — `get()` now checks the file's `mtime` and `size` via `statSync` before returning. If either changed since the last read, it re-reads and decrypts the file. Uses both mtime and size to handle filesystems with coarse mtime resolution (FAT32: 2s, NFS: varies).

## Bug 4: No graceful shutdown

**Problem:** `FileStoreFactory.close()` cleared timers but never waited for in-flight `put()`/`remove()`/`clear()` operations to finish. If the LSP server shut down while a write was in progress, data could be lost.

**Fix:** `EncryptedFileStore.close()` tracks in-flight operations with a counter and returns a promise that resolves only when all operations complete. `FileStoreFactory.close()` now awaits all store `close()` calls.

## Bug 5: `cleanupOldVersions` blocked the event loop

**Problem:** Used `readdirSync` + `rmSync` with `recursive: true`, which blocks the Node.js event loop. This runs after a 2-minute timeout during active LSP use, stalling completions, diagnostics, and hover for the duration of the delete.

**Fix:** Converted to async `readdir` + `rm` from `fs/promises`.

## Bug 6: Constructor TOCTOU race

**Problem:** The original constructor had `if (existsSync(file)) { lockAndRead } else { saveSync() }`. The `saveSync()` path ran without any lock. Two processes could both see the file as non-existent and race to create it. While both wrote empty `{}` (so no data loss in practice), it was architecturally unsound.

**Fix:** Constructor now always creates the file first if missing, then locks and reads. The lock serializes the read so both processes converge on consistent state.

## Bug 7: `Atomics.wait` not portable

**Problem:** The initial fix for Bug 1 used `Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), ...)` for synchronous sleep. This works in Node.js but throws `TypeError` in browser main threads (Electron renderer, web-based IDE sandboxes).

**Fix:** Replaced with a portable `busyWaitSync` using a `Date.now()` spin loop. Only used in the constructor path where blocking is acceptable.

---

## Test changes

- Updated `should read from in-memory cache` → `should detect cross-process writes via file mtime` (reflects Bug 3 fix — `get()` now detects external writes)
- Updated `should cleanup old version directories` → now `await`s the async method (reflects Bug 5 fix)
- Fixed `should resolve close immediately` to include an assertion (ESLint `vitest/expect-expect`)
- Added 6 new tests: stale cache detection (2), graceful shutdown (3), factory close draining (1)