### PR TITLE
fix: make guard rule pack lookup case-insensitive

### DIFF
--- a/src/services/guard/GeneratedGuardRules.ts
+++ b/src/services/guard/GeneratedGuardRules.ts
@@ -4567,7 +4567,7 @@ rule WORKSPACE_ENCRYPTION_ENABLED when %workspace_encryption_enabled !empty {
 };
 
 export const RULE_PACKS: Record<string, string[]> = {
-    'ABS-CCIGv2-Material': [
+    'abs-ccigv2-material': [
         'CLOUD_TRAIL_CLOUD_WATCH_LOGS_ENABLED',
         'CLOUDTRAIL_S3_DATAEVENTS_ENABLED',
         'CLOUDWATCH_ALARM_ACTION_CHECK',
@@ -4638,7 +4638,7 @@ export const RULE_PACKS: Record<string, string[]> = {
         'S3_BUCKET_DEFAULT_LOCK_ENABLED',
         'S3_BUCKET_VERSIONING_ENABLED',
     ],
-    'ABS-CCIGv2-Standard': [
+    'abs-ccigv2-standard': [
         'CLOUD_TRAIL_CLOUD_WATCH_LOGS_ENABLED',
         'CLOUDTRAIL_S3_DATAEVENTS_ENABLED',
         'CLOUDWATCH_ALARM_ACTION_CHECK',
@@ -5932,7 +5932,7 @@ export const RULE_PACKS: Record<string, string[]> = {
         'REDSHIFT_BACKUP_ENABLED',
         'S3_BUCKET_VERSIONING_ENABLED',
     ],
-    'FDA-21CFR-Part-11': [
+    'fda-21cfr-part-11': [
         'S3_BUCKET_VERSIONING_ENABLED',
         'S3_BUCKET_DEFAULT_LOCK_ENABLED',
         'CLOUD_TRAIL_LOG_FILE_VALIDATION_ENABLED',
@@ -7463,7 +7463,7 @@ export const RULE_PACKS: Record<string, string[]> = {
         'CLOUDWATCH_ALARM_ACTION_CHECK',
         'SECRETSMANAGER_USING_CMK',
     ],
-    'wa-Reliability-Pillar': [
+    'wa-reliability-pillar': [
         'LAMBDA_CONCURRENCY_CHECK',
         'LAMBDA_DLQ_CHECK',
         'ELASTICSEARCH_IN_VPC_ONLY',
@@ -7488,7 +7488,7 @@ export const RULE_PACKS: Record<string, string[]> = {
         'RDS_INSTANCE_DELETION_PROTECTION_ENABLED',
         'S3_BUCKET_DEFAULT_LOCK_ENABLED',
     ],
-    'wa-Security-Pillar': [
+    'wa-security-pillar': [
         'CODEBUILD_PROJECT_ENVVAR_AWSCRED_CHECK',
         'ECS_TASK_DEFINITION_USER_FOR_HOST_MODE_CHECK',
         'IAM_NO_INLINE_POLICY_CHECK',
@@ -7549,7 +7549,7 @@ export const RULE_PACKS: Record<string, string[]> = {
 };
 
 export function getRulesForPack(packName: string): GuardRuleData[] {
-    const ruleNames = RULE_PACKS[packName];
+    const ruleNames = RULE_PACKS[packName.toLowerCase()];
     if (!ruleNames) {
         throw new Error('Unknown rule pack: ' + packName);
     }

--- a/src/services/guard/GuardService.ts
+++ b/src/services/guard/GuardService.ts
@@ -640,7 +640,7 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
         const availablePackSet = new Set(availablePackNames);
 
         for (const enabledPack of this.settings.enabledRulePacks) {
-            if (!availablePackSet.has(enabledPack)) {
+            if (!availablePackSet.has(enabledPack.toLowerCase())) {
                 errors.push(`Rule pack '${enabledPack}' is enabled but not available`);
             }
         }

--- a/tools/generate-guard-rules.ts
+++ b/tools/generate-guard-rules.ts
@@ -445,7 +445,7 @@ async function main() {
             .filter((f) => f.startsWith('rule_set_') && f.endsWith('.json'));
 
         for (const file of mappingFiles) {
-            const packName = file.replace('rule_set_', '').replace('.json', '').replace(/_/g, '-');
+            const packName = file.replace('rule_set_', '').replace('.json', '').replace(/_/g, '-').toLowerCase();
             const mappingPath = path.join(mappingsDir, file);
             const mapping = JSON.parse(fs.readFileSync(mappingPath, 'utf8'));
 


### PR DESCRIPTION
## Problem

Guard rule pack lookup fails with `Unknown rule pack: PCI-DSS-3-2-1` because the IDE sends pack names with their original casing (e.g. `PCI-DSS-3-2-1`, `FedRAMP-Moderate`) but the `RULE_PACKS` keys had inconsistent casing — some lowercase, some mixed case.

## Fix

- **`tools/generate-guard-rules.ts`** — `.toLowerCase()` pack names at generation time
- **`src/services/guard/GeneratedGuardRules.ts`** — all 5 mixed-case keys normalized to lowercase
- **`src/services/guard/GuardService.ts`** — `.toLowerCase()` on input in `getRulesForPack` and `validateRuleConfiguration`

## Testing

- 3248 unit tests pass, lint clean
- Any casing of pack names now resolves correctly