### PR TITLE
fix: explicitly configure axios proxy for schema downloads

### DIFF
--- a/src/utils/RemoteDownload.ts
+++ b/src/utils/RemoteDownload.ts
@@ -1,11 +1,26 @@
-import axios from 'axios';
+import axios, { AxiosProxyConfig } from 'axios';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
+
+function getProxyConfig(): AxiosProxyConfig | undefined {
+    const proxyUrl =
+        process.env.HTTPS_PROXY ?? process.env.https_proxy ?? process.env.HTTP_PROXY ?? process.env.http_proxy;
+    if (!proxyUrl) return undefined;
+
+    const parsed = new URL(proxyUrl);
+    return {
+        host: parsed.hostname,
+        port: Number.parseInt(parsed.port, 10), // radix 10 for decimal parsing
+        // URL.protocol includes trailing colon (e.g. "http:"), strip it for axios config
+        protocol: parsed.protocol.replace(':', ''),
+    };
+}
 
 export async function downloadFile(url: string): Promise<Buffer> {
     const response = await axios({
         method: 'get',
         url: url,
         responseType: 'arraybuffer',
+        proxy: getProxyConfig(),
     });
 
     LoggerFactory.getLogger('Remote').info(`Fetching ${url}`);
@@ -17,6 +32,7 @@ export async function downloadJson<T = unknown>(url: string): Promise<T> {
     const response = await axios<T>({
         method: 'get',
         url: url,
+        proxy: getProxyConfig(),
     });
 
     return response.data;


### PR DESCRIPTION
## Problem

The axios upgrade from 1.15.2 → 1.16.1 (in #593) introduced built-in `https-proxy-agent` support, which changed how HTTPS proxies are handled internally. This broke the IDE canary tests which set up a local `mockttp` proxy server and inject `HTTPS_PROXY=http://localhost:{port}` into the LSP process to serve schema files locally.

The schema download hangs indefinitely because the new axios proxy handling doesn't properly connect to the mock proxy, causing a 30-second timeout on every LSP instance and failing all schema-dependent tests (hover, autocomplete, resource operations).

## Fix

Explicitly pass proxy configuration derived from `HTTPS_PROXY`/`HTTP_PROXY` environment variables to axios request options in `RemoteDownload.ts`. This ensures axios uses the proxy correctly regardless of its internal detection logic.

When no proxy env var is set, behavior is unchanged (no proxy). When set, the explicit config ensures proper connectivity.

## Testing

- Verified TypeScript compilation passes

## Related

- Caused by: #593 (dependency upgrade commit 257de51)