### PR TITLE
feat: add Failed state to cfn-lint initialization

### DIFF
--- a/src/services/cfnLint/CfnLintErrors.ts
+++ b/src/services/cfnLint/CfnLintErrors.ts
@@ -6,6 +6,17 @@ export class WorkerNotInitializedError extends Error {
     }
 }
 
+export class InitializationError extends Error {
+    public readonly phase: string;
+
+    constructor(message: string, phase?: string, options?: ErrorOptions) {
+        super(message, options);
+        this.name = 'InitializationError';
+        this.phase = phase ?? 'unknown';
+        Object.setPrototypeOf(this, InitializationError.prototype);
+    }
+}
+
 export class MountError extends Error {
     public override readonly cause?: Error;
 

--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -17,7 +17,7 @@ import { extractErrorMessage } from '../../utils/Errors';
 import { ReadinessContributor, ReadinessStatus } from '../../utils/ReadinessContributor';
 import { byteSize } from '../../utils/String';
 import { DiagnosticCoordinator } from '../DiagnosticCoordinator';
-import { WorkerNotInitializedError, MountError } from './CfnLintErrors';
+import { InitializationError, WorkerNotInitializedError, MountError } from './CfnLintErrors';
 import { LocalCfnLintExecutor } from './LocalCfnLintExecutor';
 import { PyodideWorkerManager } from './PyodideWorkerManager';
 
@@ -31,6 +31,7 @@ enum STATUS {
     Uninitialized = 0,
     Initializing = 1,
     Initialized = 2,
+    Failed = 3,
 }
 
 /**
@@ -177,17 +178,19 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         this.status = STATUS.Initializing;
 
         const startTime = performance.now();
-        try {
-            if (this.settings.path) {
-                // Local executor doesn't need heavy initialization
-                this.localExecutor = new LocalCfnLintExecutor(this.settings.path);
-                this.status = STATUS.Initialized;
-                this.telemetry.count('init.success', 1, { attributes: { mode: 'local' } });
-                this.telemetry.histogram('init.duration', performance.now() - startTime, { unit: 'ms' });
-                return;
-            }
 
-            // Initialize the worker manager
+        if (this.settings.path) {
+            // Local executor doesn't need heavy initialization
+            this.localExecutor = new LocalCfnLintExecutor(this.settings.path);
+            this.status = STATUS.Initialized;
+            this.telemetry.count('init.success', 1, { attributes: { mode: 'local' } });
+            this.telemetry.histogram('init.duration', performance.now() - startTime, { unit: 'ms' });
+            return;
+        }
+
+        try {
+            // PyodideWorkerManager.initialize() already retries with exponential backoff
+            // (configured via settings.initialization: maxRetries=3, backoff, 2-min total timeout)
             await this.workerManager.initialize();
 
             // Remount previously mounted folders after worker recovery
@@ -216,8 +219,12 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
                 this.log.warn(`Failed to get cfn-lint version: ${extractErrorMessage(error)}`);
             }
         } catch (error) {
-            this.status = STATUS.Uninitialized;
-            this.telemetry.error('init.fault', error, undefined, { captureErrorType: true });
+            this.status = STATUS.Failed;
+            const phase = error instanceof InitializationError ? error.phase : 'unknown';
+            this.telemetry.error('init.fault', error, undefined, {
+                captureErrorType: true,
+                attributes: { 'init.phase': phase },
+            });
             this.telemetry.histogram('init.duration', performance.now() - startTime, { unit: 'ms' });
             throw new Error(`Failed to initialize Pyodide worker: ${extractErrorMessage(error)}`);
         }
@@ -624,6 +631,10 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             return;
         }
 
+        if (this.status === STATUS.Failed) {
+            throw new Error('CfnLintService initialization failed permanently. Restart the language server to retry.');
+        }
+
         if (this.status === STATUS.Uninitialized) {
             this.initializationPromise = this.initialize();
         } else if (this.status === STATUS.Initializing) {
@@ -763,6 +774,11 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             }
         }
 
+        if (this.status === STATUS.Failed) {
+            this.telemetry.count('lint.uninitialized', 1);
+            return;
+        }
+
         if (this.status !== STATUS.Initialized) {
             // Create a promise that will be resolved when the queued request is processed
             return await new Promise<void>((resolve, reject) => {
@@ -856,12 +872,12 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         // Cancel all pending delayed requests
         this.delayer.cancelAll();
 
-        if (this.status !== STATUS.Uninitialized) {
+        if (this.status !== STATUS.Uninitialized && this.status !== STATUS.Failed) {
             // Shutdown worker manager
             await this.workerManager.shutdown();
             this.localExecutor = undefined;
-            this.status = STATUS.Uninitialized;
         }
+        this.status = STATUS.Uninitialized;
     }
 
     static create(

--- a/src/services/cfnLint/PyodideWorkerManager.ts
+++ b/src/services/cfnLint/PyodideWorkerManager.ts
@@ -8,7 +8,7 @@ import { ScopedTelemetry } from '../../telemetry/ScopedTelemetry';
 import { Telemetry } from '../../telemetry/TelemetryDecorator';
 import { extractErrorMessage } from '../../utils/Errors';
 import { retryWithExponentialBackoff } from '../../utils/Retry';
-import { WorkerNotInitializedError } from './CfnLintErrors';
+import { InitializationError, WorkerNotInitializedError } from './CfnLintErrors';
 
 interface WorkerTask {
     id: string;
@@ -25,6 +25,7 @@ interface WorkerMessage {
     error?: string;
     success?: boolean;
     data?: string;
+    phase?: string;
 }
 
 export class PyodideWorkerManager {
@@ -200,7 +201,10 @@ export class PyodideWorkerManager {
         if (message.success) {
             task.resolve(message.result);
         } else {
-            task.reject(new Error(message.error));
+            const error = message.phase
+                ? new InitializationError(message.error ?? 'Unknown error', message.phase)
+                : new Error(message.error);
+            task.reject(error);
         }
     }
 

--- a/src/services/cfnLint/pyodide-worker.ts
+++ b/src/services/cfnLint/pyodide-worker.ts
@@ -93,11 +93,22 @@ if (parentPort) {
                     id,
                     error: extractErrorMessage(error),
                     success: false,
+                    phase: action === 'initialize' ? currentInitPhase : undefined,
                 });
             }
         }
     });
 }
+
+type InitPhase =
+    | 'pyodide_load'
+    | 'micropip_load'
+    | 'ssl_load'
+    | 'packages_load'
+    | 'cfn_lint_install'
+    | 'cfn_lint_setup';
+
+let currentInitPhase: InitPhase = 'pyodide_load';
 
 // Initialize Pyodide with cfn-lint
 async function initializePyodide(): Promise<InitializeResult> {
@@ -113,6 +124,7 @@ async function initializePyodide(): Promise<InitializeResult> {
 
     try {
         // Load Pyodide with explicit stdout/stderr handlers
+        currentInitPhase = 'pyodide_load';
         pyodide = await loadPyodide({
             stdout: customStdout,
             stderr: customStderr,
@@ -134,11 +146,13 @@ async function initializePyodide(): Promise<InitializeResult> {
         // Load bootstrap packages — micropip is required for fallback installs
         // loadPackage fetches from JsDelivr CDN which can silently fail
         // Set CFN_LSP_OFFLINE=1 to skip CDN and test local wheel fallback
+        currentInitPhase = 'micropip_load';
         const offlineMode = process.env.CFN_LSP_OFFLINE === '1';
         if (!offlineMode) {
             await pyodide.loadPackage('micropip');
         }
         // ssl is a system shared library — must always use loadPackage (can't install via micropip)
+        currentInitPhase = 'ssl_load';
         await pyodide.loadPackage('ssl');
 
         // Verify micropip is available; fall back to local wheel if CDN failed
@@ -168,6 +182,7 @@ async function initializePyodide(): Promise<InitializeResult> {
 
         // Load packages with verification and local wheel/micropip fallback
         // Define the package mapping once, used for both verification and cfn-lint skip logic
+        currentInitPhase = 'packages_load';
         const pyodidePackages = ['pyyaml', 'regex', 'rpds-py', 'pydantic', 'pydantic-core'];
         if (!offlineMode) {
             for (const pkg of pyodidePackages) {
@@ -211,6 +226,7 @@ async function initializePyodide(): Promise<InitializeResult> {
      `);
 
         // Install cfn-lint with local wheel fallback
+        currentInitPhase = 'cfn_lint_install';
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const installResult = await pyodide.runPythonAsync(`
       import micropip
@@ -256,6 +272,7 @@ async function initializePyodide(): Promise<InitializeResult> {
     `);
 
         // Setup Python functions for linting
+        currentInitPhase = 'cfn_lint_setup';
         await pyodide.runPythonAsync(`
       import json
       from cfnlint.version import __version__


### PR DESCRIPTION
Description of changes:
PyodideWorkerManager already retries initialization with exponential backoff (3 retries, 1s-30s backoff, 2-min total timeout). Previously, if that exhausted, CfnLintService would reset to Uninitialized and re-attempt on every file edit - emitting init.fault each time.

Changes:

- Add `STATUS.Failed`: entered when `workerManager.initialize()` throws after its internal retries
- Emit `init.fault` exactly once per session (after all retries exhausted)
- `lintDelayed()` silently continues if the service is failed
- `ensureInitialized()` short-circuits when Failed — no more re-initialization attempts
- `close()` resets to Uninitialized so a language server restart allows a fresh attempt

User experience:
- Previously: cfn-lint silently retried forever on each file edit, burning CPU
- Now: user sees a diagnostic on line 1 ("cfn-lint failed to initialize. Restart the language server to retry.")

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.