### PR TITLE
Handle DNE files more consistently

### DIFF
--- a/src/schema/GetSchemaTask.ts
+++ b/src/schema/GetSchemaTask.ts
@@ -27,7 +27,7 @@ export class GetPublicSchemaTask extends GetSchemaTask {
     @Telemetry()
     private readonly telemetry!: ScopedTelemetry;
 
-    static readonly MaxAttempts = 3;
+    static readonly MaxAttempts = 5;
     private attempts = 0;
 
     constructor(

--- a/src/utils/File.ts
+++ b/src/utils/File.ts
@@ -1,9 +1,9 @@
-import { readFileSync, existsSync, PathLike } from 'fs'; // eslint-disable-line no-restricted-imports
+import { readFileSync, PathLike } from 'fs'; // eslint-disable-line no-restricted-imports
 import { readFile, rename, unlink, open } from 'fs/promises'; // eslint-disable-line no-restricted-imports
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { isWindows } from './Environment';
 import { DoesNotExist } from './Errors';
-import { sleep } from './Retry';
+import { calculateDelay, sleep } from './Retry';
 import { toString } from './String';
 
 const log = LoggerFactory.getLogger('File');
@@ -15,29 +15,31 @@ type Options =
           flag?: string | undefined;
       };
 
+const ENOENT = 'ENOENT'; // No such file or directory
+const RETRIABLE_RENAME_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
+
+function wrapReadEnoentError(path: PathLike, err: unknown): never {
+    log.error(err);
+    if (isFileNotFoundError(err)) {
+        throw new DoesNotExist(toString(path));
+    }
+
+    throw err;
+}
+
 export function readFileIfExists(path: PathLike, options: Options = 'utf8'): string {
     try {
-        if (existsSync(path)) {
-            return readFileSync(path, options);
-        } else {
-            throw new DoesNotExist(toString(path));
-        }
+        return readFileSync(path, options);
     } catch (err) {
-        log.error(err);
-        throw err;
+        wrapReadEnoentError(path, err);
     }
 }
 
 export async function readFileIfExistsAsync(path: PathLike, options: Options = 'utf8'): Promise<string> {
     try {
-        if (existsSync(path)) {
-            return await readFile(path, options);
-        } else {
-            throw new DoesNotExist(toString(path));
-        }
+        return await readFile(path, options);
     } catch (err) {
-        log.error(err);
-        throw err;
+        wrapReadEnoentError(path, err);
     }
 }
 
@@ -49,18 +51,13 @@ export function readBufferIfExists(
     } | null,
 ): Buffer {
     try {
-        if (existsSync(path)) {
-            return readFileSync(path, options);
-        } else {
-            throw new DoesNotExist(toString(path));
-        }
+        return readFileSync(path, options);
     } catch (err) {
-        log.error(err);
-        throw err;
+        wrapReadEnoentError(path, err);
     }
 }
 
