### PR TITLE
Filedb improv

### DIFF
--- a/assets/featureFlag/alpha.json
+++ b/assets/featureFlag/alpha.json
@@ -1,49 +1,53 @@
 {
-  "version": 1,
-  "description": "Feature flags for alpha environment",
-  "features": {
-    "Constants": {
-      "enabled": false
-    },
-    "EnhancedDryRun": {
-      "enabled": true,
-      "fleetPercentage": 100,
-      "allowlistedRegions": [
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
-        "ca-central-1",
-        "ca-west-1",
-        "sa-east-1",
-        "mx-central-1",
-        "eu-north-1",
-        "eu-west-1",
-        "eu-west-2",
-        "eu-west-3",
-        "eu-central-1",
-        "eu-central-2",
-        "eu-south-1",
-        "eu-south-2",
-        "ap-east-1",
-        "ap-east-2",
-        "ap-south-1",
-        "ap-south-2",
-        "ap-northeast-1",
-        "ap-northeast-2",
-        "ap-northeast-3",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-southeast-3",
-        "ap-southeast-4",
-        "ap-southeast-5",
-        "ap-southeast-7",
-        "me-south-1",
-        "me-central-1",
-        "af-south-1",
-        "il-central-1",
-        "test-region"
-      ]
+    "version": 1,
+    "description": "Feature flags for alpha environment",
+    "features": {
+        "Constants": {
+            "enabled": false
+        },
+        "EnhancedDryRun": {
+            "enabled": true,
+            "fleetPercentage": 100,
+            "allowlistedRegions": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "ca-central-1",
+                "ca-west-1",
+                "sa-east-1",
+                "mx-central-1",
+                "eu-north-1",
+                "eu-west-1",
+                "eu-west-2",
+                "eu-west-3",
+                "eu-central-1",
+                "eu-central-2",
+                "eu-south-1",
+                "eu-south-2",
+                "ap-east-1",
+                "ap-east-2",
+                "ap-south-1",
+                "ap-south-2",
+                "ap-northeast-1",
+                "ap-northeast-2",
+                "ap-northeast-3",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "ap-southeast-3",
+                "ap-southeast-4",
+                "ap-southeast-5",
+                "ap-southeast-7",
+                "me-south-1",
+                "me-central-1",
+                "af-south-1",
+                "il-central-1",
+                "test-region"
+            ]
+        },
+        "FileDb": {
+            "enabled": true,
+            "fleetPercentage": 100
+        }
     }
-  }
 }

--- a/assets/featureFlag/beta.json
+++ b/assets/featureFlag/beta.json
@@ -1,48 +1,52 @@
 {
-  "version": 1,
-  "description": "Feature flags for beta environment",
-  "features": {
-    "Constants": {
-      "enabled": false
-    },
-    "EnhancedDryRun": {
-      "enabled": true,
-      "fleetPercentage": 100,
-      "allowlistedRegions": [
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
-        "ca-central-1",
-        "ca-west-1",
-        "sa-east-1",
-        "mx-central-1",
-        "eu-north-1",
-        "eu-west-1",
-        "eu-west-2",
-        "eu-west-3",
-        "eu-central-1",
-        "eu-central-2",
-        "eu-south-1",
-        "eu-south-2",
-        "ap-east-1",
-        "ap-east-2",
-        "ap-south-1",
-        "ap-south-2",
-        "ap-northeast-1",
-        "ap-northeast-2",
-        "ap-northeast-3",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-southeast-3",
-        "ap-southeast-4",
-        "ap-southeast-5",
-        "ap-southeast-7",
-        "me-south-1",
-        "me-central-1",
-        "af-south-1",
-        "il-central-1"
-      ]
+    "version": 1,
+    "description": "Feature flags for beta environment",
+    "features": {
+        "Constants": {
+            "enabled": false
+        },
+        "EnhancedDryRun": {
+            "enabled": true,
+            "fleetPercentage": 100,
+            "allowlistedRegions": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "ca-central-1",
+                "ca-west-1",
+                "sa-east-1",
+                "mx-central-1",
+                "eu-north-1",
+                "eu-west-1",
+                "eu-west-2",
+                "eu-west-3",
+                "eu-central-1",
+                "eu-central-2",
+                "eu-south-1",
+                "eu-south-2",
+                "ap-east-1",
+                "ap-east-2",
+                "ap-south-1",
+                "ap-south-2",
+                "ap-northeast-1",
+                "ap-northeast-2",
+                "ap-northeast-3",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "ap-southeast-3",
+                "ap-southeast-4",
+                "ap-southeast-5",
+                "ap-southeast-7",
+                "me-south-1",
+                "me-central-1",
+                "af-south-1",
+                "il-central-1"
+            ]
+        },
+        "FileDb": {
+            "enabled": false,
+            "fleetPercentage": 100
+        }
     }
-  }
 }

