### PR TITLE
fix: download wheels targeting Python 3.13 with pinned requirements

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,71 @@
+name: Automated Maintenance
+
+on:
+  schedule:
+    - cron: '0 10 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  get-configs:
+    uses: ./.github/workflows/configs.yml
+
+  maintenance:
+    needs: [get-configs]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js ${{ needs.get-configs.outputs.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ needs.get-configs.outputs.node-version }}
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Install git-secrets
+        run: |
+          git clone https://github.com/awslabs/git-secrets.git /tmp/git-secrets
+          cd /tmp/git-secrets
+          sudo make install
+
+      - name: Update requirements-pyodide.txt
+        run: |
+          PACKAGES=$(grep -v '^#' requirements-pyodide.txt | grep -v '^$' | sed 's/==.*//' | tr '\n' ' ')
+
+          rm -rf /tmp/wheels-update && mkdir /tmp/wheels-update
+          python3 -m pip download --dest /tmp/wheels-update \
+            --only-binary=:all: --python-version 313 --platform any \
+            --implementation py --abi none --no-deps $PACKAGES
+
+          # Regenerate lock file from downloaded wheel filenames
+          head -8 requirements-pyodide.txt > /tmp/requirements-header.txt
+          ls /tmp/wheels-update/*.whl | xargs -I{} basename {} | sort | \
+            sed 's/^\(.*\)-\(.*\)-py[23].*/\1==\2/' | sed 's/_/-/g' \
+            > /tmp/requirements-pins.txt
+          cat /tmp/requirements-header.txt /tmp/requirements-pins.txt > requirements-pyodide.txt
+
+      - name: Verify wheels download
+        run: npm run download-wheels
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: 'chore: Maintenance update'
+          branch: maintenance/update
+          delete-branch: true
+          title: 'chore: Maintenance Update'
+          body: |
+            Automated maintenance update.
+
+            - Updated wheels via download-wheels
+
+            This PR was created by the `maintenance` workflow.
+
+            > To trigger validation, close and reopen this PR.
+          labels: maintenance, automated

--- a/requirements-pyodide.txt
+++ b/requirements-pyodide.txt
@@ -1,0 +1,28 @@
+# Pure-Python wheels for cfn-lint in Pyodide (Python 3.13)
+# These are downloaded at build time and bundled as offline fallback.
+# Compiled packages (pyyaml, regex, rpds-py, pydantic-core) are fetched
+# separately from the Pyodide CDN as wasm32 wheels.
+#
+# To update: run `python3 -m pip download --only-binary=:all: --python-version 313
+#   --platform any --implementation py --abi none --no-deps <packages>`
+# and update the pinned versions below.
+cfn-lint==1.50.1
+aws-sam-translator==1.109.0
+jsonpatch==1.33
+jsonpointer==3.1.1
+networkx==3.6.1
+sympy==1.14.0
+mpmath==1.4.1
+typing_extensions==4.15.0
+boto3==1.43.4
+botocore==1.43.4
+jmespath==1.1.0
+s3transfer==0.17.0
+python-dateutil==2.9.0.post0
+six==1.17.0
+urllib3==2.6.3
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+referencing==0.37.0
+attrs==26.1.0
+annotated-types==0.7.0

--- a/tools/download-wheels.ts
+++ b/tools/download-wheels.ts
@@ -30,10 +30,18 @@ function downloadWheels(): void {
 
     try {
         // 1. Download cfn-lint and pure Python dependencies via pip
-        execSync('python3 -m pip download --dest ' + wheelsDir + ' --only-binary=:all: cfn-lint', {
-            stdio: 'inherit',
-            cwd: projectRoot,
-        });
+        // Use --python-version 313 to ensure we get wheels compatible with Pyodide's Python 3.13,
+        // regardless of the host Python version (e.g. Python 3.7 on legacy build containers).
+        const requirementsFile = join(projectRoot, 'requirements-pyodide.txt');
+        execSync(
+            `python3 -m pip download --dest ${wheelsDir}` +
+                ` --only-binary=:all: --python-version 313 --platform any --implementation py --abi none` +
+                ` --no-deps -r ${requirementsFile}`,
+            {
+                stdio: 'inherit',
+                cwd: projectRoot,
+            },
+        );
 
         // 2. Remove host-platform wheels for Pyodide-managed packages (pip gets the wrong arch)
         const wheels = readdirSync(wheelsDir).filter((file) => file.endsWith('.whl'));


### PR DESCRIPTION
The legacy Linux build container (node:18-buster) has Python 3.7, which causes `pip download cfn-lint` to resolve cfn-lint 0.83.x (the last version supporting 3.7). This results in a bundled cfn-lint that doesn't export `lint` from the top-level module, breaking pyodide initialization at runtime.

## Changes
- **`tools/download-wheels.ts`** — Use `--python-version 313 --platform any --implementation py --abi none --no-deps` with a requirements file so all builds (including legacy) download wheels compatible with Pyodide's Python 3.13
- **`requirements-pyodide.txt`** (new) — Pins all pure-Python wheel versions for reproducible builds across platforms
- **`.github/workflows/maintenance.yml`** (restored) — Weekly job that checks for newer versions, updates the requirements file, and opens a PR