### PR TITLE
Do not call find occurences multiple times

### DIFF
--- a/src/services/CodeActionService.ts
+++ b/src/services/CodeActionService.ts
@@ -24,7 +24,7 @@ import { Telemetry, Track } from '../telemetry/TelemetryDecorator';
 import { pointToPosition } from '../utils/TypeConverters';
 import { ExtractToParameterProvider } from './extractToParameter/ExtractToParameterProvider';
 
-export interface CodeActionFix {
+interface CodeActionFix {
     title: string;
     kind: string;
     actionType: string;
@@ -536,25 +536,20 @@ export class CodeActionService {
                     this.telemetry.count('refactor.extractToParameterOffered', 1);
                 }
 
-                const hasMultiple = this.telemetry.measure('refactor.hasMultipleOccurrences', () =>
-                    this.extractToParameterProvider.hasMultipleOccurrences(context, params.textDocument.uri),
+                const extractAllAction = this.telemetry.measure('refactor.extractAllToParameter', () =>
+                    this.generateExtractAllOccurrencesToParameterAction(params, context),
                 );
 
-                if (hasMultiple) {
-                    const extractAllAction = this.telemetry.measure('refactor.extractAllToParameter', () =>
-                        this.generateExtractAllOccurrencesToParameterAction(params, context),
-                    );
-
-                    if (extractAllAction) {
-                        refactorActions.push(extractAllAction);
-                        this.telemetry.count('refactor.extractAllToParameterOffered', 1);
-                    }
+                if (extractAllAction) {
+                    refactorActions.push(extractAllAction);
+                    this.telemetry.count('refactor.extractAllToParameterOffered', 1);
                 }
             }
         } catch (error) {
             this.logError('generating refactor actions', error);
         }
 
+        this.telemetry.histogram('refactor.actions', refactorActions.length);
         return refactorActions;
     }
 

--- a/src/services/extractToParameter/AllOccurrencesFinder.ts
+++ b/src/services/extractToParameter/AllOccurrencesFinder.ts
@@ -1,6 +1,7 @@
 import { SyntaxNode } from 'tree-sitter';
 import { Range } from 'vscode-languageserver';
 import { TopLevelSection } from '../../context/CloudFormationEnums';
+import { SyntaxTree } from '../../context/syntaxtree/SyntaxTree';
 import { SyntaxTreeManager } from '../../context/syntaxtree/SyntaxTreeManager';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { LiteralValueInfo, LiteralValueType } from './ExtractToParameterTypes';
@@ -43,7 +44,7 @@ export class AllOccurrencesFinder {
         const sections = syntaxTree.findTopLevelSections([TopLevelSection.Resources, TopLevelSection.Outputs]);
 
         for (const sectionNode of sections.values()) {
-            this.traverseForMatches(sectionNode, targetValue, targetType, occurrences, documentUri);
+            this.traverseForMatches(sectionNode, targetValue, targetType, occurrences, syntaxTree);
         }
 
         return occurrences;
@@ -54,15 +55,14 @@ export class AllOccurrencesFinder {
         targetValue: string | number | boolean | unknown[],
         targetType: LiteralValueType,
         occurrences: Range[],
-        documentUri: string,
+        syntaxTree: SyntaxTree,
     ): void {
         // First check without propertyPath for performance
         const literalInfo = this.literalDetector.detectLiteralValue(node);
 
         if (literalInfo && this.isMatchingLiteral(literalInfo, targetValue, targetType)) {
             // Only compute propertyPath for matching literals to check if extractable
-            const syntaxTree = this.syntaxTreeManager.getSyntaxTree(documentUri);
-            const propertyPath = syntaxTree?.getPathAndEntityInfo(node)?.propertyPath;
+            const propertyPath = syntaxTree.getPathAndEntityInfo(node)?.propertyPath;
 
             // Re-check with propertyPath to exclude non-extractable paths
             const literalInfoWithPath = this.literalDetector.detectLiteralValue(node, propertyPath);
@@ -74,7 +74,7 @@ export class AllOccurrencesFinder {
         }
 
         for (const child of node.children) {
-            this.traverseForMatches(child, targetValue, targetType, occurrences, documentUri);
+            this.traverseForMatches(child, targetValue, targetType, occurrences, syntaxTree);
         }
     }
 

--- a/src/services/extractToParameter/ExtractToParameterProvider.ts
+++ b/src/services/extractToParameter/ExtractToParameterProvider.ts
@@ -65,30 +65,6 @@ export class ExtractToParameterProvider implements IExtractToParameterProvider {
     }
 
     /**
-     * Checks if there are multiple occurrences of the selected literal value in the template.
-     * Used to determine whether to offer the "Extract All Occurrences" action.
-     */
-    hasMultipleOccurrences(context: Context, uri?: string): boolean {
-        if (!this.canExtract(context)) {
-            return false;
-        }
-
-        const literalInfo = this.literalDetector.detectLiteralValue(context.syntaxNode, context.propertyPath);
-
-        if (!literalInfo) {
-            return false;
-        }
-
-        if (!uri) {
-            return false;
-        }
-
-        const allOccurrences = this.allOccurrencesFinder.findAllOccurrences(uri, literalInfo.value, literalInfo.type);
-
-        return allOccurrences.length > 1;
-    }
-
-    /**
      * Performs the complete extraction workflow including name generation,
      * type inference, and text edit creation.
      */
@@ -141,6 +117,11 @@ export class ExtractToParameterProvider implements IExtractToParameterProvider {
             baseExtraction.literalInfo.value,
             baseExtraction.literalInfo.type,
         );
+
+        // Only offer "extract all" when the literal appears more than once.
+        if (allOccurrences.length <= 1) {
+            return undefined;
+        }
 
         const replacementEdits = allOccurrences.map((occurrenceRange) =>
             this.textEditGenerator.generateLiteralReplacementEdit(

--- a/tst/unit/services/extractToParameter/ExtractToParameterProvider.test.ts
+++ b/tst/unit/services/extractToParameter/ExtractToParameterProvider.test.ts
@@ -163,6 +163,13 @@ describe('ExtractToParameterProvider', () => {
             const result = provider.canExtract(mockContext);
             expect(result).toBe(false);
         });
+
+        it('should return true for extractable literal in the Outputs section', () => {
+            (mockContext as any).section = TopLevelSection.Outputs;
+
+            const result = provider.canExtract(mockContext);
+            expect(result).toBe(true);
+        });
     });
 
     describe('generateExtraction method', () => {
@@ -580,157 +587,6 @@ Resources:
         });
     });
 
-    describe('hasMultipleOccurrences method', () => {
-        it('should return true when multiple occurrences exist', () => {
-            const mockTemplateContent = `{
-                "Resources": {
-                    "Bucket1": {
-                        "Type": "AWS::S3::Bucket",
-                        "Properties": {
-                            "BucketName": "my-bucket"
-                        }
-                    },
-                    "Bucket2": {
-                        "Type": "AWS::S3::Bucket",
-                        "Properties": {
-                            "BucketName": "my-bucket"
-                        }
-                    }
-                }
-            }`;
-
-            // Mock the syntax tree to return the template content with proper Resources section structure
-            (mockContext.syntaxNode as any) = {
-                type: 'string',
-                text: '"my-bucket"',
-                startPosition: { row: 0, column: 0 },
-                endPosition: { row: 0, column: 11 },
-                tree: {
-                    rootNode: {
-                        text: mockTemplateContent,
-                        children: [
-                            {
-                                type: 'pair',
-                                startPosition: { row: 0, column: 0 },
-                                endPosition: { row: 0, column: 0 },
-                                childForFieldName: (field: string) => {
-                                    if (field === 'key') {
-                                        return {
-                                            text: '"Resources"',
-                                            startPosition: { row: 0, column: 0 },
-                                            endPosition: { row: 0, column: 0 },
-                                        };
-                                    }
-                                    if (field === 'value') {
-                                        return {
-                                            type: 'object',
-                                            startPosition: { row: 0, column: 0 },
-                                            endPosition: { row: 0, column: 0 },
-                                            children: [
-                                                {
-                                                    type: 'string',
-                                                    text: '"my-bucket"',
-                                                    startPosition: { row: 0, column: 0 },
-                                                    endPosition: { row: 0, column: 11 },
-                                                    children: [],
-                                                },
-                                                {
-                                                    type: 'string',
-                                                    text: '"my-bucket"',
-                                                    startPosition: { row: 1, column: 0 },
-                                                    endPosition: { row: 1, column: 11 },
-                                                    children: [],
-                                                },
-                                            ],
-                                        };
-                                    }
-                                    return null;
-                                },
-                                children: [],
-                            },
-                        ],
-                    },
-                },
-            } as any;
-
-            vi.spyOn(mockContext as any, 'getRootEntityText').mockReturnValue(mockTemplateContent);
-
-            // Setup SyntaxTree mock to return Resources section with multiple occurrences
-            const mockResourcesSection = {
-                type: 'object',
-                children: [
-                    {
-                        type: 'string',
-                        text: '"my-bucket"',
-                        startPosition: { row: 0, column: 0 },
-                        endPosition: { row: 0, column: 11 },
-                        children: [],
-                    },
-                    {
-                        type: 'string',
-                        text: '"my-bucket"',
-                        startPosition: { row: 1, column: 0 },
-                        endPosition: { row: 1, column: 11 },
-                        children: [],
-                    },
-                ],
-            };
-
-            const sectionsMap = new Map([[TopLevelSection.Resources, mockResourcesSection as any]]);
-            mockSyntaxTree.findTopLevelSections.returns(sectionsMap);
-            mockSyntaxTreeManager.getSyntaxTree.returns(mockSyntaxTree);
-
-            const result = provider.hasMultipleOccurrences(mockContext, 'file:///test.json');
-            expect(result).toBe(true);
-        });
-
-        it('should return false when only one occurrence exists', () => {
-            const mockTemplateContent = `{
-                "Resources": {
-                    "Bucket1": {
-                        "Type": "AWS::S3::Bucket",
-                        "Properties": {
-                            "BucketName": "unique-bucket"
-                        }
-                    }
-                }
-            }`;
-
-            (mockContext.syntaxNode as any) = {
-                type: 'string',
-                text: '"unique-bucket"',
-                startPosition: { row: 0, column: 0 },
-                endPosition: { row: 0, column: 15 },
-                tree: {
-                    rootNode: {
-                        text: mockTemplateContent,
-                        children: [
-                            {
-                                type: 'string',
-                                text: '"unique-bucket"',
-                                startPosition: { row: 0, column: 0 },
-                                endPosition: { row: 0, column: 15 },
-                                children: [],
-                            },
-                        ],
-                    },
-                },
-            } as any;
-
-            vi.spyOn(mockContext as any, 'getRootEntityText').mockReturnValue(mockTemplateContent);
-
-            const result = provider.hasMultipleOccurrences(mockContext, 'file:///test.json');
-            expect(result).toBe(false);
-        });
-
-        it('should return false for non-extractable contexts', () => {
-            vi.spyOn(mockContext, 'isValue').mockReturnValue(false);
-
-            const result = provider.hasMultipleOccurrences(mockContext, 'file:///test.json');
-            expect(result).toBe(false);
-        });
-    });
-
     describe('generateAllOccurrencesExtraction method', () => {
         it('should generate extraction for all occurrences of a string literal', () => {
             const mockTemplateContent = `{
@@ -842,8 +698,58 @@ Resources:
             expect(result?.parameterDefinition.Type).toBe(ParameterType.String);
             expect(result?.parameterDefinition.Default).toBe('my-bucket');
             expect(result?.replacementEdits).toBeDefined();
-            expect(result?.replacementEdits.length).toBeGreaterThan(0);
+            expect(result?.replacementEdits.length).toBe(2);
             expect(result?.parameterInsertionEdit).toBeDefined();
+        });
+
+        it('should return undefined when the literal occurs only once (real traversal)', () => {
+            const mockTemplateContent = `{
+                "Resources": {
+                    "Bucket1": {
+                        "Type": "AWS::S3::Bucket",
+                        "Properties": { "BucketName": "my-bucket" }
+                    }
+                }
+            }`;
+
+            (mockContext.syntaxNode as any) = {
+                type: 'string',
+                text: '"my-bucket"',
+                startPosition: { row: 0, column: 0 },
+                endPosition: { row: 0, column: 11 },
+                tree: { rootNode: { text: mockTemplateContent, children: [] } },
+            };
+            vi.spyOn(mockContext as any, 'getRootEntityText').mockReturnValue(mockTemplateContent);
+
+            const singleOccurrenceSection = {
+                type: 'object',
+                children: [
+                    {
+                        type: 'string',
+                        text: '"my-bucket"',
+                        startPosition: { row: 0, column: 0 },
+                        endPosition: { row: 0, column: 11 },
+                        children: [],
+                    },
+                ],
+            };
+            mockSyntaxTree.findTopLevelSections.returns(
+                new Map([[TopLevelSection.Resources, singleOccurrenceSection as any]]),
+            );
+            mockSyntaxTreeManager.getSyntaxTree.returns(mockSyntaxTree);
+
+            // Spy call-through: proves we reached the occurrence check (past performBaseExtraction)
+            const findSpy = vi.spyOn((provider as any).allOccurrencesFinder, 'findAllOccurrences');
+
+            const result = provider.generateAllOccurrencesExtraction(
+                mockContext,
+                mockRange,
+                mockEditorSettings,
+                'file:///test.json',
+            );
+
+            expect(findSpy).toHaveBeenCalled();
+            expect(result).toBeUndefined();
         });
 
         it('should return undefined for non-extractable contexts', () => {


### PR DESCRIPTION
`generateCodeActions` is synchronous, so its measured duration is main-thread block time. The "Extract to Parameter" refactor ran the full Resources+Outputs literal scan (AllOccurrencesFinder.findAllOccurrences) twice per request - once in `hasMultipleOccurrences`, then again in `generateAllOccurrencesExtraction`. 

From metric for the worst real sample: total 12,003 ms = hasMultipleOccurrences 6,145 ms + extractAllToParameter 5,978 ms. While the actual extract action was only 60 ms. Because the editor requests code actions on cursor moves and diagnostic refreshes, this caused repeated multi-second freezes.

1. CodeActionService.generateRefactorActions - removed the separate hasMultipleOccurrences scan; the extract-all path now runs the scan only once.
2. ExtractToParameterProvider.generateAllOccurrencesExtraction - returns undefined when occurrences ≤ 1, preserving the prior "offer Extract-All only for multiple occurrences" behavior now that the gating scan is gone.
3. AllOccurrencesFinder.traverseForMatches - reuses the syntax tree already fetched in findAllOccurrences instead of re-fetching it from the manager on every matching node.

These eliminate the redundant 2× full-template scan (and the redundant per-match tree lookups) that caused the freezes, while keeping the offered actions identical.