--- a/assets/featureFlag/prod.json
+++ b/assets/featureFlag/prod.json
@@ -1,48 +1,52 @@
 {
-  "version": 1,
-  "description": "Feature flags for prod environment",
-  "features": {
-    "Constants": {
-      "enabled": false
-    },
-    "EnhancedDryRun": {
-      "enabled": true,
-      "fleetPercentage": 100,
-      "allowlistedRegions": [
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
-        "ca-central-1",
-        "ca-west-1",
-        "sa-east-1",
-        "mx-central-1",
-        "eu-north-1",
-        "eu-west-1",
-        "eu-west-2",
-        "eu-west-3",
-        "eu-central-1",
-        "eu-central-2",
-        "eu-south-1",
-        "eu-south-2",
-        "ap-east-1",
-        "ap-east-2",
-        "ap-south-1",
-        "ap-south-2",
-        "ap-northeast-1",
-        "ap-northeast-2",
-        "ap-northeast-3",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-southeast-3",
-        "ap-southeast-4",
-        "ap-southeast-5",
-        "ap-southeast-7",
-        "me-south-1",
-        "me-central-1",
-        "af-south-1",
-        "il-central-1"
-      ]
+    "version": 1,
+    "description": "Feature flags for prod environment",
+    "features": {
+        "Constants": {
+            "enabled": false
+        },
+        "EnhancedDryRun": {
+            "enabled": true,
+            "fleetPercentage": 100,
+            "allowlistedRegions": [
+                "us-east-1",
+                "us-east-2",
+                "us-west-1",
+                "us-west-2",
+                "ca-central-1",
+                "ca-west-1",
+                "sa-east-1",
+                "mx-central-1",
+                "eu-north-1",
+                "eu-west-1",
+                "eu-west-2",
+                "eu-west-3",
+                "eu-central-1",
+                "eu-central-2",
+                "eu-south-1",
+                "eu-south-2",
+                "ap-east-1",
+                "ap-east-2",
+                "ap-south-1",
+                "ap-south-2",
+                "ap-northeast-1",
+                "ap-northeast-2",
+                "ap-northeast-3",
+                "ap-southeast-1",
+                "ap-southeast-2",
+                "ap-southeast-3",
+                "ap-southeast-4",
+                "ap-southeast-5",
+                "ap-southeast-7",
+                "me-south-1",
+                "me-central-1",
+                "af-south-1",
+                "il-central-1"
+            ]
+        },
+        "FileDb": {
+            "enabled": false,
+            "fleetPercentage": 0
+        }
     }
-  }
 }

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -1,3 +1,4 @@
+import { FeatureFlag } from '../featureFlag/FeatureFlagI';
 import { Closeable } from '../utils/Closeable';
 import { isWindows } from '../utils/Environment';
 import { pathToStorage } from '../utils/Storage';
@@ -62,8 +63,8 @@ export class MultiDataStoreFactoryProvider implements DataStoreFactoryProvider {
     private readonly memoryStoreFactory: MemoryStoreFactory;
     private readonly persistedStore: DataStoreFactory;
 
-    constructor() {
-        if (isWindows) {
+    constructor(fileDbFeatureFlag: FeatureFlag) {
+        if (fileDbFeatureFlag.isEnabled() || isWindows) {
             this.persistedStore = new FileStoreFactory(pathToStorage());
         } else {
             this.persistedStore = new LMDBStoreFactory(pathToStorage());

--- a/src/datastore/file/EncryptedFileStore.ts
+++ b/src/datastore/file/EncryptedFileStore.ts
@@ -1,45 +1,79 @@
-import { existsSync, readFileSync, renameSync, statSync, writeFileSync } from 'fs'; // eslint-disable-line no-restricted-imports -- files being checked
-import { rename, writeFile } from 'fs/promises';
-import { join } from 'path';
+import {
+    closeSync,
+    existsSync,
+    fsyncSync,
+    openSync,
+    readdirSync,
+    readFileSync, // eslint-disable-line no-restricted-imports -- atomic file primitives required here
+    renameSync,
+    statSync,
+    unlinkSync,
+    writeFileSync,
+} from 'fs';
+import { open, rename, unlink, writeFile } from 'fs/promises';
+import { basename, join } from 'path';
 import { Logger } from 'pino';
 import { lock, LockOptions, lockSync } from 'proper-lockfile';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../../telemetry/ScopedTelemetry';
 import { TelemetryService } from '../../telemetry/TelemetryService';
+import { processId } from '../../utils/Environment';
+import { sleep } from '../../utils/Retry';
 import { DataStore } from '../DataStore';
 import { decrypt, encrypt } from './Encryption';
 
-const LOCK_OPTIONS_SYNC: LockOptions = { stale: 10_000 };
-const LOCK_OPTIONS: LockOptions = { ...LOCK_OPTIONS_SYNC, retries: { retries: 20, minTimeout: 50, maxTimeout: 1000 } };
+const STALE_MS = 30_000;
+const LOCK_OPTIONS_SYNC: LockOptions = { stale: STALE_MS, realpath: false };
+const LOCK_OPTIONS: LockOptions = {
+    ...LOCK_OPTIONS_SYNC,
+    retries: { retries: 100, minTimeout: 25, maxTimeout: 200, factor: 1.5, randomize: true },
+};
+
+const RENAME_MAX_RETRIES = 10;
+const RENAME_RETRY_DELAY_MS = 50;
+const RETRIABLE_RENAME_CODES = new Set(['EPERM', 'EACCES', 'EBUSY', 'ENOENT']);
+
+const SYNC_LOCK_MAX_ATTEMPTS = 200;
+const SYNC_LOCK_RETRY_DELAY_MS = 50;
 
 export class EncryptedFileStore implements DataStore {
     private readonly log: Logger;
     private readonly file: string;
+    private readonly dir: string;
+    private readonly lockfilePath: string;
     private content: Record<string, unknown> = {};
     private readonly telemetry: ScopedTelemetry;
+    private writeQueue: Promise<void> = Promise.resolve();
+    private tempFileCounter = 0;
 
     constructor(
-        private readonly KEY: Buffer,
+        private readonly encryptionKey: Buffer,
         name: string,
         fileDbDir: string,
     ) {
         this.log = LoggerFactory.getLogger(`FileStore.${name}`);
         this.file = join(fileDbDir, `${name}.enc`);
+        this.dir = fileDbDir;
+        this.lockfilePath = join(fileDbDir, `${name}.enc.lock`);
         this.telemetry = TelemetryService.instance.get(`FileStore.${name}`);
 
-        if (existsSync(this.file)) {
-            const release = lockSync(this.file, LOCK_OPTIONS_SYNC);
-            try {
-                this.content = this.readFile();
-            } catch (error) {
-                this.log.error(error, 'Failed to decrypt file store, recreating store');
-                this.telemetry.count('filestore.recreate', 1);
+        this.cleanupStaleTmpFiles();
+
+        const release = lockSyncWithRetry(fileDbDir, { ...LOCK_OPTIONS_SYNC, lockfilePath: this.lockfilePath });
+        try {
+            if (existsSync(this.file)) {
+                try {
+                    this.content = this.readFile();
+                } catch (error) {
+                    this.log.error(error, 'Failed to decrypt file store, recreating store');
+                    this.telemetry.count('filestore.recreate', 1);
+                    this.saveSync();
+                }
+            } else {
                 this.saveSync();
-            } finally {
-                release();
             }
-        } else {
-            this.saveSync();
+        } finally {
+            release();
         }
     }
 
@@ -90,35 +124,175 @@ export class EncryptedFileStore implements DataStore {
     }
 
     private async withLock<T>(operation: string, fn: () => Promise<T>): Promise<T> {
-        return await this.telemetry.measureAsync(
-            operation,
-            async () => {
-                const release = await lock(this.file, LOCK_OPTIONS);
-                try {
-                    this.content = this.readFile();
-                    return await fn();
-                } finally {
-                    await release();
-                }
-            },
-            { captureErrorAttributes: true },
-        );
+        const previous = this.writeQueue;
+        let releaseNext!: () => void;
+        this.writeQueue = new Promise<void>((resolve) => {
+            releaseNext = resolve;
+        });
+        try {
+            await previous;
+            return await this.telemetry.measureAsync(
+                operation,
+                async () => {
+                    const release = await lock(this.dir, { ...LOCK_OPTIONS, lockfilePath: this.lockfilePath });
+                    try {
+                        this.content = existsSync(this.file) ? this.readFile() : {};
+                        return await fn();
+                    } finally {
+                        await release();
+                    }
+                },
+                { captureErrorAttributes: true },
+            );
+        } finally {
+            releaseNext();
+        }
     }
 
     private readFile(): Record<string, unknown> {
-        return JSON.parse(decrypt(this.KEY, readFileSync(this.file))) as Record<string, unknown>;
+        return JSON.parse(decrypt(this.encryptionKey, readFileSync(this.file))) as Record<string, unknown>;
     }
 
     private saveSync() {
-        const tmp = `${this.file}.${process.pid}.tmp`;
-        writeFileSync(tmp, encrypt(this.KEY, JSON.stringify(this.content)));
-        renameSync(tmp, this.file);
+        const tmp = this.tmpPath();
+        writeFileSync(tmp, encrypt(this.encryptionKey, JSON.stringify(this.content)));
+        fsyncFileSync(tmp);
+        renameSyncWithRetry(tmp, this.file);
+        fsyncDirSync(this.dir);
     }
 
     private async save() {
-        const tmp = `${this.file}.${process.pid}.tmp`;
-        await writeFile(tmp, encrypt(this.KEY, JSON.stringify(this.content)));
-        await rename(tmp, this.file);
+        const tmp = this.tmpPath();
+        await writeFile(tmp, encrypt(this.encryptionKey, JSON.stringify(this.content)));
+        await fsyncFile(tmp);
+        await renameWithRetry(tmp, this.file);
+        await fsyncDir(this.dir);
+    }
+
+    private tmpPath(): string {
+        this.tempFileCounter = (this.tempFileCounter + 1) % Number.MAX_SAFE_INTEGER;
+        return `${this.file}.${processId()}.${this.tempFileCounter}.tmp`;
+    }
+
+    private cleanupStaleTmpFiles(): void {
+        const prefix = `${basename(this.file)}.`;
+        try {
+            for (const entry of readdirSync(this.dir)) {
+                if (entry.startsWith(prefix) && entry.endsWith('.tmp')) {
+                    try {
+                        unlinkSync(join(this.dir, entry));
+                    } catch {
+                        // ignore - another process may own it
+                    }
+                }
+            }
+        } catch {
+            // ignore - dir may not exist yet
+        }
+    }
+}
+
+function fsyncFileSync(filePath: string): void {
+    const fd = openSync(filePath, 'r+');
+    try {
+        fsyncSync(fd);
+    } finally {
+        closeSync(fd);
+    }
+}
+
+function fsyncDirSync(dirPath: string): void {
+    try {
+        const fd = openSync(dirPath, 'r');
+        try {
+            fsyncSync(fd);
+        } finally {
+            closeSync(fd);
+        }
+    } catch {
+        // Windows cannot fsync directories - writes are still durable via NTFS journaling
+    }
+}
+
+async function fsyncFile(filePath: string): Promise<void> {
+    const handle = await open(filePath, 'r+');
+    try {
+        await handle.sync();
+    } finally {
+        await handle.close();
+    }
+}
+
+async function fsyncDir(dirPath: string): Promise<void> {
+    try {
+        const handle = await open(dirPath, 'r');
+        try {
+            await handle.sync();
+        } finally {
+            await handle.close();
+        }
+    } catch {
+        // Windows cannot fsync directories
+    }
+}
+
+function renameSyncWithRetry(sourcePath: string, destinationPath: string): void {
+    for (let attempt = 0; attempt < RENAME_MAX_RETRIES; attempt++) {
+        try {
+            renameSync(sourcePath, destinationPath);
+            return;
+        } catch (error) {
+            const code = (error as NodeJS.ErrnoException).code;
+            if (!code || !RETRIABLE_RENAME_CODES.has(code) || attempt === RENAME_MAX_RETRIES - 1) {
+                try {
+                    unlinkSync(sourcePath);
+                } catch {
+                    // best-effort tmp cleanup
+                }
+                throw error;
+            }
+            sleepSyncMs(RENAME_RETRY_DELAY_MS);
+        }
+    }
+}
+
+function lockSyncWithRetry(target: string, options: LockOptions): () => void {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < SYNC_LOCK_MAX_ATTEMPTS; attempt++) {
+        try {
+            return lockSync(target, options);
+        } catch (error) {
+            lastError = error;
+            if ((error as NodeJS.ErrnoException).code !== 'ELOCKED') {
+                throw error;
+            }
+            sleepSyncMs(SYNC_LOCK_RETRY_DELAY_MS);
+        }
+    }
+    throw lastError;
+}
+
+function sleepSyncMs(ms: number): void {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+async function renameWithRetry(sourcePath: string, destinationPath: string): Promise<void> {
+    for (let attempt = 0; attempt < RENAME_MAX_RETRIES; attempt++) {
+        try {
+            await rename(sourcePath, destinationPath);
+            return;
+        } catch (error) {
+            const code = (error as NodeJS.ErrnoException).code;
+            if (!code || !RETRIABLE_RENAME_CODES.has(code) || attempt === RENAME_MAX_RETRIES - 1) {
+                try {
+                    await unlink(sourcePath);
+                } catch {
+                    // best-effort tmp cleanup
+                }
+                throw error;
+            }
+            await sleep(RENAME_RETRY_DELAY_MS);
+        }
     }
 }
 

--- a/src/datastore/file/EncryptedFileStore.ts
+++ b/src/datastore/file/EncryptedFileStore.ts
@@ -139,7 +139,9 @@ export class EncryptedFileStore implements DataStore {
                         this.content = existsSync(this.file) ? this.readFile() : {};
                         return await fn();
                     } finally {
-                        await release();
+                        await release().catch(() => {
+                            // do nothing, lock was already released
+                        });
                     }
                 },
                 { captureErrorAttributes: true },

--- a/src/featureFlag/FeatureFlagProvider.ts
+++ b/src/featureFlag/FeatureFlagProvider.ts
@@ -28,7 +28,7 @@ export class FeatureFlagProvider implements Closeable {
 
     constructor(
         private readonly getLatestFeatureFlags: (env: string) => Promise<unknown>,
-        private readonly localFile = join(__dirname, 'assets', 'featureFlag', `${AwsEnv.toLowerCase()}.json`),
+        private readonly localFile = defaultLocalFile(),
         refreshIntervalMs: number = RefreshIntervalMs,
         dynamicRefreshIntervalMs: number = DynamicRefreshIntervalMs,
     ) {
@@ -134,4 +134,8 @@ function defaultConfig(configFile: string, telemetry: ScopedTelemetry): FeatureF
         log.error(err, 'Failed to read config file, using empty config');
         return { version: 1, description: 'Default empty config', features: {} };
     }
+}
+
+export function defaultLocalFile() {
+    return join(__dirname, 'assets', 'featureFlag', `${AwsEnv.toLowerCase()}.json`);
 }

--- a/src/featureFlag/FeatureFlagSupplier.ts
+++ b/src/featureFlag/FeatureFlagSupplier.ts
@@ -33,7 +33,10 @@ export class FeatureFlagSupplier implements Closeable {
         defaultConfig: () => unknown,
         dynamicRefreshIntervalMs: number = DynamicRefreshIntervalMs,
     ) {
-        for (const [key, builder] of Object.entries(FeatureBuilders)) {
+        for (const [key, builder] of Object.entries(FeatureBuilders) as [
+            FeatureFlagConfigKey,
+            FeatureFlagBuilderType,
+        ][]) {
             const ff = new DynamicFeatureFlag(
                 key,
                 () => featureConfigSupplier(key, configSupplier, defaultConfig, this.telemetry),
@@ -43,7 +46,10 @@ export class FeatureFlagSupplier implements Closeable {
             this._featureFlags.set(key, ff);
         }
 
-        for (const [key, builder] of Object.entries(TargetedFeatureBuilders)) {
+        for (const [key, builder] of Object.entries(TargetedFeatureBuilders) as [
+            TargetedFeatureFlagConfigKey,
+            TargetedFeatureFlagBuilderType<unknown>,
+        ][]) {
             const ff = new DynamicTargetedFeatureFlag(
                 key,
                 () => featureConfigSupplier(key, configSupplier, defaultConfig, this.telemetry),
@@ -100,14 +106,15 @@ function featureConfigSupplier(
     }
 }
 
-const FeatureBuilders: Record<string, FeatureFlagBuilderType> = {
+const FeatureBuilders = {
     Constants: buildStatic,
-} as const;
-const TargetedFeatureBuilders: Record<string, TargetedFeatureFlagBuilderType<unknown>> = {
+    FileDb: buildLocalHost,
+} as const satisfies Record<string, FeatureFlagBuilderType>;
+const TargetedFeatureBuilders = {
     EnhancedDryRun: (name: string, config?: FeatureFlagConfigType) => {
         return new CompoundFeatureFlag(buildLocalHost(name, config), buildRegional(name, config));
     },
-} as const;
+} as const satisfies Record<string, TargetedFeatureFlagBuilderType<unknown>>;
 
 export type FeatureFlagConfigKey = keyof typeof FeatureBuilders;
 export type TargetedFeatureFlagConfigKey = keyof typeof TargetedFeatureBuilders;

--- a/src/server/CfnExternal.ts
+++ b/src/server/CfnExternal.ts
@@ -1,4 +1,4 @@
-import { FeatureFlagProvider, getFromGitHub } from '../featureFlag/FeatureFlagProvider';
+import { FeatureFlagProvider } from '../featureFlag/FeatureFlagProvider';
 import { LspComponents } from '../protocol/LspComponents';
 import { getSamSchemas } from '../schema/GetSamSchemaTask';
 import { getRemotePrivateSchemas, getRemotePublicSchemas } from '../schema/GetSchemaTask';
@@ -41,7 +41,7 @@ export class CfnExternal implements Configurables, Closeable {
     readonly featureFlags: FeatureFlagProvider;
     readonly onlineFeatureGuard: OnlineFeatureGuard;
 
-    constructor(lsp: LspComponents, core: CfnInfraCore, overrides: Partial<CfnExternal> = {}) {
+    constructor(lsp: LspComponents, core: CfnInfraCore, overrides: Omit<Partial<CfnExternal>, 'featureFlags'> = {}) {
         this.awsClient =
             overrides.awsClient ?? new AwsClient(core.awsCredentials, core.awsMetadata?.cloudformation?.endpoint);
 
@@ -71,14 +71,7 @@ export class CfnExternal implements Configurables, Closeable {
             new GuardService(core.documentManager, core.diagnosticCoordinator, core.syntaxTreeManager);
 
         this.onlineStatus = overrides.onlineStatus ?? new OnlineStatus();
-        this.featureFlags =
-            overrides.featureFlags ??
-            new FeatureFlagProvider(
-                getFromGitHub,
-                undefined,
-                validatePositiveOrUndefined(core.awsMetadata?.featureFlags?.refreshIntervalMs),
-                validatePositiveOrUndefined(core.awsMetadata?.featureFlags?.dynamicRefreshIntervalMs),
-            );
+        this.featureFlags = core.featureFlags;
         this.onlineFeatureGuard = overrides.onlineFeatureGuard ?? new OnlineFeatureGuard(core.awsCredentials);
     }
 
@@ -87,12 +80,6 @@ export class CfnExternal implements Configurables, Closeable {
     }
 
     async close() {
-        return await closeSafely(
-            this.cfnLintService,
-            this.guardService,
-            this.schemaRetriever,
-            this.onlineStatus,
-            this.featureFlags,
-        );
+        return await closeSafely(this.cfnLintService, this.guardService, this.schemaRetriever, this.onlineStatus);
     }
 }

--- a/src/server/CfnInfraCore.ts
+++ b/src/server/CfnInfraCore.ts
@@ -5,6 +5,7 @@ import { SyntaxTreeManager } from '../context/syntaxtree/SyntaxTreeManager';
 import { DataStoreFactoryProvider, MultiDataStoreFactoryProvider } from '../datastore/DataStore';
 import { DocumentManager } from '../document/DocumentManager';
 import { DocumentMetadata } from '../document/DocumentProtocol';
+import { defaultLocalFile, FeatureFlagProvider, getFromGitHub } from '../featureFlag/FeatureFlagProvider';
 import { LspComponents } from '../protocol/LspComponents';
 import { DiagnosticCoordinator } from '../services/DiagnosticCoordinator';
 import { SettingsManager } from '../settings/SettingsManager';
@@ -15,6 +16,7 @@ import { UsageTracker } from '../usageTracker/UsageTracker';
 import { UsageTrackerMetrics } from '../usageTracker/UsageTrackerMetrics';
 import { Closeable, closeSafely } from '../utils/Closeable';
 import { Configurable, Configurables } from '../utils/Configurable';
+import { validatePositiveOrUndefined } from '../utils/Number';
 import { AwsMetadata, ExtendedInitializeParams } from './InitParams';
 
 /**
@@ -24,6 +26,7 @@ import { AwsMetadata, ExtendedInitializeParams } from './InitParams';
  */
 export class CfnInfraCore implements Configurables, Closeable {
     readonly awsMetadata?: AwsMetadata;
+    readonly featureFlags: FeatureFlagProvider;
     readonly dataStoreFactory: DataStoreFactoryProvider;
     readonly clientMessage: ClientMessage;
     readonly settingsManager: SettingsManager;
@@ -45,7 +48,16 @@ export class CfnInfraCore implements Configurables, Closeable {
         overrides: Partial<CfnInfraCore> = {},
     ) {
         this.awsMetadata = initializeParams.initializationOptions?.aws;
-        this.dataStoreFactory = overrides.dataStoreFactory ?? new MultiDataStoreFactoryProvider();
+        this.featureFlags =
+            overrides.featureFlags ??
+            new FeatureFlagProvider(
+                getFromGitHub,
+                defaultLocalFile(),
+                validatePositiveOrUndefined(this.awsMetadata?.featureFlags?.refreshIntervalMs),
+                validatePositiveOrUndefined(this.awsMetadata?.featureFlags?.dynamicRefreshIntervalMs),
+            );
+        this.dataStoreFactory =
+            overrides.dataStoreFactory ?? new MultiDataStoreFactoryProvider(this.featureFlags.get('FileDb'));
         this.clientMessage = overrides.clientMessage ?? new ClientMessage(lspComponents.communication);
         this.settingsManager =
             overrides.settingsManager ?? new SettingsManager(lspComponents.workspace, this.awsMetadata?.settings);
@@ -82,6 +94,11 @@ export class CfnInfraCore implements Configurables, Closeable {
     }
 
     async close() {
-        return await closeSafely(this.documentManager, this.dataStoreFactory, TelemetryService.instance);
+        return await closeSafely(
+            this.documentManager,
+            this.dataStoreFactory,
+            this.featureFlags,
+            TelemetryService.instance,
+        );
     }
 }

--- a/src/server/CfnLspProviders.ts
+++ b/src/server/CfnLspProviders.ts
@@ -73,7 +73,7 @@ export class CfnLspProviders implements Configurables, Closeable {
 
         this.hoverRouter =
             overrides.hoverRouter ??
-            new HoverRouter(core.contextManager, external.schemaRetriever, external.featureFlags.get('Constants'));
+            new HoverRouter(core.contextManager, external.schemaRetriever, core.featureFlags.get('Constants'));
         this.completionRouter = overrides.completionRouter ?? CompletionRouter.create(core, external, this);
 
         this.definitionProvider = overrides.definitionProvider ?? new DefinitionProvider(core.contextManager);

--- a/src/utils/Environment.ts
+++ b/src/utils/Environment.ts
@@ -82,3 +82,7 @@ export const isLinux = process.platform === 'linux';
 export const ProcessType = `${process.platform}${process.env.BUILD_TARGET ? `-${process.env.BUILD_TARGET}` : ''}-${process.arch}`;
 export const ServiceEnv = `${getNodeEnv()}-${getAwsEnv()}`;
 export const Service = `${ExtensionId}-${ExtensionVersion}`;
+
+export function processId() {
+    return process.pid;
+}

--- a/src/utils/Retry.ts
+++ b/src/utils/Retry.ts
@@ -11,7 +11,7 @@ export type RetryOptions = {
     totalTimeoutMs: number;
 };
 
-function sleep(ms: number): Promise<void> {
+export function sleep(ms: number): Promise<void> {
     return new Promise<void>((resolve) => {
         setTimeout(resolve, ms);
     });

--- a/tools/telemetry-generator.ts
+++ b/tools/telemetry-generator.ts
@@ -193,7 +193,11 @@ function main() {
         stubInterface<LspSystemHandlers>(),
     );
 
-    const dataStoreFactory = new MultiDataStoreFactoryProvider();
+    const featureFlags = new FeatureFlagProvider(
+        getFromGitHub,
+        join(__dirname, '..', 'assets', 'featureFlag', `${AwsEnv}.json`),
+    );
+    const dataStoreFactory = new MultiDataStoreFactoryProvider(featureFlags.get('FileDb'));
     const core = new CfnInfraCore(
         lsp,
         {
@@ -213,10 +217,6 @@ function main() {
     const schemaStore = new SchemaStore(dataStoreFactory);
     const external = new CfnExternal(lsp, core, {
         schemaStore,
-        featureFlags: new FeatureFlagProvider(
-            getFromGitHub,
-            join(__dirname, '..', 'assets', 'featureFlag', `${AwsEnv}.json`),
-        ),
     });
 
     const providers = new CfnLspProviders(core, external, {

--- a/tst/unit/datastore/FileStore.test.ts
+++ b/tst/unit/datastore/FileStore.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'child_process';
 import { randomUUID as v4 } from 'crypto';
-import { rmSync, mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync } from 'fs';
+import { rmSync, mkdirSync, writeFileSync, existsSync, readdirSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { promisify } from 'util';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -328,6 +328,62 @@ describe('FileStore', () => {
 
             const files = readdirSync(encTestDir);
             expect(files.filter((f) => f.endsWith('.tmp'))).toHaveLength(0);
+        });
+    });
+
+    describe('stale tmp cleanup', () => {
+        it('should remove leftover tmp files from prior crashed processes on construction', () => {
+            const encTestDir = join(testDir, 'stale-tmp-test');
+            mkdirSync(encTestDir, { recursive: true });
+            const key = encryptionKey(2);
+
+            // Simulate leftover tmp files from a crashed process
+            writeFileSync(join(encTestDir, 'test.enc.9999.1.tmp'), 'stale1');
+            writeFileSync(join(encTestDir, 'test.enc.8888.2.tmp'), 'stale2');
+            // Unrelated file should survive
+            writeFileSync(join(encTestDir, 'other.txt'), 'keep');
+
+            new EncryptedFileStore(key, 'test', encTestDir);
+
+            const files = readdirSync(encTestDir);
+            expect(files.filter((f) => f.endsWith('.tmp'))).toHaveLength(0);
+            expect(files).toContain('other.txt');
+        });
+
+        it('should not remove tmp files belonging to a different store name', () => {
+            const encTestDir = join(testDir, 'stale-tmp-isolation');
+            mkdirSync(encTestDir, { recursive: true });
+            const key = encryptionKey(2);
+
+            // tmp file for a different store name
+            writeFileSync(join(encTestDir, 'other.enc.9999.1.tmp'), 'other-store');
+
+            new EncryptedFileStore(key, 'test', encTestDir);
+
+            const files = readdirSync(encTestDir);
+            expect(files).toContain('other.enc.9999.1.tmp');
+        });
+    });
+
+    describe('withLock file deletion resilience', () => {
+        it('should handle file being deleted between writes', async () => {
+            const encTestDir = join(testDir, 'deleted-file-test');
+            mkdirSync(encTestDir, { recursive: true });
+            const key = encryptionKey(2);
+
+            const store = new EncryptedFileStore(key, 'test', encTestDir);
+            await store.put('key1', 'value1');
+
+            // Simulate another process deleting the file
+            unlinkSync(join(encTestDir, 'test.enc'));
+
+            // Next write should recreate the file (withLock checks existsSync)
+            await store.put('key2', 'value2');
+
+            // Only key2 should exist — key1 was lost with the deleted file
+            const store2 = new EncryptedFileStore(key, 'test', encTestDir);
+            expect(store2.get('key1')).toBeUndefined();
+            expect(store2.get('key2')).toBe('value2');
         });
     });
 

--- a/tst/unit/featureFlag/FeatureFlagSupplier.test.ts
+++ b/tst/unit/featureFlag/FeatureFlagSupplier.test.ts
@@ -25,7 +25,7 @@ describe('FeatureFlagSupplier', () => {
     it('should initialize with feature flags', () => {
         const supplier = new FeatureFlagSupplier(configSupplier, throwError);
 
-        expect([...supplier.featureFlags.keys()]).toEqual(['Constants']);
+        expect([...supplier.featureFlags.keys()]).toEqual(['Constants', 'FileDb']);
         expect(supplier.featureFlags.get('Constants')?.isEnabled()).toBe(false);
 
         expect([...supplier.targetedFeatureFlags.keys()]).toEqual(['EnhancedDryRun']);
@@ -52,7 +52,7 @@ describe('FeatureFlagSupplier', () => {
     it('should handle invalid config and fallback to default', () => {
         const supplier = new FeatureFlagSupplier(() => 'invalid', configSupplier);
 
-        expect([...supplier.featureFlags.keys()]).toEqual(['Constants']);
+        expect([...supplier.featureFlags.keys()]).toEqual(['Constants', 'FileDb']);
         expect([...supplier.targetedFeatureFlags.keys()]).toEqual(['EnhancedDryRun']);
 
         supplier.close();
@@ -61,7 +61,7 @@ describe('FeatureFlagSupplier', () => {
     it('should handle undefined config', () => {
         const supplier = new FeatureFlagSupplier(() => undefined, configSupplier);
 
-        expect([...supplier.featureFlags.keys()]).toEqual(['Constants']);
+        expect([...supplier.featureFlags.keys()]).toEqual(['Constants', 'FileDb']);
         expect([...supplier.targetedFeatureFlags.keys()]).toEqual(['EnhancedDryRun']);
 
         supplier.close();

--- a/tst/utils/MockServerComponents.ts
+++ b/tst/utils/MockServerComponents.ts
@@ -362,6 +362,7 @@ export function createMockComponents(o: Partial<CfnLspServerComponentsType> = {}
 
     const core: MockInfraCoreComponents = {
         dataStoreFactory,
+        featureFlags: overrides.featureFlags ?? stubInterface<FeatureFlagProvider>(),
         clientMessage: overrides.clientMessage ?? createMockClientMessage(),
         settingsManager: overrides.settingsManager ?? createMockSettingsManager(),
         syntaxTreeManager: overrides.syntaxTreeManager ?? createMockSyntaxTreeManager(),

--- a/tst/utils/TestExtension.ts
+++ b/tst/utils/TestExtension.ts
@@ -133,8 +133,14 @@ export class TestExtension implements Closeable {
                     const lsp = this.serverConnection.components;
                     LoggerFactory.reconfigure('warn');
 
-                    const dataStoreFactory = new MultiDataStoreFactoryProvider();
+                    const ffFile = join(__dirname, '..', '..', 'assets', 'featureFlag', 'alpha.json');
+                    const featureFlags = new FeatureFlagProvider((_env) => {
+                        return Promise.resolve(JSON.parse(readFileSync(ffFile, 'utf8')));
+                    }, ffFile);
+
+                    const dataStoreFactory = new MultiDataStoreFactoryProvider(featureFlags.get('FileDb'));
                     this.core = new CfnInfraCore(lsp, params, {
+                        featureFlags,
                         dataStoreFactory,
                     });
 
@@ -150,14 +156,10 @@ export class TestExtension implements Closeable {
                         },
                     );
 
-                    const ffFile = join(__dirname, '..', '..', 'assets', 'featureFlag', 'alpha.json');
                     this.external = new CfnExternal(lsp, this.core, {
                         schemaStore,
                         schemaRetriever,
                         cfnLintService: createMockCfnLintService(),
-                        featureFlags: new FeatureFlagProvider((_env) => {
-                            return Promise.resolve(JSON.parse(readFileSync(ffFile, 'utf8')));
-                        }, ffFile),
                         awsClient: config.awsClientFactory?.(
                             this.core.awsCredentials,
                             this.core.awsMetadata?.cloudformation?.endpoint,


### PR DESCRIPTION
## Purpose

Prepare the CloudFormation Language Server to migrate its persistence layer from LMDB to an encrypted file-based datastore on all platforms (currently only Windows uses it). The migration is gated behind a new feature flag and the file store itself is hardened for production use.

---

## Two Core Changes

### 1. New `FileDb` Feature Flag

A new feature flag controls whether the file-based datastore is used instead of LMDB on non-Windows systems.

| Environment | Enabled | Fleet % |
|-------------|---------|---------|
| Alpha       | Yes     | 100%    |
| Beta        | No      | 100%    |
| Prod        | No      | 0%      |

Only alpha is opted in 

### 2. EncryptedFileStore Hardening

The file-based datastore received significant reliability improvements across six areas:

- **Atomic writes with fsync** — After writing a temp file, data is flushed to disk before the atomic rename. The parent directory is also fsynced to ensure the directory entry is durable. Windows silently skips directory fsync since NTFS journaling handles durability.

- **Rename retry logic** — File renames now retry up to 10 times on transient OS errors (EPERM, EACCES, EBUSY, ENOENT). This handles Windows-specific issues like antivirus or indexers holding file handles. Failed temp files are cleaned up on final failure.

- **Serialized write queue** — Writes are chained through an internal promise queue so multiple async operations within the same process don't interleave. Each write waits for the previous one to finish before acquiring the cross-process file lock.

- **Improved locking strategy** — The lock target changed from the data file itself to the parent directory with an explicit lockfile path. This avoids issues where the data file gets replaced via rename while a lock still references it. Lock retry parameters were retuned: more retries, shorter intervals, and randomized jitter to reduce contention. The synchronous lock used during construction now retries instead of failing immediately.

- **Stale temp file cleanup** — On startup, the store scans its directory and removes leftover `.tmp` files from prior crashed processes. Only files matching the store's own name prefix are removed.

- **Resilience to external file deletion** — If the data file is deleted between operations (e.g., by another process), the store gracefully starts from an empty state instead of throwing an error.

---