-export function readBufferIfExistsAsync(
+export async function readBufferIfExistsAsync(
     path: PathLike,
     options?: {
         encoding?: null | undefined;
@@ -68,24 +65,17 @@ export function readBufferIfExistsAsync(
     } | null,
 ): Promise<Buffer> {
     try {
-        if (existsSync(path)) {
-            return readFile(path, options);
-        } else {
-            throw new DoesNotExist(toString(path));
-        }
+        return await readFile(path, options);
     } catch (err) {
-        log.error(err);
-        throw err;
+        wrapReadEnoentError(path, err);
     }
 }
-
-const RETRIABLE_RENAME_CODES = new Set(['EPERM', 'EACCES', 'EBUSY', 'ENOENT']);
 
 export async function asyncRenameWithRetry(
     sourcePath: string,
     destinationPath: string,
     maxRetries = 10,
-    retryDelayMs = 50,
+    initialDelayMs = 50,
 ): Promise<void> {
     for (let attempt = 0; attempt < maxRetries; attempt++) {
         try {
@@ -95,14 +85,15 @@ export async function asyncRenameWithRetry(
             const code = (error as NodeJS.ErrnoException).code;
             if (!code || !RETRIABLE_RENAME_CODES.has(code) || attempt === maxRetries - 1) {
                 try {
-                    await unlink(sourcePath);
+                    if (!isFileNotFoundError(error)) {
+                        await unlink(sourcePath);
+                    }
                 } catch (err) {
-                    // best-effort tmp cleanup
-                    log.error(err);
+                    log.error(err, `Best effort tmp cleanup failed for ${sourcePath}`);
                 }
                 throw error;
             }
-            await sleep(retryDelayMs);
+            await sleep(calculateDelay(attempt, initialDelayMs));
         }
     }
 }
@@ -133,7 +124,5 @@ export async function asyncDirSync(dirPath: string): Promise<void> {
 }
 
 export function isFileNotFoundError(error: unknown): boolean {
-    // File was deleted by another process (e.g. a concurrent IDE session sharing the same storage directory)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
-    return (error as any).code === 'ENOENT';
+    return error !== null && typeof error === 'object' && (error as NodeJS.ErrnoException).code === ENOENT;
 }

--- a/src/utils/LocalFile.ts
+++ b/src/utils/LocalFile.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync, unlinkSync } from 'fs';
-import { unlink, writeFile, readdir } from 'fs/promises';
+import { unlink, writeFile, readdir, stat } from 'fs/promises';
 import { Stats } from 'node:fs';
 import { Stream } from 'node:stream';
 import { basename, dirname, join } from 'path';
@@ -31,7 +31,33 @@ const LOCK_OPTIONS: LockOptions = {
         randomize: true, // Add jitter to retry delays to avoid contention between concurrent writes
     },
 };
+const STALE_TMP_FILE_THRESHOLD_MS = 30 * 60 * 1000;
 
+/**
+ * Cross-platform local file with atomic writes and lockless reads.
+ *
+ * ## Write path
+ * Writes use a write-to-temp → fsync → rename pattern under a `proper-lockfile` advisory lock,
+ * ensuring that the target file is always in a consistent state. The temp file is created in the
+ * same directory as the target so the rename is always a same-volume operation.
+ *
+ * ## Read path — lockless by design
+ * Reads do not acquire a lock. This is safe because `fs.rename` (libuv `MoveFileExW` on Windows,
+ * `rename(2)` on POSIX) is an atomic replace on same-volume NTFS and all POSIX filesystems.
+ * A concurrent reader will see either the old or the new content, never a partial or corrupt file.
+ *
+ * ### Risk profile
+ * | Scenario                                  | POSIX        | Windows (NTFS)                          |
+ * |-------------------------------------------|--------------|-----------------------------------------|
+ * | Reader during rename                      | Old or new   | Old or new (atomic via `MoveFileExW`)   |
+ * | Reader between delete+create (non-NTFS)   | N/A          | Transient `ENOENT` → returns `undefined`|
+ * | Partial / corrupt read                    | Not possible | Not possible (rename is atomic)         |
+ *
+ * The only scenario where a reader could observe a missing file is on a non-NTFS Windows filesystem
+ * (e.g. FAT32, network share) where rename may not be atomic. Even then, the failure mode is
+ * graceful: `readString` / `readBytes` return `undefined`, and all callers treat that as a cache
+ * miss (e.g. falling back to defaults or re-fetching).
+ */
 export class LocalFile {
     private tempFileCounter = 0;
     readonly fileName: string;
@@ -40,6 +66,7 @@ export class LocalFile {
     constructor(readonly path: string) {
         this.fileName = basename(path);
         this.dirName = dirname(path);
+        this.scheduleCleanup();
     }
 
     exists() {
@@ -119,7 +146,7 @@ export class LocalFile {
     ): Promise<boolean> {
         const release = await this.tryLock();
         try {
-            await this.cleanupStaleTmpFiles();
+            this.scheduleCleanup(); // Defer tmp file cleanup, so we don't block the main write operation
             const tmp = this.tmpPath();
 
             try {
@@ -188,6 +215,12 @@ export class LocalFile {
         return `${this.path}.${processId()}.${this.tempFileCounter}.tmp`;
     }
 
+    private scheduleCleanup() {
+        setTimeout(() => {
+            this.cleanupStaleTmpFiles().catch(log.error);
+        }, 60 * 1000).unref();
+    }
+
     private async cleanupStaleTmpFiles() {
         try {
             const entries = await readdir(this.dirName);
@@ -196,7 +229,12 @@ export class LocalFile {
                     const fullPath = join(this.dirName, entry);
 
                     try {
-                        await unlink(fullPath);
+                        const fileStat = await stat(fullPath);
+                        // Only delete the file if it is significantly older than the current time.
+                        // This prevents process B from deleting process A's active temp file when stealing a lock.
+                        if (Date.now() - fileStat.mtimeMs > STALE_TMP_FILE_THRESHOLD_MS) {
+                            await unlink(fullPath);
+                        }
                     } catch (err) {
                         if (isFileNotFoundError(err)) {
                             continue;

--- a/src/utils/Retry.ts
+++ b/src/utils/Retry.ts
@@ -17,12 +17,20 @@ export function sleep(ms: number): Promise<void> {
     });
 }
 
-function calculateDelay(
+const DefaultRetryOptions = {
+    maxRetries: 3,
+    initialDelayMs: 1000,
+    maxDelayMs: 5000,
+    backoffMultiplier: 2,
+    jitterFactor: 0.1,
+};
+
+export function calculateDelay(
     attempt: number,
-    initialDelayMs: number,
-    jitterFactor: number,
-    backoffMultiplier: number,
-    maxDelayMs: number,
+    initialDelayMs: number = DefaultRetryOptions.initialDelayMs,
+    jitterFactor: number = DefaultRetryOptions.jitterFactor,
+    backoffMultiplier: number = DefaultRetryOptions.backoffMultiplier,
+    maxDelayMs: number = DefaultRetryOptions.maxDelayMs,
 ): number {
     // 1. Exponential Backoff: initial * 2^0, initial * 2^1, etc.
     const exponentialDelay = initialDelayMs * Math.pow(backoffMultiplier, attempt);
@@ -45,11 +53,11 @@ export async function retryWithExponentialBackoff<T>(
     },
 ): Promise<T> {
     const {
-        maxRetries = 3,
-        initialDelayMs = 1000,
-        maxDelayMs = 5000,
-        backoffMultiplier = 2,
-        jitterFactor = 0.1,
+        maxRetries = DefaultRetryOptions.maxRetries,
+        initialDelayMs = DefaultRetryOptions.initialDelayMs,
+        maxDelayMs = DefaultRetryOptions.maxDelayMs,
+        backoffMultiplier = DefaultRetryOptions.backoffMultiplier,
+        jitterFactor = DefaultRetryOptions.jitterFactor,
         operationName,
         totalTimeoutMs,
     } = options;

--- a/tst/unit/utils/File.test.ts
+++ b/tst/unit/utils/File.test.ts
@@ -92,9 +92,8 @@ describe('File', () => {
             expect(Buffer.compare(result, binaryContent)).toBe(0);
         });
 
-        it('should throw DoesNotExist for nonexistent path', () => {
-            // readBufferIfExistsAsync throws synchronously from existsSync check
-            expect(() => readBufferIfExistsAsync(nonexistentPath)).toThrow('does not exist');
+        it('should throw DoesNotExist for nonexistent path', async () => {
+            await expect(readBufferIfExistsAsync(nonexistentPath)).rejects.toThrow('does not exist');
         });
     });
 

--- a/tst/unit/utils/LocalFile.test.ts
+++ b/tst/unit/utils/LocalFile.test.ts
@@ -1,14 +1,16 @@
 import { randomUUID as v4 } from 'crypto';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, readdirSync, unlinkSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync, readdirSync, unlinkSync, utimesSync } from 'fs';
 import { join } from 'path';
-import { describe, it, expect, beforeAll, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { LocalFile } from '../../../src/utils/LocalFile';
+import { waitFor } from '../../utils/Utils';
 
 describe('LocalFile', () => {
     const testDir = join(process.cwd(), 'node_modules', '.cache', 'localfile-tests', v4());
     const filePath = join(testDir, 'test-file.txt');
 
-    beforeAll(() => {
+    beforeEach(() => {
+        rmSync(testDir, { recursive: true, force: true });
         mkdirSync(testDir, { recursive: true });
     });
 
@@ -111,16 +113,32 @@ describe('LocalFile', () => {
             expect(readFileSync(tmpFile).equals(Buffer.from(data))).toBe(true);
         });
 
-        it('should clean up stale tmp files before writing', async () => {
-            writeFileSync(filePath, 'original');
-            const staleTmp = `${filePath}.99999.1.tmp`;
-            writeFileSync(staleTmp, 'stale');
+        it('should clean up stale tmp files after writing', async () => {
+            vi.useFakeTimers({ shouldAdvanceTime: true });
+            try {
+                writeFileSync(filePath, 'original');
+                const staleTmp = `${filePath}.99999.1.tmp`;
+                writeFileSync(staleTmp, 'stale');
 
-            const localFile = new LocalFile(filePath);
-            await localFile.write('new-content');
+                // Backdate the tmp file so it exceeds the 30-minute staleness threshold
+                const oldTime = new Date(Date.now() - 31 * 60 * 1000);
+                utimesSync(staleTmp, oldTime, oldTime);
 
-            expect(existsSync(staleTmp)).toBe(false);
-            expect(readFileSync(filePath, 'utf8')).toBe('new-content');
+                const localFile = new LocalFile(filePath);
+                await localFile.write('new-content');
+
+                // Advance past the 60s setTimeout to trigger deferred cleanup
+                await vi.advanceTimersByTimeAsync(60 * 1000);
+                // Allow the async cleanup to complete
+                await vi.advanceTimersByTimeAsync(0);
+
+                await waitFor(() => {
+                    expect(existsSync(staleTmp)).toBe(false);
+                    expect(readFileSync(filePath, 'utf8')).toBe('new-content');
+                });
+            } finally {
+                vi.useRealTimers();
+            }
         });
 
         it('should not leave tmp files after successful write', async () => {


### PR DESCRIPTION
  1. Eliminates TOCTOU race conditions in file reads
    - Removes the existsSync check-then-read pattern from readFileIfExists, readFileIfExistsAsync, readBufferIfExists, and readBufferIfExistsAsync. Instead, it just attempts
  the read and catches ENOENT, converting it to DoesNotExist. This eliminates the race where a file could be deleted between the existence check and the actual read.
    - readBufferIfExistsAsync is now properly async (it was missing the keyword before).

  2. Safer isFileNotFoundError
    - Adds a null/type guard before accessing .code, preventing potential crashes on non-object errors.

  3. Smarter rename retry logic
    - ENOENT is removed from the retriable rename error codes — if the source file doesn't exist, retrying won't help.
    - On non-retriable failures, it only attempts to unlink the source file if the error isn't ENOENT (can't delete what doesn't exist).
    - Retry delay now uses exponential backoff with jitter (calculateDelay) instead of a fixed delay.

  5. Deferred temp file cleanup
    - Stale .tmp file cleanup is moved out of the write hot path into a setTimeout(..., 60s).unref() so it doesn't block writes.
    - Cleanup now checks file age (30-minute threshold via stat().mtimeMs) before deleting, preventing process B from deleting process A's active temp file during lock
  stealing.
    - Adds detailed JSDoc explaining the lockless-read / atomic-write design and its cross-platform safety profile.

  6. calculateDelay exported
    - Extracted default retry options into a DefaultRetryOptions constant