### PR TITLE
Switch Guard and CfnLint telemetry to emitting error type

### DIFF
--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -192,7 +192,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             }
         } catch (error) {
             this.status = STATUS.Uninitialized;
-            this.telemetry.error('init.fault', error, undefined, { captureErrorAttributes: true });
+            this.telemetry.error('init.fault', error, undefined, { captureErrorType: true });
             this.telemetry.histogram('init.duration', performance.now() - startTime, { unit: 'ms' });
             throw new Error(`Failed to initialize Pyodide worker: ${extractErrorMessage(error)}`);
         }
@@ -233,7 +233,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             this.logError('mounting folder', error);
             const errorType = this.classifyLintError(error);
             this.telemetry.error('mount.fault', error, undefined, {
-                captureErrorAttributes: true,
+                captureErrorType: true,
                 attributes: { errorType },
             });
             throw new MountError(`Failed to mount folder ${mountDir}`, error instanceof Error ? error : undefined);
@@ -331,7 +331,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      * @param uri The document URI
      * @param fileType The CloudFormation file type
      */
-    @Count({ name: 'lint.standaloneFile', captureErrorAttributes: true })
+    @Count({ name: 'lint.standaloneFile', captureErrorType: true })
     private async lintStandaloneFile(content: string, uri: string, fileType: CloudFormationFileType): Promise<void> {
         const startTime = performance.now();
         const doc = this.documentManager.get(uri);
@@ -364,7 +364,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             // Only count as lint.error if it's a cfn-lint failure, not infrastructure issues
             if (!this.isInfrastructureError(errorType)) {
                 this.telemetry.error('lint.error', error, undefined, {
-                    captureErrorAttributes: true,
+                    captureErrorType: true,
                     attributes: {
                         fileType,
                         errorType,
@@ -409,7 +409,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      * @param fileType The CloudFormation file type
      * @param content The document content (used for GitSync deployment files)
      */
-    @Count({ name: 'lint.workspaceFile', captureErrorAttributes: true })
+    @Count({ name: 'lint.workspaceFile', captureErrorType: true })
     private async lintWorkspaceFile(
         uri: string,
         folder: WorkspaceFolder,
@@ -476,7 +476,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             // Only count as lint.error if it's a cfn-lint failure, not infrastructure issues
             if (!this.isInfrastructureError(errorType)) {
                 this.telemetry.error('lint.error', error, undefined, {
-                    captureErrorAttributes: true,
+                    captureErrorType: true,
                     attributes: {
                         fileType,
                         errorType,

--- a/src/services/cfnLint/PyodideWorkerManager.ts
+++ b/src/services/cfnLint/PyodideWorkerManager.ts
@@ -140,17 +140,17 @@ export class PyodideWorkerManager {
                     },
                     reject: (reason: Error) => {
                         this.worker = undefined;
-                        this.telemetry.error('pyodide.init.fault', reason, undefined, { captureErrorAttributes: true });
+                        this.telemetry.error('pyodide.init.fault', reason, undefined, { captureErrorType: true });
 
                         // Try to determine if it was a PyPI or wheels failure
                         const errorMessage = reason.message || '';
                         if (errorMessage.includes('PyPI')) {
                             this.telemetry.error('init.pypi.fault', reason, undefined, {
-                                captureErrorAttributes: true,
+                                captureErrorType: true,
                             });
                         } else if (errorMessage.includes('wheels') || errorMessage.includes('wheel')) {
                             this.telemetry.error('init.wheels.fault', reason, undefined, {
-                                captureErrorAttributes: true,
+                                captureErrorType: true,
                             });
                         }
 

--- a/src/services/guard/GuardService.ts
+++ b/src/services/guard/GuardService.ts
@@ -184,7 +184,7 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
      * @param uri The document URI
      * @param forceUseContent If true, always use the provided content (for consistency with CfnLintService)
      */
-    @Count({ name: 'validate', captureErrorAttributes: true })
+    @Count({ name: 'validate', captureErrorType: true })
     async validate(content: string, uri: string, _forceUseContent?: boolean): Promise<void> {
         const fileType = this.documentManager.get(uri)?.cfnFileType;
 
@@ -254,7 +254,7 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
                 // Publish empty diagnostics to clear any previous Guard diagnostics
                 this.publishDiagnostics(uri, []);
                 this.telemetry.error('parser.error', error, undefined, {
-                    captureErrorAttributes: true,
+                    captureErrorType: true,
                     attributes: { errorType: 'ParseError' },
                 });
                 // Parse errors are developer issues, not service availability issues
@@ -264,7 +264,7 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
             // Check for WASM errors
             if (errorMessage.includes('WASM') || errorMessage.includes('wasm')) {
                 this.telemetry.error('wasm.error', error, undefined, {
-                    captureErrorAttributes: true,
+                    captureErrorType: true,
                     attributes: { errorType: 'WasmError' },
                 });
             }
@@ -275,13 +275,13 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
                 errorMessage.includes('Memory') ||
                 errorMessage.includes('out of memory')
             ) {
-                this.telemetry.error('memory.threshold.exceeded', error, undefined, { captureErrorAttributes: true });
+                this.telemetry.error('memory.threshold.exceeded', error, undefined, { captureErrorType: true });
             }
 
             // For other errors (WASM issues, timeouts, etc.), log as error and show diagnostic
             this.publishErrorDiagnostics(uri, errorMessage);
             this.telemetry.error('validate.error', error, undefined, {
-                captureErrorAttributes: true,
+                captureErrorType: true,
                 attributes: { fileType, errorType: 'Unknown' },
             });
         } finally {
@@ -672,7 +672,7 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
                 this.log.info(`Loaded ${customRules.length} rules from custom file: ${this.settings.rulesFile}`);
             } catch (error) {
                 this.telemetry.error('rules.load.error', error, undefined, {
-                    captureErrorAttributes: true,
+                    captureErrorType: true,
                     attributes: { errorType: 'CustomFile' },
                 });
                 this.log.error(
@@ -711,7 +711,7 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
                     }
                 } catch (error) {
                     this.telemetry.error('rules.load.error', error, undefined, {
-                        captureErrorAttributes: true,
+                        captureErrorType: true,
                         attributes: { pack: packName, errorType: 'PackLoad' },
                     });
                     this.log.error(`Failed to get rules for pack '${packName}': ${extractErrorMessage(error)}`);


### PR DESCRIPTION
*Description of changes:*

Ensuring only error type is being emitted for Guard and CfnLint telemetry due to being unable to control what third party services send back in the error message and error stack trace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
