### PR TITLE
fix: classify missing credentials as a client error

### DIFF
--- a/src/auth/AwsCredentials.ts
+++ b/src/auth/AwsCredentials.ts
@@ -10,6 +10,7 @@ import { Telemetry } from '../telemetry/TelemetryDecorator';
 import { getRegion } from '../utils/Region';
 import { parseWithPrettyError } from '../utils/ZodErrorWrapper';
 import { UpdateCredentialsParams, IamCredentials } from './AwsLspAuthTypes';
+import { CredentialsProviderError } from './CredentialsProviderError';
 
 const DecryptedCredentialsSchema = z.object({
     data: z.object({
@@ -50,9 +51,7 @@ export class AwsCredentials {
 
     getIAM(): DeepReadonly<IamCredentials> {
         if (!this.iamCredentials) {
-            const error = new Error('IAM credentials not configured');
-            error.name = 'CredentialsProviderError';
-            throw error;
+            throw new CredentialsProviderError();
         }
         return structuredClone(this.iamCredentials);
     }

--- a/src/auth/AwsCredentials.ts
+++ b/src/auth/AwsCredentials.ts
@@ -51,7 +51,7 @@ export class AwsCredentials {
 
     getIAM(): DeepReadonly<IamCredentials> {
         if (!this.iamCredentials) {
-            throw new CredentialsProviderError();
+            throw new CredentialsProviderError('IAM credentials not configured');
         }
         return structuredClone(this.iamCredentials);
     }

--- a/src/auth/AwsCredentials.ts
+++ b/src/auth/AwsCredentials.ts
@@ -50,7 +50,9 @@ export class AwsCredentials {
 
     getIAM(): DeepReadonly<IamCredentials> {
         if (!this.iamCredentials) {
-            throw new Error('IAM credentials not configured');
+            const error = new Error('IAM credentials not configured');
+            error.name = 'CredentialsProviderError';
+            throw error;
         }
         return structuredClone(this.iamCredentials);
     }

--- a/src/auth/CredentialsProviderError.ts
+++ b/src/auth/CredentialsProviderError.ts
@@ -1,7 +1,6 @@
 export class CredentialsProviderError extends Error {
-    constructor(message: string = 'IAM credentials not configured') {
+    constructor(message: string) {
         super(message);
         this.name = 'CredentialsProviderError';
-        Object.setPrototypeOf(this, CredentialsProviderError.prototype);
     }
 }

--- a/src/auth/CredentialsProviderError.ts
+++ b/src/auth/CredentialsProviderError.ts
@@ -2,5 +2,6 @@ export class CredentialsProviderError extends Error {
     constructor(message: string) {
         super(message);
         this.name = 'CredentialsProviderError';
+        Object.setPrototypeOf(this, CredentialsProviderError.prototype);
     }
 }

--- a/src/auth/CredentialsProviderError.ts
+++ b/src/auth/CredentialsProviderError.ts
@@ -1,0 +1,7 @@
+export class CredentialsProviderError extends Error {
+    constructor(message: string = 'IAM credentials not configured') {
+        super(message);
+        this.name = 'CredentialsProviderError';
+        Object.setPrototypeOf(this, CredentialsProviderError.prototype);
+    }
+}

--- a/src/services/AwsClient.ts
+++ b/src/services/AwsClient.ts
@@ -38,15 +38,11 @@ export class AwsClient {
     }
 
     private iamClientConfig(): IamClientConfig {
-        try {
-            const credential = this.credentialsProvider.getIAM();
-            return {
-                region: credential.region,
-                credentials: credential,
-                customUserAgent: `${ExtensionId}/${ExtensionVersion}`,
-            };
-        } catch {
-            throw new Error('AWS credentials not configured. Authentication required for online features.');
-        }
+        const credential = this.credentialsProvider.getIAM();
+        return {
+            region: credential.region,
+            credentials: credential,
+            customUserAgent: `${ExtensionId}/${ExtensionVersion}`,
+        };
     }
 }

--- a/tst/unit/resourceState/ResourceStateManager.test.ts
+++ b/tst/unit/resourceState/ResourceStateManager.test.ts
@@ -108,6 +108,16 @@ describe('ResourceStateManager', () => {
             expect(result.error).toContain('not authorized to perform');
         });
 
+        it('should return error when credentials are not configured', async () => {
+            const error = new Error('IAM credentials not configured');
+            error.name = 'CredentialsProviderError';
+            vi.mocked(mockCcapiService.getResource).mockRejectedValue(error);
+
+            const result = await manager.getResource('AWS::CloudWatch::Alarm', 'myalarm');
+            expect(result.resource).toBeUndefined();
+            expect(result.error).toContain('IAM credentials not configured');
+        });
+
         it('should return error when S3 bucket verification throws ResourceNotFoundException', async () => {
             vi.mocked(mockS3Service.verifyBucketAccessibleInRegion).mockRejectedValue(
                 new ResourceNotFoundException({

--- a/tst/unit/services/AwsClient.test.ts
+++ b/tst/unit/services/AwsClient.test.ts
@@ -49,9 +49,7 @@ describe('AwsClient', () => {
         it('should handle credentials provider errors', () => {
             mockComponents.awsCredentials.getIAM.throws(new Error('IAM credentials not configured'));
 
-            expect(() => component.getCloudFormationClient()).toThrow(
-                'AWS credentials not configured. Authentication required for online features.',
-            );
+            expect(() => component.getCloudFormationClient()).toThrow('IAM credentials not configured');
         });
     });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current code today catches a missing credential-related error, and rethrows it as a new one with a generic name (`Error`), that is not being recognized as a credential-related issue.  The fix, proposed in this PR, lets the original error to propagate untouched.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
