### PR TITLE
fix: add close-guard to prevent TOCTOU race in LMDB lifecycle

### DIFF
--- a/src/datastore/LMDBStoreFactory.ts
+++ b/src/datastore/LMDBStoreFactory.ts
@@ -23,6 +23,7 @@ export class LMDBStoreFactory implements DataStoreFactory {
     private env: RootDatabase;
     private openPid = processId();
     private closed = false;
+    private activeOps = 0;
 
     private readonly stores = new Map<StoreName, LMDBStore>();
 
@@ -96,10 +97,29 @@ export class LMDBStoreFactory implements DataStoreFactory {
         if (this.closed) return;
         this.closed = true;
 
+        const deadline = Date.now() + 2000;
+        while (this.activeOps > 0 && Date.now() < deadline) {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        if (this.activeOps > 0) {
+            this.log.warn({ activeOps: this.activeOps }, 'Closing LMDB with in-flight operations after timeout');
+        }
+
         clearInterval(this.metricsInterval);
         clearTimeout(this.timeout);
         this.stores.clear();
         await this.env.close();
+    }
+
+    private beginOp(): () => void {
+        // Safe: JS is single-threaded, so closed check + increment is atomic within a tick
+        if (this.closed) {
+            throw new Error('Database is closed');
+        }
+        this.activeOps++;
+        return () => {
+            this.activeOps--;
+        };
     }
 
     private handleError(error: unknown): void {
@@ -175,6 +195,12 @@ export class LMDBStoreFactory implements DataStoreFactory {
         }
     }
 
+    /**
+     * Replaces the LMDB environment synchronously. In-flight async operations may
+     * fail on the old env, but execAsync's retry logic will recover using the new
+     * store handle (updated by recreateStores). Unlike close(), we don't drain
+     * activeOps because the env is being replaced, not destroyed.
+     */
     private reopenEnv(): void {
         this.telemetry.count('env.reopen', 1);
         this.env = createEnv(this.lmdbDir).env;
@@ -202,6 +228,7 @@ export class LMDBStoreFactory implements DataStoreFactory {
                 database,
                 (e) => this.handleError(e),
                 () => this.ensureValidEnv(),
+                () => this.beginOp(),
             ),
         );
     }

--- a/src/datastore/lmdb/LMDBStore.ts
+++ b/src/datastore/lmdb/LMDBStore.ts
@@ -14,6 +14,8 @@ export class LMDBStore implements DataStore {
         private store: Database<unknown, string>,
         private readonly onError: ErrorHandler,
         private readonly validateDatabase: () => void,
+        // eslint-disable-next-line unicorn/consistent-function-scoping
+        private readonly beginOp: () => () => void = () => () => {},
     ) {
         this.telemetry = TelemetryService.instance.get(`LMDB.${name}`);
     }
@@ -26,6 +28,7 @@ export class LMDBStore implements DataStore {
         return this.telemetry.measure(
             op,
             () => {
+                const release = this.beginOp();
                 try {
                     this.validateDatabase();
                     return fn();
@@ -34,6 +37,8 @@ export class LMDBStore implements DataStore {
                     this.telemetry.count(`retry.${op}`, 1);
                     this.validateDatabase();
                     return fn();
+                } finally {
+                    release();
                 }
             },
             { captureErrorAttributes: true },
@@ -44,6 +49,7 @@ export class LMDBStore implements DataStore {
         return await this.telemetry.measureAsync(
             op,
             async () => {
+                const release = this.beginOp();
                 try {
                     this.validateDatabase();
                     return await fn();
@@ -52,6 +58,8 @@ export class LMDBStore implements DataStore {
                     this.telemetry.count(`retry.${op}`, 1);
                     this.validateDatabase();
                     return await fn();
+                } finally {
+                    release();
                 }
             },
             { captureErrorAttributes: true },

--- a/tst/unit/datastore/LMDB.closeGuard.test.ts
+++ b/tst/unit/datastore/LMDB.closeGuard.test.ts
@@ -1,0 +1,81 @@
+import { randomUUID as v4 } from 'crypto';
+import fs from 'fs';
+import { join } from 'path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { DataStore, StoreName } from '../../../src/datastore/DataStore';
+import { LMDBStoreFactory } from '../../../src/datastore/LMDBStoreFactory';
+
+describe('LMDB close guard', () => {
+    let factory: LMDBStoreFactory;
+    let store: DataStore;
+    const testDir = join(process.cwd(), 'node_modules', '.cache', 'lmdb-close-guard-tests', v4());
+
+    beforeEach(() => {
+        fs.mkdirSync(testDir, { recursive: true });
+        factory = new LMDBStoreFactory(testDir);
+        store = factory.get(StoreName.public_schemas);
+    });
+
+    afterEach(async () => {
+        await factory.close();
+        if (fs.existsSync(testDir)) {
+            fs.rmSync(testDir, { recursive: true, force: true });
+        }
+    });
+
+    it('should reject put after close', async () => {
+        await factory.close();
+        await expect(store.put('key', 'value')).rejects.toThrow('Database is closed');
+    });
+
+    it('should reject remove after close', async () => {
+        await factory.close();
+        await expect(store.remove('key')).rejects.toThrow('Database is closed');
+    });
+
+    it('should reject clear after close', async () => {
+        await factory.close();
+        await expect(store.clear()).rejects.toThrow('Database is closed');
+    });
+
+    it('should reject get after close', async () => {
+        await factory.close();
+        expect(() => store.get('key')).toThrow('Database is closed');
+    });
+
+    it('should reject keys after close', async () => {
+        await factory.close();
+        expect(() => store.keys(10)).toThrow('Database is closed');
+    });
+
+    it('should allow operations before close', async () => {
+        await store.put('key', 'value');
+        expect(store.get('key')).toBe('value');
+    });
+
+    it('should wait for in-flight operations before closing', async () => {
+        const putPromise = store.put('key', 'value');
+
+        const closePromise = factory.close();
+
+        await expect(putPromise).resolves.toBe(true);
+        await expect(closePromise).resolves.toBeUndefined();
+    });
+
+    it('should handle concurrent puts then close', async () => {
+        const puts = Array.from({ length: 10 }, (_, i) => store.put(`key-${i}`, `value-${i}`));
+
+        const closePromise = factory.close();
+
+        const results = await Promise.allSettled(puts);
+        const fulfilled = results.filter((r) => r.status === 'fulfilled');
+        expect(fulfilled.length).toBeGreaterThan(0);
+
+        await closePromise;
+    });
+
+    it('should handle double close gracefully', async () => {
+        await factory.close();
+        await expect(factory.close()).resolves.not.toThrow();
+    });
+});


### PR DESCRIPTION
Add a close-guard to synchronize database operations with environment lifecycle (close/reopenEnv). This prevents the race condition where close() or reopenEnv() can execute while async operations are still in-flight, causing 'Can not renew a transaction from a closed database' errors.

1. First `LMDBStore.execAsync()` calls `validateDatabase()` -> this passes -> then `await fn()` yields to the event loop
2. While yielded, `LMDBStoreFactory.close()` or `reopenEnv()` runs, sets `closed = true`, calls `env.close()` which aborts all active transactions and nulls the native LMDB handle
3. The awaited `fn()` resumes and tries `mdb_txn_renew()` on the now-closed environment

This approach uses an activeOps counter instead of locks:
- beginOp() — called at the start of every operation. Rejects with "Database is closed" if shutdown has started, otherwise increments the counter and returns a release function.
- close() — sets closed = true to reject new operations, then polls until activeOps === 0 (max 2s) before closing the env. Logs a warning if the timeout is hit.
    reopenEnv() — no draining needed. It's synchronous, and execAsync's retry logic handles any in-flight ops that fail on the old env.

Safe without locks because JS is single-threaded: the closed check + counter increment in beginOp() cannot be interrupted.

*Issue #, if available:*
This fix addresses provider latency spikes.
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
