### PR TITLE
Create a local file handler for concurrent read/writes

### DIFF
--- a/src/datastore/LMDBStoreFactory.ts
+++ b/src/datastore/LMDBStoreFactory.ts
@@ -4,7 +4,7 @@ import { open, RootDatabase, RootDatabaseOptionsWithPath } from 'lmdb';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
 import { Telemetry } from '../telemetry/TelemetryDecorator';
-import { isWindows } from '../utils/Environment';
+import { isWindows, processId } from '../utils/Environment';
 import { extractErrorMessage } from '../utils/Errors';
 import { formatNumber, toString } from '../utils/String';
 import { DataStore, DataStoreFactory, PersistedStores, StoreName } from './DataStore';
@@ -21,7 +21,7 @@ export class LMDBStoreFactory implements DataStoreFactory {
     private readonly metricsInterval: NodeJS.Timeout;
 
     private env: RootDatabase;
-    private openPid = process.pid;
+    private openPid = processId();
     private closed = false;
 
     private readonly stores = new Map<StoreName, LMDBStore>();
@@ -119,9 +119,9 @@ export class LMDBStoreFactory implements DataStoreFactory {
     }
 
     private ensureValidEnv(): void {
-        if (process.pid !== this.openPid) {
+        if (processId() !== this.openPid) {
             this.telemetry.count('process.forked', 1);
-            this.log.warn({ oldPid: this.openPid, newPid: process.pid }, 'Process fork detected, reopening LMDB');
+            this.log.warn({ oldPid: this.openPid, newPid: processId() }, 'Process fork detected, reopening LMDB');
 
             try {
                 this.reopenEnv();
@@ -139,7 +139,7 @@ export class LMDBStoreFactory implements DataStoreFactory {
 
     private recoverFromFork(): void {
         this.telemetry.count('forked.recover', 1);
-        this.log.warn({ oldPid: this.openPid, newPid: process.pid }, 'Process fork detected, reopening LMDB');
+        this.log.warn({ oldPid: this.openPid, newPid: processId() }, 'Process fork detected, reopening LMDB');
 
         try {
             this.reopenEnv();
@@ -178,7 +178,7 @@ export class LMDBStoreFactory implements DataStoreFactory {
     private reopenEnv(): void {
         this.telemetry.count('env.reopen', 1);
         this.env = createEnv(this.lmdbDir).env;
-        this.openPid = process.pid;
+        this.openPid = processId();
         this.log.warn('Recreated LMDB environment');
     }
 

--- a/src/datastore/file/EncryptedFile.ts
+++ b/src/datastore/file/EncryptedFile.ts
@@ -1,14 +1,9 @@
-import { existsSync, readFileSync, statSync, unlinkSync } from 'fs'; // eslint-disable-line no-restricted-imports -- files being checked
-import { rename, unlink, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { Logger } from 'pino';
-import { lock, LockOptions, lockSync } from 'proper-lockfile';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { TelemetryService } from '../../telemetry/TelemetryService';
+import { LocalFile } from '../../utils/LocalFile';
 import { decrypt, encrypt } from './Encryption';
-
-const LOCK_OPTIONS_SYNC: LockOptions = { stale: 10_000 };
-const LOCK_OPTIONS: LockOptions = { ...LOCK_OPTIONS_SYNC, retries: { retries: 20, minTimeout: 50, maxTimeout: 1000 } };
 
 /**
  * Encrypted on-disk envelope. Stores the original key alongside the value
@@ -21,30 +16,25 @@ export type EncryptedEntry<T = unknown> = {
 
 export class EncryptedFile {
     private readonly log: Logger;
-    private readonly file: string;
+    private readonly file: LocalFile;
     private key: string | undefined;
     private content: EncryptedEntry | undefined = undefined;
 
     constructor(
-        private readonly KEY: Buffer,
+        private readonly encryptionKey: Buffer,
         storeName: string,
         fileName: string,
         fileDbDir: string,
     ) {
         this.log = LoggerFactory.getLogger(`EncryptedFile.${storeName}`);
-        this.file = join(fileDbDir, fileName);
+        this.file = new LocalFile(join(fileDbDir, fileName));
 
-        if (this.exists()) {
-            const release = lockSync(this.file, LOCK_OPTIONS_SYNC);
-            try {
-                this.content = this.readFile();
-            } catch (error) {
-                this.log.error(error, 'Failed to decrypt file store, deleting store');
-                TelemetryService.instance.get(`FileStore.${storeName}`).count('filestore.recreate', 1);
-                unlinkSync(this.file);
-            } finally {
-                release();
-            }
+        try {
+            this.content = this.readFile();
+        } catch (error) {
+            this.log.error(error, 'Failed to decrypt, deleting file');
+            TelemetryService.instance.get(`FileStore.${storeName}`).count('filestore.recreate', 1);
+            this.file.unsafeRemove();
         }
     }
 
@@ -56,7 +46,7 @@ export class EncryptedFile {
     }
 
     exists() {
-        return existsSync(this.file);
+        return this.file.exists();
     }
 
     entry(): EncryptedEntry | undefined {
@@ -73,78 +63,24 @@ export class EncryptedFile {
         }
 
         this.content = { key: this.key, value };
-
-        if (!this.exists()) {
-            await this.save();
-            return true;
-        }
-
-        const release = await this.tryLock();
-        if (!release) {
-            await this.save();
-            return true;
-        }
-        try {
-            await this.save();
-            return true;
-        } finally {
-            await release();
-        }
+        return await this.file.write(encrypt(this.encryptionKey, JSON.stringify(this.content)));
     }
 
     async remove() {
         this.content = undefined;
-
-        if (!this.exists()) {
-            return true;
-        }
-
-        const release = await this.tryLock();
-        if (!release) {
-            return true;
-        }
-        try {
-            await unlink(this.file);
-            return true;
-        } catch (error: unknown) {
-            if (isFileNotFound(error)) {
-                return true;
-            }
-            throw error;
-        } finally {
-            await release();
-        }
-    }
-
-    /** Returns the release function, or undefined if the file was deleted by another process. */
-    private async tryLock(): Promise<(() => Promise<void>) | undefined> {
-        try {
-            return await lock(this.file, LOCK_OPTIONS);
-        } catch (error: unknown) {
-            if (isFileNotFound(error)) {
-                return undefined;
-            }
-            throw error;
-        }
+        return await this.file.remove();
     }
 
     fileSize(): number {
-        return existsSync(this.file) ? statSync(this.file).size : 0;
+        return this.file.fileBytes();
     }
 
-    private readFile(): EncryptedEntry {
-        return JSON.parse(decrypt(this.KEY, readFileSync(this.file))) as EncryptedEntry;
+    private readFile(): EncryptedEntry | undefined {
+        const contents = this.file.readBytes();
+        if (contents !== undefined) {
+            return JSON.parse(decrypt(this.encryptionKey, contents)) as EncryptedEntry;
+        }
+
+        return;
     }
-
-    private async save() {
-        const tmp = `${this.file}.${process.pid}.tmp`;
-        await writeFile(tmp, encrypt(this.KEY, JSON.stringify(this.content)));
-        await rename(tmp, this.file);
-    }
-}
-
-const ENOENT = 'ENOENT'; // File was deleted by another process (e.g. a concurrent IDE session sharing the same storage directory).
-
-function isFileNotFound(error: unknown): boolean {
-    return error instanceof Error && (error as NodeJS.ErrnoException).code === ENOENT;
 }

--- a/src/featureFlag/FeatureFlagProvider.ts
+++ b/src/featureFlag/FeatureFlagProvider.ts
@@ -1,4 +1,3 @@
-import { writeFileSync } from 'fs';
 import { join } from 'path';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
@@ -6,7 +5,7 @@ import { Measure, Telemetry } from '../telemetry/TelemetryDecorator';
 import { Closeable } from '../utils/Closeable';
 import { AwsEnv } from '../utils/Environment';
 import { isClientNetworkError } from '../utils/Errors';
-import { readFileIfExists } from '../utils/File';
+import { LocalFile } from '../utils/LocalFile';
 import { downloadJson } from '../utils/RemoteDownload';
 import { DynamicRefreshIntervalMs } from './DynamicFeatureFlag';
 import { FeatureFlagConfigSchema, FeatureFlagSchemaType } from './FeatureFlagBuilder';
@@ -25,21 +24,23 @@ export class FeatureFlagProvider implements Closeable {
     private readonly supplier: FeatureFlagSupplier;
 
     private readonly timeout: NodeJS.Timeout;
+    private readonly file: LocalFile;
 
     constructor(
         private readonly getLatestFeatureFlags: (env: string) => Promise<unknown>,
-        private readonly localFile = featureFlagLocalFile(),
+        filePath = featureFlagLocalFile(),
         refreshIntervalMs: number = RefreshIntervalMs,
         dynamicRefreshIntervalMs: number = DynamicRefreshIntervalMs,
     ) {
-        this.config = defaultConfig(localFile, this.telemetry);
+        this.file = new LocalFile(filePath);
+        this.config = defaultConfig(this.file, this.telemetry);
 
         this.supplier = new FeatureFlagSupplier(
             () => {
                 return this.config;
             },
             () => {
-                return defaultConfig(localFile, this.telemetry);
+                return defaultConfig(this.file, this.telemetry);
             },
             dynamicRefreshIntervalMs,
         );
@@ -76,7 +77,8 @@ export class FeatureFlagProvider implements Closeable {
             return;
         }
         this.config = newConfig;
-        writeFileSync(this.localFile, JSON.stringify(newConfig, undefined, 2));
+
+        await this.file.write(JSON.stringify(newConfig, undefined, 2));
         this.telemetry.count('refresh.local.update', 1);
         log.info('Updated and saved feature flags');
         this.log();
@@ -127,13 +129,22 @@ export function getFromGitHub(env: string): Promise<FeatureFlagSchemaType> {
     );
 }
 
-function defaultConfig(configFile: string, telemetry: ScopedTelemetry): FeatureFlagSchemaType {
+const EmptyConfig = { version: 1, description: 'Default empty config', features: {} };
+
+function defaultConfig(configFile: LocalFile, telemetry: ScopedTelemetry): FeatureFlagSchemaType {
     try {
-        return JSON.parse(readFileIfExists(configFile, 'utf8')) as FeatureFlagSchemaType;
+        const contents = configFile.readString();
+        if (contents === undefined) {
+            telemetry.count('default.empty', 1);
+            log.error('No local feature flag configs found');
+            return EmptyConfig;
+        }
+
+        return JSON.parse(contents) as FeatureFlagSchemaType;
     } catch (err) {
         telemetry.count('parse.default.error', 1);
         log.error(err, 'Failed to read config file, using empty config');
-        return { version: 1, description: 'Default empty config', features: {} };
+        return EmptyConfig;
     }
 }
 

--- a/src/utils/Environment.ts
+++ b/src/utils/Environment.ts
@@ -82,3 +82,7 @@ export const isLinux = process.platform === 'linux';
 export const ProcessType = `${process.platform}${process.env.BUILD_TARGET ? `-${process.env.BUILD_TARGET}` : ''}-${process.arch}`;
 export const ServiceEnv = `${getNodeEnv()}-${getAwsEnv()}`;
 export const Service = `${ExtensionId}-${ExtensionVersion}`;
+
+export function processId() {
+    return process.pid;
+}

--- a/src/utils/Errors.ts
+++ b/src/utils/Errors.ts
@@ -109,3 +109,13 @@ export function errorAttributes(error: unknown, origin?: 'uncaughtException' | '
         ...location,
     };
 }
+
+export class DoesNotExist extends Error {
+    constructor(resource: string, options?: ErrorOptions) {
+        super(`${resource} does not exist`, options);
+        this.name = this.constructor.name;
+
+        // Explicitly set the prototype, to ensure that `instanceof` checks work correctly
+        Object.setPrototypeOf(this, DoesNotExist.prototype);
+    }
+}

--- a/src/utils/File.ts
+++ b/src/utils/File.ts
@@ -1,6 +1,9 @@
 import { readFileSync, existsSync, PathLike } from 'fs'; // eslint-disable-line no-restricted-imports
-import { readFile } from 'fs/promises'; // eslint-disable-line no-restricted-imports
+import { readFile, rename, unlink, open } from 'fs/promises'; // eslint-disable-line no-restricted-imports
 import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { isWindows } from './Environment';
+import { DoesNotExist } from './Errors';
+import { sleep } from './Retry';
 import { toString } from './String';
 
 const log = LoggerFactory.getLogger('File');
@@ -17,7 +20,7 @@ export function readFileIfExists(path: PathLike, options: Options = 'utf8'): str
         if (existsSync(path)) {
             return readFileSync(path, options);
         } else {
-            throw new Error(`Path ${toString(path)} does not exist`);
+            throw new DoesNotExist(toString(path));
         }
     } catch (err) {
         log.error(err);
@@ -30,7 +33,7 @@ export async function readFileIfExistsAsync(path: PathLike, options: Options = '
         if (existsSync(path)) {
             return await readFile(path, options);
         } else {
-            throw new Error(`Path ${toString(path)} does not exist`);
+            throw new DoesNotExist(toString(path));
         }
     } catch (err) {
         log.error(err);
@@ -49,10 +52,88 @@ export function readBufferIfExists(
         if (existsSync(path)) {
             return readFileSync(path, options);
         } else {
-            throw new Error(`Path ${toString(path)} does not exist`);
+            throw new DoesNotExist(toString(path));
         }
     } catch (err) {
         log.error(err);
         throw err;
     }
+}
+
+export function readBufferIfExistsAsync(
+    path: PathLike,
+    options?: {
+        encoding?: null | undefined;
+        flag?: string | undefined;
+    } | null,
+): Promise<Buffer> {
+    try {
+        if (existsSync(path)) {
+            return readFile(path, options);
+        } else {
+            throw new DoesNotExist(toString(path));
+        }
+    } catch (err) {
+        log.error(err);
+        throw err;
+    }
+}
+
+const RETRIABLE_RENAME_CODES = new Set(['EPERM', 'EACCES', 'EBUSY', 'ENOENT']);
+
+export async function asyncRenameWithRetry(
+    sourcePath: string,
+    destinationPath: string,
+    maxRetries = 10,
+    retryDelayMs = 50,
+): Promise<void> {
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+            await rename(sourcePath, destinationPath);
+            return;
+        } catch (error) {
+            const code = (error as NodeJS.ErrnoException).code;
+            if (!code || !RETRIABLE_RENAME_CODES.has(code) || attempt === maxRetries - 1) {
+                try {
+                    await unlink(sourcePath);
+                } catch (err) {
+                    // best-effort tmp cleanup
+                    log.error(err);
+                }
+                throw error;
+            }
+            await sleep(retryDelayMs);
+        }
+    }
+}
+
+export async function asyncFileSync(filePath: string): Promise<void> {
+    const handle = await open(filePath, 'r+');
+    try {
+        await handle.sync();
+    } finally {
+        await handle.close();
+    }
+}
+
+export async function asyncDirSync(dirPath: string): Promise<void> {
+    try {
+        const handle = await open(dirPath, 'r');
+        try {
+            await handle.sync();
+        } finally {
+            await handle.close();
+        }
+    } catch (err) {
+        // Windows cannot fsync directories
+        if (!isWindows) {
+            log.error(err);
+        }
+    }
+}
+
+export function isFileNotFoundError(error: unknown): boolean {
+    // File was deleted by another process (e.g. a concurrent IDE session sharing the same storage directory)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
+    return (error as any).code === 'ENOENT';
 }

--- a/src/utils/LocalFile.ts
+++ b/src/utils/LocalFile.ts
@@ -1,0 +1,217 @@
+import { existsSync, statSync, unlinkSync } from 'fs';
+import { unlink, writeFile, readdir } from 'fs/promises';
+import { Stats } from 'node:fs';
+import { Stream } from 'node:stream';
+import { basename, dirname, join } from 'path';
+import { LockOptions, lock } from 'proper-lockfile';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { processId } from './Environment';
+import { DoesNotExist } from './Errors';
+import {
+    asyncDirSync,
+    asyncFileSync,
+    asyncRenameWithRetry,
+    isFileNotFoundError,
+    readBufferIfExists,
+    readBufferIfExistsAsync,
+    readFileIfExists,
+    readFileIfExistsAsync,
+} from './File';
+
+const log = LoggerFactory.getLogger('LocalFile');
+
+const LOCK_OPTIONS: LockOptions = {
+    stale: 10_000, // A lock older than this (ms) is considered abandoned and can be stolen by another process
+    realpath: false, // Use path.resolve instead of fs.realpath so locking works on files that don't exist yet (first write)
+    retries: {
+        retries: 20, // Maximum number of attempts to acquire the lock before giving up.
+        factor: 2, // Exponential backoff multiplier between retries
+        minTimeout: 50, // Minimum delay (ms) before the first retry
+        maxTimeout: 2000, // Maximum delay (ms) cap for any single retry
+        randomize: true, // Add jitter to retry delays to avoid contention between concurrent writes
+    },
+};
+
+export class LocalFile {
+    private tempFileCounter = 0;
+    readonly fileName: string;
+    readonly dirName: string;
+
+    constructor(readonly path: string) {
+        this.fileName = basename(path);
+        this.dirName = dirname(path);
+    }
+
+    exists() {
+        return existsSync(this.path);
+    }
+
+    stats(): Stats | undefined {
+        if (this.exists()) {
+            return statSync(this.path);
+        }
+        return undefined;
+    }
+
+    isFile(): boolean {
+        return this.stats()?.isFile() ?? false;
+    }
+
+    isDirectory(): boolean {
+        return this.stats()?.isDirectory() ?? false;
+    }
+
+    fileBytes(): number {
+        return this.stats()?.size ?? 0;
+    }
+
+    readString(): string | undefined {
+        try {
+            return readFileIfExists(this.path);
+        } catch (err) {
+            if (err instanceof DoesNotExist) {
+                return undefined;
+            }
+            throw err;
+        }
+    }
+
+    async readStringAsync(): Promise<string | undefined> {
+        try {
+            return await readFileIfExistsAsync(this.path);
+        } catch (err) {
+            if (err instanceof DoesNotExist) {
+                return undefined;
+            }
+            throw err;
+        }
+    }
+
+    readBytes(): Buffer | undefined {
+        try {
+            return readBufferIfExists(this.path);
+        } catch (err) {
+            if (err instanceof DoesNotExist) {
+                return undefined;
+            }
+            throw err;
+        }
+    }
+
+    async readBytesAsync(): Promise<Buffer | undefined> {
+        try {
+            return await readBufferIfExistsAsync(this.path);
+        } catch (err) {
+            if (err instanceof DoesNotExist) {
+                return undefined;
+            }
+            throw err;
+        }
+    }
+
+    async write(
+        data:
+            | string
+            | NodeJS.ArrayBufferView
+            | Iterable<string | NodeJS.ArrayBufferView>
+            | AsyncIterable<string | NodeJS.ArrayBufferView>
+            | Stream,
+    ): Promise<boolean> {
+        const release = await this.tryLock();
+        try {
+            await this.cleanupStaleTmpFiles();
+            const tmp = this.tmpPath();
+
+            try {
+                await writeFile(tmp, data);
+                await asyncFileSync(tmp);
+                await asyncRenameWithRetry(tmp, this.path);
+
+                await asyncDirSync(dirname(this.path));
+                return true;
+            } catch (err) {
+                // If anything fails during the write/sync/rename phase, clean up the orphaned temp file before bubbling up the error.
+                try {
+                    if (existsSync(tmp)) {
+                        unlinkSync(tmp);
+                    }
+                } catch {
+                    // Ignore cleanup error, we want to throw the original writeError
+                }
+                throw err;
+            }
+        } finally {
+            await release();
+        }
+    }
+
+    async remove(): Promise<boolean> {
+        const release = await this.tryLock();
+        try {
+            await unlink(this.path);
+            return true;
+        } catch (err) {
+            // If the file is already gone, treat it as a success (idempotent)
+            if (isFileNotFoundError(err)) {
+                return true;
+            }
+
+            throw err;
+        } finally {
+            await release();
+        }
+    }
+
+    /**
+     * @unsafe Delete a file without locks
+     */
+    unsafeRemove(): boolean {
+        try {
+            unlinkSync(this.path);
+            return true;
+        } catch (err) {
+            // If the file is already gone, treat it as a success (idempotent)
+            if (isFileNotFoundError(err)) {
+                return true;
+            }
+
+            throw err;
+        }
+    }
+
+    private tryLock() {
+        return lock(this.path, LOCK_OPTIONS);
+    }
+
+    private tmpPath() {
+        this.tempFileCounter = (this.tempFileCounter + 1) % Number.MAX_SAFE_INTEGER;
+        return `${this.path}.${processId()}.${this.tempFileCounter}.tmp`;
+    }
+
+    private async cleanupStaleTmpFiles() {
+        try {
+            const entries = await readdir(this.dirName);
+            for (const entry of entries) {
+                if (entry.startsWith(`${this.fileName}.`) && entry.endsWith('.tmp')) {
+                    const fullPath = join(this.dirName, entry);
+
+                    try {
+                        await unlink(fullPath);
+                    } catch (err) {
+                        if (isFileNotFoundError(err)) {
+                            continue;
+                        }
+
+                        log.error(err, `Failed to clean up stale temp file: ${fullPath}`);
+                    }
+                }
+            }
+        } catch (err) {
+            if (isFileNotFoundError(err)) {
+                return;
+            }
+
+            log.error(err, `Cleanup failed to read directory: ${this.dirName}`);
+        }
+    }
+}

--- a/tst/unit/datastore/EncryptedFile.test.ts
+++ b/tst/unit/datastore/EncryptedFile.test.ts
@@ -1,0 +1,128 @@
+import { randomUUID as v4 } from 'crypto';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { encryptionKey } from '../../../src/datastore/file/Encryption';
+import { EncryptedFile } from '../../../src/datastore/file/EncryptedFile';
+
+describe('EncryptedFile', () => {
+    const key = encryptionKey(2);
+    const testDir = join(process.cwd(), 'node_modules', '.cache', 'encryptedfile-tests', v4());
+
+    beforeEach(() => {
+        mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        rmSync(testDir, { recursive: true, force: true });
+    });
+
+    describe('put and get', () => {
+        it('should round-trip a value through encrypt/write/read/decrypt', async () => {
+            const file = new EncryptedFile(key, 'test', 'data.enc', testDir);
+            file.setKey('my-key');
+
+            await file.put({ region: 'us-east-1' });
+
+            // Read back from a fresh instance (simulates restart)
+            const file2 = new EncryptedFile(key, 'test', 'data.enc', testDir);
+            expect(file2.get()).toEqual({ region: 'us-east-1' });
+            expect(file2.entry()?.key).toBe('my-key');
+        });
+
+        it('should overwrite existing values', async () => {
+            const file = new EncryptedFile(key, 'test', 'overwrite.enc', testDir);
+            file.setKey('k');
+
+            await file.put('first');
+            await file.put('second');
+
+            const file2 = new EncryptedFile(key, 'test', 'overwrite.enc', testDir);
+            expect(file2.get()).toBe('second');
+        });
+    });
+
+    describe('remove', () => {
+        it('should delete the file and clear content', async () => {
+            const file = new EncryptedFile(key, 'test', 'remove.enc', testDir);
+            file.setKey('k');
+            await file.put('data');
+            expect(file.exists()).toBe(true);
+
+            await file.remove();
+
+            expect(file.exists()).toBe(false);
+            expect(file.get()).toBeUndefined();
+        });
+
+        it('should succeed when file does not exist', async () => {
+            const file = new EncryptedFile(key, 'test', 'nonexistent.enc', testDir);
+            await expect(file.remove()).resolves.toBe(true);
+        });
+    });
+
+    describe('corrupt file recovery', () => {
+        it('should delete corrupt file and return undefined content', () => {
+            const fileName = 'corrupt.enc';
+            const filePath = join(testDir, fileName);
+
+            // Write garbage data that will fail decryption
+            writeFileSync(filePath, 'this is not valid encrypted data');
+            expect(existsSync(filePath)).toBe(true);
+
+            // Constructor should catch the decryption error, delete the file, and not throw
+            const file = new EncryptedFile(key, 'test', fileName, testDir);
+
+            expect(file.get()).toBeUndefined();
+            expect(file.exists()).toBe(false);
+        });
+
+        it('should recover and allow new writes after corrupt file deletion', async () => {
+            const fileName = 'recover.enc';
+            writeFileSync(join(testDir, fileName), Buffer.from([0xde, 0xad, 0xbe, 0xef]));
+
+            const file = new EncryptedFile(key, 'test', fileName, testDir);
+            expect(file.get()).toBeUndefined();
+
+            file.setKey('new-key');
+            await file.put('fresh-data');
+
+            const file2 = new EncryptedFile(key, 'test', fileName, testDir);
+            expect(file2.get()).toBe('fresh-data');
+        });
+    });
+
+    describe('fileSize', () => {
+        it('should return 0 for nonexistent file', () => {
+            const file = new EncryptedFile(key, 'test', 'missing.enc', testDir);
+            expect(file.fileSize()).toBe(0);
+        });
+
+        it('should return positive size after write', async () => {
+            const file = new EncryptedFile(key, 'test', 'sized.enc', testDir);
+            file.setKey('k');
+            await file.put('some data');
+            expect(file.fileSize()).toBeGreaterThan(0);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should throw when setting key twice', () => {
+            const file = new EncryptedFile(key, 'test', 'double-key.enc', testDir);
+            file.setKey('first');
+            expect(() => file.setKey('second')).toThrow('File key was already set');
+        });
+
+        it('should throw when putting without a key', async () => {
+            const file = new EncryptedFile(key, 'test', 'no-key.enc', testDir);
+            await expect(file.put('data')).rejects.toThrow('File key is not set');
+        });
+
+        it('should return undefined for nonexistent file', () => {
+            const file = new EncryptedFile(key, 'test', 'nope.enc', testDir);
+            expect(file.get()).toBeUndefined();
+            expect(file.entry()).toBeUndefined();
+            expect(file.exists()).toBe(false);
+        });
+    });
+});

--- a/tst/unit/datastore/FilestoreWorker.ts
+++ b/tst/unit/datastore/FilestoreWorker.ts
@@ -1,10 +1,8 @@
 import { randomUUID as v4 } from 'crypto';
 import { join } from 'path';
 import { staticInitialize } from '../../../src/app/initialize';
-import { encryptionKey } from '../../../src/datastore/file/Encryption';
-import { KeyedFileStore } from '../../../src/datastore/file/KeyedFileStore';
 
-// Worker script for multiprocess FileStore testing
+// Initialize BEFORE importing modules that call factories like Logger at the top level
 staticInitialize(undefined, {
     telemetryEnabled: false,
     logLevel: 'silent',
@@ -12,9 +10,12 @@ staticInitialize(undefined, {
 });
 
 const [encTestDir, workerId, numWrites] = process.argv.slice(2);
-const key = encryptionKey(2);
 
 async function main() {
+    const { encryptionKey } = await import('../../../src/datastore/file/Encryption');
+    const { KeyedFileStore } = await import('../../../src/datastore/file/KeyedFileStore');
+
+    const key = encryptionKey(2);
     const store = new KeyedFileStore(key, 'test', encTestDir);
 
     for (let i = 0; i < Number.parseInt(numWrites); i++) {

--- a/tst/unit/utils/File.test.ts
+++ b/tst/unit/utils/File.test.ts
@@ -1,16 +1,38 @@
 import { randomUUID as v4 } from 'crypto';
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { rename } from 'fs/promises';
 import { join } from 'path';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { readFileIfExists, readFileIfExistsAsync, readBufferIfExists } from '../../../src/utils/File';
+import { describe, it, expect, beforeAll, afterAll, vi, beforeEach, afterEach } from 'vitest';
+import {
+    asyncDirSync,
+    asyncFileSync,
+    asyncRenameWithRetry,
+    isFileNotFoundError,
+    readBufferIfExists,
+    readBufferIfExistsAsync,
+    readFileIfExists,
+    readFileIfExistsAsync,
+} from '../../../src/utils/File';
+
+// Capture the real rename before mocking so we can delegate to it without recursion
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+const { rename: realRename } = await vi.hoisted(async () => await import('fs/promises'));
+
+vi.mock('fs/promises', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('fs/promises')>();
+    return { ...actual, rename: vi.fn(actual.rename) };
+});
 
 describe('File', () => {
     const testDir = join(process.cwd(), 'node_modules', '.cache', 'file-tests', v4());
     const textFile = join(testDir, 'text.txt');
     const binaryFile = join(testDir, 'binary.bin');
     const textContent = 'hello world 🌍';
-    const binaryContent = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+    const binaryContent = Buffer.from('CloudFormation template 🚀', 'utf8');
     const nonexistentPath = join(testDir, 'does-not-exist.txt');
+
+    const mockedRename = vi.mocked(rename);
 
     beforeAll(() => {
         mkdirSync(testDir, { recursive: true });
@@ -55,6 +77,135 @@ describe('File', () => {
 
         it('should throw for nonexistent path', () => {
             expect(() => readBufferIfExists(nonexistentPath)).toThrow('does not exist');
+        });
+    });
+
+    describe('readBufferIfExistsAsync', () => {
+        it('should return file content as buffer', async () => {
+            const result = await readBufferIfExistsAsync(binaryFile);
+            expect(Buffer.isBuffer(result)).toBe(true);
+            expect(Buffer.compare(result, binaryContent)).toBe(0);
+        });
+
+        it('should accept options parameter', async () => {
+            const result = await readBufferIfExistsAsync(binaryFile, null);
+            expect(Buffer.compare(result, binaryContent)).toBe(0);
+        });
+
+        it('should throw DoesNotExist for nonexistent path', () => {
+            // readBufferIfExistsAsync throws synchronously from existsSync check
+            expect(() => readBufferIfExistsAsync(nonexistentPath)).toThrow('does not exist');
+        });
+    });
+
+    describe('asyncRenameWithRetry', () => {
+        const renameDir = join(testDir, 'rename');
+
+        beforeEach(() => {
+            mkdirSync(renameDir, { recursive: true });
+            mockedRename.mockRestore();
+        });
+
+        afterEach(() => {
+            rmSync(renameDir, { recursive: true, force: true });
+            mockedRename.mockRestore();
+        });
+
+        it('should rename file on first attempt', async () => {
+            const source = join(renameDir, 'source.txt');
+            const destination = join(renameDir, 'destination.txt');
+            writeFileSync(source, 'rename-me');
+
+            await asyncRenameWithRetry(source, destination);
+
+            expect(readFileIfExists(destination)).toBe('rename-me');
+        });
+
+        it('should retry on transient EPERM errors and succeed', async () => {
+            const source = join(renameDir, 'retry-source.txt');
+            const destination = join(renameDir, 'retry-dest.txt');
+            writeFileSync(source, 'retry-content');
+
+            const epermError = Object.assign(new Error('EPERM'), { code: 'EPERM' });
+            mockedRename
+                .mockRejectedValueOnce(epermError)
+                .mockRejectedValueOnce(epermError)
+                .mockImplementationOnce(realRename);
+
+            await asyncRenameWithRetry(source, destination, 5, 1);
+
+            expect(mockedRename).toHaveBeenCalledTimes(3);
+        });
+
+        it('should throw non-retriable errors immediately', async () => {
+            const source = join(renameDir, 'fail-source.txt');
+            const destination = join(renameDir, 'fail-dest.txt');
+            writeFileSync(source, 'fail-content');
+
+            const unknownError = Object.assign(new Error('UNKNOWN'), { code: 'UNKNOWN' });
+            mockedRename.mockRejectedValueOnce(unknownError);
+
+            await expect(asyncRenameWithRetry(source, destination, 3, 1)).rejects.toThrow('UNKNOWN');
+            expect(mockedRename).toHaveBeenCalledTimes(1);
+        });
+
+        it('should throw after exhausting all retries', async () => {
+            const source = join(renameDir, 'exhaust-source.txt');
+            const destination = join(renameDir, 'exhaust-dest.txt');
+            writeFileSync(source, 'exhaust-content');
+
+            const busyError = Object.assign(new Error('EBUSY'), { code: 'EBUSY' });
+            mockedRename.mockRejectedValue(busyError);
+
+            await expect(asyncRenameWithRetry(source, destination, 2, 1)).rejects.toThrow('EBUSY');
+            expect(mockedRename).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('asyncFileSync', () => {
+        it('should fsync an existing file without error', async () => {
+            const syncFile = join(testDir, 'sync-target.txt');
+            writeFileSync(syncFile, 'sync-content');
+
+            await expect(asyncFileSync(syncFile)).resolves.toBeUndefined();
+        });
+
+        it('should throw for nonexistent file', async () => {
+            await expect(asyncFileSync(join(testDir, 'no-such-file.txt'))).rejects.toThrow();
+        });
+    });
+
+    describe('asyncDirSync', () => {
+        it('should fsync an existing directory without error', async () => {
+            const syncDir = join(testDir, 'sync-dir');
+            mkdirSync(syncDir, { recursive: true });
+
+            await expect(asyncDirSync(syncDir)).resolves.toBeUndefined();
+        });
+
+        it('should not throw for nonexistent directory', async () => {
+            await expect(asyncDirSync(join(testDir, 'no-such-dir'))).resolves.toBeUndefined();
+        });
+    });
+
+    describe('isFileNotFoundError', () => {
+        it('should return true for ENOENT error', () => {
+            const enoentError = Object.assign(new Error('not found'), { code: 'ENOENT' });
+            expect(isFileNotFoundError(enoentError)).toBe(true);
+        });
+
+        it('should return false for other error codes', () => {
+            const epermError = Object.assign(new Error('permission denied'), { code: 'EPERM' });
+            expect(isFileNotFoundError(epermError)).toBe(false);
+        });
+
+        it('should return false for error without code', () => {
+            expect(isFileNotFoundError(new Error('generic error'))).toBe(false);
+        });
+
+        it('should return false for objects without code property', () => {
+            expect(isFileNotFoundError({ message: 'no code' })).toBe(false);
+            expect(isFileNotFoundError(42)).toBe(false);
         });
     });
 });

--- a/tst/unit/utils/LocalFile.test.ts
+++ b/tst/unit/utils/LocalFile.test.ts
@@ -1,0 +1,215 @@
+import { randomUUID as v4 } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, readdirSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { describe, it, expect, beforeAll, afterEach, beforeEach } from 'vitest';
+import { LocalFile } from '../../../src/utils/LocalFile';
+
+describe('LocalFile', () => {
+    const testDir = join(process.cwd(), 'node_modules', '.cache', 'localfile-tests', v4());
+    const filePath = join(testDir, 'test-file.txt');
+
+    beforeAll(() => {
+        mkdirSync(testDir, { recursive: true });
+    });
+
+    describe('constructor', () => {
+        it('should parse fileName and dirName from path', () => {
+            const file = new LocalFile('/some/dir/file.txt');
+            expect(file.fileName).toBe('file.txt');
+            expect(file.dirName).toBe('/some/dir');
+            expect(file.path).toBe('/some/dir/file.txt');
+        });
+    });
+
+    describe('exists', () => {
+        it('should return true when file exists', () => {
+            writeFileSync(filePath, 'content');
+            expect(new LocalFile(filePath).exists()).toBe(true);
+        });
+
+        it('should return false when file does not exist', () => {
+            expect(new LocalFile(join(testDir, 'missing.txt')).exists()).toBe(false);
+        });
+    });
+
+    describe('stats', () => {
+        it('should return Stats for existing file', () => {
+            writeFileSync(filePath, 'stats-content');
+            const stats = new LocalFile(filePath).stats();
+            expect(stats).toBeDefined();
+            expect(stats!.isFile()).toBe(true);
+        });
+
+        it('should return undefined for nonexistent file', () => {
+            expect(new LocalFile(join(testDir, 'missing.txt')).stats()).toBeUndefined();
+        });
+    });
+
+    describe('isFile', () => {
+        it('should return true for a regular file', () => {
+            writeFileSync(filePath, 'data');
+            expect(new LocalFile(filePath).isFile()).toBe(true);
+        });
+
+        it('should return false for a directory', () => {
+            expect(new LocalFile(testDir).isFile()).toBe(false);
+        });
+
+        it('should return false for nonexistent path', () => {
+            expect(new LocalFile(join(testDir, 'nope')).isFile()).toBe(false);
+        });
+    });
+
+    describe('isDirectory', () => {
+        it('should return true for a directory', () => {
+            expect(new LocalFile(testDir).isDirectory()).toBe(true);
+        });
+
+        it('should return false for a regular file', () => {
+            writeFileSync(filePath, 'data');
+            expect(new LocalFile(filePath).isDirectory()).toBe(false);
+        });
+
+        it('should return false for nonexistent path', () => {
+            expect(new LocalFile(join(testDir, 'nope')).isDirectory()).toBe(false);
+        });
+    });
+
+    describe('fileBytes', () => {
+        it('should return byte size of file', () => {
+            const content = 'hello';
+            writeFileSync(filePath, content);
+            expect(new LocalFile(filePath).fileBytes()).toBe(Buffer.byteLength(content));
+        });
+
+        it('should return 0 for nonexistent file', () => {
+            expect(new LocalFile(join(testDir, 'missing.txt')).fileBytes()).toBe(0);
+        });
+    });
+
+    describe('read/write', () => {
+        let tmpFile: string;
+        let tmpLocalFile: LocalFile;
+
+        beforeEach(() => {
+            tmpFile = join(testDir, v4());
+            tmpLocalFile = new LocalFile(tmpFile);
+        });
+
+        afterEach(() => {
+            if (existsSync(tmpFile)) {
+                unlinkSync(tmpFile);
+            }
+        });
+
+        it('write', async () => {
+            const data = v4();
+            const result = await tmpLocalFile.write(data);
+
+            expect(result).toBe(true);
+            expect(readFileSync(tmpFile, 'utf8')).toBe(data);
+            expect(readFileSync(tmpFile).equals(Buffer.from(data))).toBe(true);
+        });
+
+        it('should clean up stale tmp files before writing', async () => {
+            writeFileSync(filePath, 'original');
+            const staleTmp = `${filePath}.99999.1.tmp`;
+            writeFileSync(staleTmp, 'stale');
+
+            const localFile = new LocalFile(filePath);
+            await localFile.write('new-content');
+
+            expect(existsSync(staleTmp)).toBe(false);
+            expect(readFileSync(filePath, 'utf8')).toBe('new-content');
+        });
+
+        it('should not leave tmp files after successful write', async () => {
+            writeFileSync(filePath, 'original');
+            const localFile = new LocalFile(filePath);
+
+            await localFile.write('new-content');
+
+            const tmpFiles = readdirSync(testDir).filter((f: string) => f.endsWith('.tmp'));
+            expect(tmpFiles).toHaveLength(0);
+        });
+
+        it('read', async () => {
+            const data = v4();
+            writeFileSync(tmpFile, data);
+
+            expect(tmpLocalFile.readString()).toBe(data);
+            expect(await tmpLocalFile.readStringAsync()).toBe(data);
+
+            expect(tmpLocalFile.readBytes()!.equals(Buffer.from(data))).toBe(true);
+            expect((await tmpLocalFile.readBytesAsync())!.equals(Buffer.from(data))).toBe(true);
+        });
+
+        it('read (does not exist)', async () => {
+            const missingFile = new LocalFile(join(testDir, v4()));
+
+            expect(missingFile.readString()).toBeUndefined();
+            expect(await missingFile.readStringAsync()).toBeUndefined();
+            expect(missingFile.readBytes()).toBeUndefined();
+            expect(await missingFile.readBytesAsync()).toBeUndefined();
+        });
+    });
+
+    describe('remove', () => {
+        it('should delete the file and return true', async () => {
+            writeFileSync(filePath, 'to-delete');
+            const localFile = new LocalFile(filePath);
+
+            const result = await localFile.remove();
+
+            expect(result).toBe(true);
+            expect(existsSync(filePath)).toBe(false);
+        });
+
+        it('should return true when file is already gone', async () => {
+            writeFileSync(filePath, 'placeholder');
+            const localFile = new LocalFile(filePath);
+
+            // Remove the file before calling remove() so unlink gets ENOENT
+            rmSync(filePath);
+
+            const result = await localFile.remove();
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('removeSync', () => {
+        it('should delete the file synchronously', () => {
+            writeFileSync(filePath, 'sync-delete');
+            const localFile = new LocalFile(filePath);
+
+            const result = localFile.unsafeRemove();
+
+            expect(result).toBe(true);
+            expect(existsSync(filePath)).toBe(false);
+        });
+
+        it('should not throw when file is already gone', () => {
+            const localFile = new LocalFile(join(testDir, 'already-gone.txt'));
+            expect(localFile.unsafeRemove()).toBe(true);
+        });
+    });
+
+    describe('concurrent writes', () => {
+        it('should serialize concurrent writes without data corruption or orphaned tmp files', async () => {
+            const concurrentFile = join(testDir, 'concurrent.txt');
+            writeFileSync(concurrentFile, 'initial');
+            const localFile = new LocalFile(concurrentFile);
+
+            const writes = Array.from({ length: 10 }, (_, i) => localFile.write(`write-${i}`));
+            await Promise.all(writes);
+
+            // The file should contain one of the written values (the last one to win the lock)
+            const content = readFileSync(concurrentFile, 'utf8');
+            expect(content).toMatch(/^write-\d$/);
+
+            // No orphaned tmp files should remain
+            const tmpFiles = readdirSync(testDir).filter((f: string) => f.endsWith('.tmp'));
+            expect(tmpFiles).toHaveLength(0);
+        });
+    });
+});

--- a/tst/unit/utils/LocalFile.writeFailure.test.ts
+++ b/tst/unit/utils/LocalFile.writeFailure.test.ts
@@ -1,0 +1,43 @@
+import { randomUUID as v4 } from 'crypto';
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'fs';
+import { writeFile } from 'fs/promises';
+import { join } from 'path';
+import { describe, it, expect, afterAll, afterEach, vi } from 'vitest';
+import { LocalFile } from '../../../src/utils/LocalFile';
+
+vi.mock('fs/promises', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('fs/promises')>();
+    return { ...actual, writeFile: vi.fn(actual.writeFile) };
+});
+
+describe('LocalFile write failure cleanup', () => {
+    const testDir = join(process.cwd(), 'node_modules', '.cache', 'localfile-write-failure', v4());
+    const filePath = join(testDir, 'test-file.txt');
+    const mockedWriteFile = vi.mocked(writeFile);
+
+    afterEach(() => {
+        mockedWriteFile.mockRestore();
+    });
+
+    afterAll(() => {
+        rmSync(testDir, { recursive: true, force: true });
+        vi.restoreAllMocks();
+    });
+
+    it('should clean up temp file and leave original untouched when writeFile fails', async () => {
+        mkdirSync(testDir, { recursive: true });
+        writeFileSync(filePath, 'original');
+        const localFile = new LocalFile(filePath);
+
+        mockedWriteFile.mockRejectedValueOnce(new Error('disk full'));
+
+        await expect(localFile.write('new-content')).rejects.toThrow('disk full');
+
+        // Original file should be untouched
+        expect(readFileSync(filePath, 'utf8')).toBe('original');
+
+        // No orphaned tmp files
+        const tmpFiles = readdirSync(testDir).filter((f: string) => f.endsWith('.tmp'));
+        expect(tmpFiles).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
Multiple language server processes (e.g., two IDE windows) share the same on-disk storage directory. `EncryptedFile` had inline locking via `proper-lockfile` and wrote through temp-file-then-rename, but `FeatureFlagProvider` called `writeFileSync` directly with no locking or atomicity. Both paths lacked fsync, so data could be lost on failure. Crashed processes left orphaned `.tmp` files that were never cleaned up.

## Changes
A new `LocalFile` class wraps a file path and provides read, write, and delete operations. All writes follow this protocol:

1. Acquire an inter-process lock using 
2. Scan the parent directory and delete any stale `.tmp` files matching `{fileName}.*.tmp` left by previous crashed writes
3. Write data to `{file}.{pid}.{counter}.tmp` — the PID + monotonic counter ensure uniqueness
4. `fsync` the temp file (flush kernel buffers to disk)
5. `rename` temp → target with retry on transient Windows errors (`EPERM`, `EACCES`, `EBUSY`, `ENOENT` — up to 10 retries, 50ms apart)
6. `fsync` the parent directory (makes the rename durable; silently skipped on Windows which doesn't support dir fsync)
7. Release the lock
8. If any step 3–6 fails: delete the temp file, then re-throw

Reads are lockless - safe because `rename` is atomic on POSIX, so readers always see a complete file.

Deletes acquire the lock, call `unlink`, and treat `ENOENT` as success (idempotent). `removeSync` is the exception — it skips locking, used only for corrupt-file cleanup in the `EncryptedFile` constructor.
