### PR TITLE
Recover LMDB crash on startup

### DIFF
--- a/src/app/standalone.ts
+++ b/src/app/standalone.ts
@@ -16,6 +16,7 @@ async function onInitialize(params: ExtendedInitializeParams) {
     // Dynamically load these modules so that OTEL can instrument all the libraries first
     const { CfnInfraCore } = await import('../server/CfnInfraCore');
     const core = new CfnInfraCore(lsp.components, params);
+    await core.dataStoreFactory.initialize();
 
     const { CfnServer } = await import('../server/CfnServer');
     server = new CfnServer(lsp.components, core);

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -36,11 +36,15 @@ export interface DataStoreFactory extends Closeable {
 
     storeNames: ReadonlyArray<string>;
 
+    initialize(): Promise<void>;
+
     close(): Promise<void>;
 }
 
 export interface DataStoreFactoryProvider extends Closeable {
     get(store: StoreName, persistence: Persistence): DataStore;
+
+    initialize(): Promise<void>;
 }
 
 export class MemoryDataStoreFactoryProvider implements DataStoreFactoryProvider {
@@ -52,6 +56,10 @@ export class MemoryDataStoreFactoryProvider implements DataStoreFactoryProvider 
 
     getMemoryStore(store: StoreName): DataStore {
         return this.memoryStoreFactory.get(store);
+    }
+
+    initialize(): Promise<void> {
+        return this.memoryStoreFactory.initialize();
     }
 
     close(): Promise<void> {
@@ -78,6 +86,11 @@ export class MultiDataStoreFactoryProvider implements DataStoreFactoryProvider {
             return this.memoryStoreFactory.get(store);
         }
         return this.persistedStore.get(store);
+    }
+
+    async initialize(): Promise<void> {
+        await this.memoryStoreFactory.initialize();
+        await this.persistedStore.initialize();
     }
 
     close(): Promise<void> {

--- a/src/datastore/FileStoreFactory.ts
+++ b/src/datastore/FileStoreFactory.ts
@@ -60,6 +60,10 @@ export class FileStoreFactory implements DataStoreFactory {
         return val;
     }
 
+    initialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
     close(): Promise<void> {
         if (this.closed) return Promise.resolve();
         this.closed = true;

--- a/src/datastore/LMDBStoreFactory.ts
+++ b/src/datastore/LMDBStoreFactory.ts
@@ -9,80 +9,67 @@ import { extractErrorMessage } from '../utils/Errors';
 import { formatNumber, toString } from '../utils/String';
 import { DataStore, DataStoreFactory, PersistedStores, StoreName } from './DataStore';
 import { LMDBStore } from './lmdb/LMDBStore';
+import { LMDBOwnershipTracker } from './lmdb/OwnershipTracker';
 import { stats } from './lmdb/Stats';
 import { encryptionStrategy } from './lmdb/Utils';
+
+const MetricsIntervalMs = 60 * 1000;
+const CleanupDelayMs = 2 * 60 * 1000;
 
 export class LMDBStoreFactory implements DataStoreFactory {
     private readonly log = LoggerFactory.getLogger('LMDB.Global');
     @Telemetry({ scope: 'LMDB.Global' }) private readonly telemetry!: ScopedTelemetry;
 
     private readonly lmdbDir: string;
-    private readonly timeout: NodeJS.Timeout;
-    private readonly metricsInterval: NodeJS.Timeout;
+    private metricsInterval?: NodeJS.Timeout;
+    private cleanupTimeout?: NodeJS.Timeout;
 
-    private env: RootDatabase;
+    private env!: RootDatabase;
     private openPid = processId();
+    private initPromise?: Promise<void>;
     private closed = false;
     private activeOps = 0;
 
     private readonly stores = new Map<StoreName, LMDBStore>();
+    private readonly ownershipTracker: LMDBOwnershipTracker;
 
     constructor(
         rootDir: string,
         public readonly storeNames = PersistedStores,
     ) {
         this.lmdbDir = join(rootDir, 'lmdb');
+        this.ownershipTracker = new LMDBOwnershipTracker(this.lmdbDir);
+    }
 
-        let config: RootDatabaseOptionsWithPath;
-        try {
-            const result = createEnv(this.lmdbDir);
-            this.env = result.env;
-            config = result.config;
-        } catch (e) {
-            this.log.warn(e, 'LMDB corrupted on startup, deleting and recreating');
+    /**
+     * Open the LMDB environment and stores. Idempotent: concurrent and repeat callers
+     * share a single in-flight promise, and a failed attempt is not cached, so a retry
+     * re-runs initialization rather than leaving the factory permanently half-open.
+     */
+    initialize(): Promise<void> {
+        this.initPromise ??= this.runInitialize().catch((error) => {
+            // Allow a later caller to retry instead of caching the rejection forever.
+            this.initPromise = undefined;
+            throw error;
+        });
+        return this.initPromise;
+    }
+
+    private async runInitialize(): Promise<void> {
+        // Record an `opening` marker and recover from a prior startup crash before the
+        // (potentially fatal) env open, so a crash here is detectable on the next start.
+        await this.ownershipTracker.beginStartup(() => {
+            this.log.warn('Detected fatal LMDB startup crash from a previous run, wiping data directory to recover');
+            this.telemetry.count('startup.crashRecovery', 1);
             this.deleteVersionDir();
-            const result = createEnv(this.lmdbDir);
-            this.env = result.env;
-            config = result.config;
-        }
+        });
 
-        try {
-            for (const store of storeNames) {
-                this.addStore(store);
-            }
-        } catch (e) {
-            this.log.warn(e, 'Store corrupted on startup, deleting and recreating');
-            this.stores.clear();
-            void this.env.close();
-            this.deleteVersionDir();
-            this.env = createEnv(this.lmdbDir).env;
-            for (const store of storeNames) {
-                this.addStore(store);
-            }
-        }
+        this.openEnvAndStores();
 
-        this.metricsInterval = setInterval(() => {
-            this.emitMetrics();
-        }, 60 * 1000);
-
-        this.timeout = setTimeout(
-            () => {
-                this.cleanupOldVersions();
-            },
-            2 * 60 * 1000,
-        );
-
-        this.log.info(
-            {
-                path: config.path,
-                maxDbs: config.maxDbs,
-                mapSize: config.mapSize,
-                encoding: config.encoding,
-                noSubdir: config.noSubdir,
-                overlappingSync: config.overlappingSync,
-            },
-            `Initialized LMDB ${Version} with stores: ${toString(storeNames)} and ${formatNumber(stats(this.env).totalSize / (1024 * 1024), 4)} MB`,
-        );
+        // The env and stores opened successfully — promote the marker out of `opening`
+        // so an abrupt kill from now on is not mistaken for a startup crash.
+        this.ownershipTracker.markRunning();
+        this.scheduleBackgroundTasks();
     }
 
     get(store: StoreName): DataStore {
@@ -105,10 +92,80 @@ export class LMDBStoreFactory implements DataStoreFactory {
             this.log.warn({ activeOps: this.activeOps }, 'Closing LMDB with in-flight operations after timeout');
         }
 
-        clearInterval(this.metricsInterval);
-        clearTimeout(this.timeout);
+        if (this.metricsInterval !== undefined) {
+            clearInterval(this.metricsInterval);
+        }
+        if (this.cleanupTimeout !== undefined) {
+            clearTimeout(this.cleanupTimeout);
+        }
         this.stores.clear();
-        await this.env.close();
+
+        // initialize() may have failed or never run, leaving env unset.
+        if ((this.env as RootDatabase | undefined) !== undefined) {
+            await this.env.close();
+        }
+        this.ownershipTracker.release();
+    }
+
+    private openEnvAndStores(): void {
+        const config = this.tryOpen() ?? this.recreateAfterCorruption();
+
+        this.log.info(
+            {
+                path: config.path,
+                maxDbs: config.maxDbs,
+                mapSize: config.mapSize,
+                encoding: config.encoding,
+                noSubdir: config.noSubdir,
+                overlappingSync: config.overlappingSync,
+            },
+            `Initialized LMDB ${Version} with stores: ${toString(this.storeNames)} and ${formatNumber(stats(this.env).totalSize / (1024 * 1024), 4)} MB`,
+        );
+    }
+
+    /**
+     * Open the environment and every store, returning the config on success or
+     * `undefined` if either step throws so the caller can recover.
+     */
+    private tryOpen(): RootDatabaseOptionsWithPath | undefined {
+        try {
+            return this.openEnvAndAddStores();
+        } catch (e) {
+            this.log.warn(e, 'LMDB corrupted on startup, deleting and recreating');
+            return undefined;
+        }
+    }
+
+    /**
+     * Delete the (presumed corrupt) version directory and open a fresh environment and
+     * stores. Unlike {@link tryOpen}, a failure here is fatal and propagates.
+     */
+    private recreateAfterCorruption(): RootDatabaseOptionsWithPath {
+        this.stores.clear();
+        if ((this.env as RootDatabase | undefined) !== undefined) {
+            void this.env.close();
+        }
+        this.deleteVersionDir();
+        return this.openEnvAndAddStores();
+    }
+
+    private openEnvAndAddStores(): RootDatabaseOptionsWithPath {
+        const { env, config } = createEnv(this.lmdbDir);
+        this.env = env;
+        for (const store of this.storeNames) {
+            this.addStore(store);
+        }
+        return config;
+    }
+
+    private scheduleBackgroundTasks(): void {
+        this.metricsInterval = setInterval(() => {
+            this.emitMetrics();
+        }, MetricsIntervalMs);
+
+        this.cleanupTimeout = setTimeout(() => {
+            this.cleanupOldVersions();
+        }, CleanupDelayMs);
     }
 
     private beginOp(): () => void {
@@ -247,10 +304,12 @@ export class LMDBStoreFactory implements DataStoreFactory {
         const entries = readdirSync(this.lmdbDir, { withFileTypes: true });
         for (const entry of entries) {
             try {
-                if (entry.name !== Version) {
-                    this.telemetry.count('oldVersion.cleanup.count', 1);
-                    rmSync(join(this.lmdbDir, entry.name), { recursive: true, force: true });
+                if (entry.name === Version || entry.name === LMDBOwnershipTracker.DirName) {
+                    continue;
                 }
+
+                this.telemetry.count('oldVersion.cleanup.count', 1);
+                rmSync(join(this.lmdbDir, entry.name), { recursive: true, force: true });
             } catch (error) {
                 this.log.error(error, 'Failed to cleanup old LMDB versions');
                 this.telemetry.count('oldVersion.cleanup.error', 1);
@@ -290,7 +349,7 @@ export class LMDBStoreFactory implements DataStoreFactory {
     }
 }
 
-const VersionNumber = 5;
+const VersionNumber = 6;
 const Version = `v${VersionNumber}`;
 const Encoding: 'msgpack' | 'json' | 'string' | 'binary' | 'ordered-binary' = 'msgpack';
 const TotalMaxDbSize = 250 * 1024 * 1024; // 250MB max size

--- a/src/datastore/MemoryStore.ts
+++ b/src/datastore/MemoryStore.ts
@@ -94,6 +94,10 @@ export class MemoryStoreFactory implements DataStoreFactory {
         return [...this.stores.keys()];
     }
 
+    initialize(): Promise<void> {
+        return Promise.resolve();
+    }
+
     close(): Promise<void> {
         clearInterval(this.metricsInterval);
         return Promise.resolve();

--- a/src/datastore/lmdb/OwnershipTracker.ts
+++ b/src/datastore/lmdb/OwnershipTracker.ts
@@ -1,0 +1,224 @@
+import { mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { lock } from 'proper-lockfile';
+import { LoggerFactory } from '../../telemetry/LoggerFactory';
+import { processId } from '../../utils/Environment';
+import { LOCK_OPTIONS } from '../../utils/LocalFile';
+
+const OWNER_MARKER_PREFIX = 'owner.';
+const COORDINATION_FILE_NAME = 'coordination';
+
+/**
+ * Lifecycle phase encoded in each owner marker's file name.
+ *
+ * - `opening`: inside the LMDB open. A C-level abort here (e.g. an lmdb assertion) kills
+ *   the process with no JS cleanup, so a marker left in this phase signals a startup crash.
+ * - `running`: the env opened successfully. A marker left here is an ordinary abrupt kill
+ *   (SIGKILL, shutdown, OOM) of a healthy process — not a startup crash.
+ */
+export enum OwnershipPhase {
+    opening = 'opening',
+    running = 'running',
+}
+
+interface MarkerScan {
+    /** Number of markers belonging to other, still-running processes. */
+    liveOwners: number;
+    /** Marker file names safe to delete (dead owners and malformed marker files). */
+    removableFiles: string[];
+    /** Number of dead owners that died while still in the `opening` phase. */
+    crashedStartups: number;
+}
+
+/**
+ * Detects fatal LMDB startup crashes across processes so a crash loop can be broken by
+ * wiping the (presumed corrupt) data directory exactly once.
+ *
+ * The LMDB directory is a single machine-wide path shared by every IDE/LSP process. A
+ * C-level abort while opening it kills the process with no JS cleanup, so the editor
+ * restarts into the same crash on loop. We detect this at the *next* startup from a
+ * per-PID marker left on disk: `owner.<pid>.opening` is written before opening LMDB and
+ * renamed to `owner.<pid>.running` once it succeeds; both are removed on clean shutdown.
+ *
+ * Under a cross-process lock, startup wipes the data directory only when BOTH hold:
+ *   1. no marker belongs to a live process (no sibling IDE is using the data), and
+ *   2. a dead owner is still in the `opening` phase (its startup died mid-open).
+ * A dead `running` marker is a healthy process killed abruptly, so reboots/force-quits
+ * preserve the cache.
+ *
+ * The scan, wipe, and marker claim share one `proper-lockfile` lock so concurrent
+ * startups can't both wipe or open a directory another is wiping. Every step is
+ * best-effort: any lock/filesystem failure is logged and treated as "cannot determine a
+ * crash → proceed without wiping", so detection alone can never block startup.
+ */
+export class LMDBOwnershipTracker {
+    static readonly DirName = 'markers';
+
+    private readonly log = LoggerFactory.getLogger('LMDB.Ownership');
+    private readonly markersDir: string;
+    private readonly coordinationPath: string;
+    private readonly pid = processId();
+
+    // True once we've written our own marker; distinguishes a recycled-PID predecessor's
+    // leftover marker (a crash) from our own marker left by an earlier retry (not a crash).
+    private ownMarkerClaimed = false;
+
+    constructor(lmdbDir: string) {
+        this.markersDir = join(lmdbDir, LMDBOwnershipTracker.DirName);
+        this.coordinationPath = join(this.markersDir, COORDINATION_FILE_NAME);
+    }
+
+    /**
+     * Under the coordination lock: detect a prior startup crash, invoke `onCrashDetected`
+     * (so the caller can safely wipe) if one is found with no live owner, clear dead
+     * markers, and claim this process's `opening` marker. Best-effort — any lock or
+     * filesystem failure is logged and swallowed so startup proceeds without a wipe.
+     */
+    async beginStartup(onCrashDetected: () => void): Promise<void> {
+        try {
+            mkdirSync(this.markersDir, { recursive: true });
+
+            const release = await lock(this.coordinationPath, LOCK_OPTIONS);
+            try {
+                const { liveOwners, removableFiles, crashedStartups } = this.scanMarkers();
+
+                if (liveOwners === 0 && crashedStartups > 0) {
+                    onCrashDetected();
+                }
+
+                for (const fileName of removableFiles) {
+                    this.removeMarker(join(this.markersDir, fileName));
+                }
+                this.writeOwnMarker(OwnershipPhase.opening);
+            } finally {
+                await release();
+            }
+        } catch (error) {
+            // Crash detection is a best-effort safeguard; never let it abort startup.
+            this.log.warn(error, 'LMDB crash detection failed; proceeding without recovery');
+        }
+    }
+
+    /**
+     * Promote this process's marker from `opening` to `running` after the env opens.
+     * Lock-free: only this process touches its own marker.
+     */
+    markRunning(): void {
+        try {
+            renameSync(this.ownMarkerPath(OwnershipPhase.opening), this.ownMarkerPath(OwnershipPhase.running));
+        } catch {
+            // The opening marker may be absent if beginStartup() could not write it.
+            // Record the running marker directly so a later startup reads the right phase.
+            try {
+                this.writeOwnMarker(OwnershipPhase.running);
+            } catch (error) {
+                this.log.warn(error, 'Failed to record LMDB running marker');
+            }
+        }
+    }
+
+    /** Remove this process's marker on clean shutdown. Idempotent. */
+    release(): void {
+        this.removeMarker(this.ownMarkerPath(OwnershipPhase.opening));
+        this.removeMarker(this.ownMarkerPath(OwnershipPhase.running));
+    }
+
+    private scanMarkers(): MarkerScan {
+        let entries: string[];
+        try {
+            entries = readdirSync(this.markersDir);
+        } catch (error) {
+            this.log.warn(error, 'Failed to list LMDB marker directory');
+            return { liveOwners: 0, removableFiles: [], crashedStartups: 0 };
+        }
+
+        const scan: MarkerScan = { liveOwners: 0, removableFiles: [], crashedStartups: 0 };
+
+        for (const fileName of entries) {
+            if (!fileName.startsWith(OWNER_MARKER_PREFIX)) {
+                continue;
+            }
+
+            const marker = parseMarker(fileName);
+            if (marker === undefined) {
+                scan.removableFiles.push(fileName);
+                continue;
+            }
+
+            const isOwnMarker = marker.pid === this.pid;
+            const isLive = !isOwnMarker && isProcessAlive(marker.pid);
+            if (isLive) {
+                scan.liveOwners++;
+                continue;
+            }
+
+            scan.removableFiles.push(fileName);
+
+            // A dead `opening` marker is a mid-open crash — unless it's our own from an
+            // earlier retry (already claimed), which would otherwise self-wipe. A same-PID
+            // marker seen before we've claimed ours is a recycled-PID predecessor's crash.
+            const isOwnRetryMarker = isOwnMarker && this.ownMarkerClaimed;
+            if (marker.phase === OwnershipPhase.opening && !isOwnRetryMarker) {
+                scan.crashedStartups++;
+            }
+        }
+
+        return scan;
+    }
+
+    private writeOwnMarker(phase: OwnershipPhase): void {
+        // Replace any leftover marker for our (possibly recycled) PID before claiming.
+        this.removeMarker(this.ownMarkerPath(OwnershipPhase.opening));
+        this.removeMarker(this.ownMarkerPath(OwnershipPhase.running));
+        writeFileSync(this.ownMarkerPath(phase), `${this.pid}\n${new Date().toISOString()}`);
+        this.ownMarkerClaimed = true;
+    }
+
+    private removeMarker(path: string): void {
+        try {
+            rmSync(path, { force: true });
+        } catch (error) {
+            this.log.warn(error, `Failed to remove LMDB marker ${path}`);
+        }
+    }
+
+    private ownMarkerPath(phase: OwnershipPhase): string {
+        return join(this.markersDir, `${OWNER_MARKER_PREFIX}${this.pid}.${phase}`);
+    }
+}
+
+interface ParsedMarker {
+    pid: number;
+    phase: OwnershipPhase;
+}
+
+function parseMarker(fileName: string): ParsedMarker | undefined {
+    const body = fileName.slice(OWNER_MARKER_PREFIX.length);
+    const separator = body.lastIndexOf('.');
+    if (separator <= 0) {
+        return undefined;
+    }
+
+    const pid = Number(body.slice(0, separator));
+    const phase = body.slice(separator + 1);
+    if (!Number.isInteger(pid) || pid <= 0 || !isOwnershipPhase(phase)) {
+        return undefined;
+    }
+
+    return { pid, phase };
+}
+
+function isOwnershipPhase(value: string): value is OwnershipPhase {
+    return value === OwnershipPhase.opening.toString() || value === OwnershipPhase.running.toString();
+}
+
+function isProcessAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error: unknown) {
+        // EPERM: the process exists but we lack permission to signal it — still alive.
+        // ESRCH (or anything else): no such process — treat as dead.
+        return (error as NodeJS.ErrnoException).code === 'EPERM';
+    }
+}

--- a/src/datastore/lmdb/OwnershipTracker.ts
+++ b/src/datastore/lmdb/OwnershipTracker.ts
@@ -3,10 +3,20 @@ import { join } from 'path';
 import { lock } from 'proper-lockfile';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { processId } from '../../utils/Environment';
+import { readFileIfExists } from '../../utils/File';
 import { LOCK_OPTIONS } from '../../utils/LocalFile';
 
 const OWNER_MARKER_PREFIX = 'owner.';
 const COORDINATION_FILE_NAME = 'coordination';
+
+/**
+ * An `opening` marker older than this is treated as a crashed startup regardless of whether its
+ * PID is currently alive. A real LMDB open completes in seconds, so this is set well beyond any
+ * plausible open duration: the margin absorbs slow disks and corruption-retry reopens while still
+ * breaking a recycled-PID crash loop within a couple of minutes. It exists because `isProcessAlive`
+ * cannot tell a crashed opener apart from an unrelated process the OS later assigned the same PID.
+ */
+const OPENING_MARKER_STALE_MS = 5 * 60 * 1000;
 
 /**
  * Lifecycle phase encoded in each owner marker's file name.
@@ -45,6 +55,12 @@ interface MarkerScan {
  *   2. a dead owner is still in the `opening` phase (its startup died mid-open).
  * A dead `running` marker is a healthy process killed abruptly, so reboots/force-quits
  * preserve the cache.
+ *
+ * Liveness is a PID check, which cannot distinguish a crashed opener from an unrelated
+ * process the OS later assigned the same PID. So an `opening` marker older than
+ * {@link OPENING_MARKER_STALE_MS} is treated as a dead crashed startup regardless of PID
+ * liveness (a genuine in-progress open is never that old), using the timestamp each marker
+ * persists in its body. This closes the window where a recycled PID keeps a crash loop alive.
  *
  * The scan, wipe, and marker claim share one `proper-lockfile` lock so concurrent
  * startups can't both wipe or open a directory another is wiping. Every step is
@@ -133,20 +149,29 @@ export class LMDBOwnershipTracker {
         }
 
         const scan: MarkerScan = { liveOwners: 0, removableFiles: [], crashedStartups: 0 };
+        const now = Date.now();
 
         for (const fileName of entries) {
             if (!fileName.startsWith(OWNER_MARKER_PREFIX)) {
                 continue;
             }
 
-            const marker = parseMarker(fileName);
+            const marker = parseMarker(fileName, this.readMarkerBody(fileName));
             if (marker === undefined) {
                 scan.removableFiles.push(fileName);
                 continue;
             }
 
             const isOwnMarker = marker.pid === this.pid;
-            const isLive = !isOwnMarker && isProcessAlive(marker.pid);
+            // An `opening` marker older than the threshold is a crashed startup even when its PID
+            // reads as alive: liveness is only a PID probe, which a PID the OS recycled to an
+            // unrelated process would pass, but a real open never lasts this long. Trusting the
+            // persisted age over `isProcessAlive` here is what defeats PID recycling.
+            const isStaleOpening =
+                marker.phase === OwnershipPhase.opening &&
+                marker.startedAt !== undefined &&
+                now - marker.startedAt > OPENING_MARKER_STALE_MS;
+            const isLive = !isOwnMarker && !isStaleOpening && isProcessAlive(marker.pid);
             if (isLive) {
                 scan.liveOwners++;
                 continue;
@@ -164,6 +189,15 @@ export class LMDBOwnershipTracker {
         }
 
         return scan;
+    }
+
+    /** Read a marker's body (best-effort); returns '' if it vanished or cannot be read. */
+    private readMarkerBody(fileName: string): string {
+        try {
+            return readFileIfExists(join(this.markersDir, fileName));
+        } catch {
+            return '';
+        }
     }
 
     private writeOwnMarker(phase: OwnershipPhase): void {
@@ -190,22 +224,40 @@ export class LMDBOwnershipTracker {
 interface ParsedMarker {
     pid: number;
     phase: OwnershipPhase;
+    /** When the marker was written (ms since epoch), or undefined if the body has no valid timestamp. */
+    startedAt: number | undefined;
 }
 
-function parseMarker(fileName: string): ParsedMarker | undefined {
-    const body = fileName.slice(OWNER_MARKER_PREFIX.length);
-    const separator = body.lastIndexOf('.');
+/**
+ * Parse a marker from its file name (authoritative for pid/phase) and, when available, the
+ * timestamp persisted in its body. `body` is the marker's file contents (`<pid>\n<ISO timestamp>`
+ * per {@link LMDBOwnershipTracker.writeOwnMarker}); an unreadable/legacy body simply yields no
+ * timestamp, leaving pid/phase detection unaffected.
+ */
+function parseMarker(fileName: string, body: string): ParsedMarker | undefined {
+    const nameBody = fileName.slice(OWNER_MARKER_PREFIX.length);
+    const separator = nameBody.lastIndexOf('.');
     if (separator <= 0) {
         return undefined;
     }
 
-    const pid = Number(body.slice(0, separator));
-    const phase = body.slice(separator + 1);
+    const pid = Number(nameBody.slice(0, separator));
+    const phase = nameBody.slice(separator + 1);
     if (!Number.isInteger(pid) || pid <= 0 || !isOwnershipPhase(phase)) {
         return undefined;
     }
 
-    return { pid, phase };
+    return { pid, phase, startedAt: parseTimestamp(body) };
+}
+
+/** Extract the ISO timestamp from a marker body (`<pid>\n<ISO timestamp>`), or undefined if absent/invalid. */
+function parseTimestamp(body: string): number | undefined {
+    const isoLine = body.split('\n', 2)[1]?.trim();
+    if (isoLine === undefined || isoLine === '') {
+        return undefined;
+    }
+    const parsed = Date.parse(isoLine);
+    return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 function isOwnershipPhase(value: string): value is OwnershipPhase {

--- a/src/datastore/lmdb/Utils.ts
+++ b/src/datastore/lmdb/Utils.ts
@@ -2,6 +2,7 @@ import { stableMachineSpecificKey } from '../../utils/MachineKey';
 
 export function encryptionStrategy(version: number): string | Buffer | undefined {
     switch (version) {
+        case 6:
         case 5:
         case 4: {
             return stableMachineSpecificKey('lmdb-static-salt', 'lmdb-encryption-key-derivation', 16).toString('hex');

--- a/src/utils/LocalFile.ts
+++ b/src/utils/LocalFile.ts
@@ -20,7 +20,7 @@ import {
 
 const log = LoggerFactory.getLogger('LocalFile');
 
-const LOCK_OPTIONS: LockOptions = {
+export const LOCK_OPTIONS: LockOptions = {
     stale: 10_000, // A lock older than this (ms) is considered abandoned and can be stolen by another process
     realpath: false, // Use path.resolve instead of fs.realpath so locking works on files that don't exist yet (first write)
     retries: {

--- a/tst/unit/datastore/LMDB.closeGuard.test.ts
+++ b/tst/unit/datastore/LMDB.closeGuard.test.ts
@@ -10,9 +10,10 @@ describe('LMDB close guard', () => {
     let store: DataStore;
     const testDir = join(process.cwd(), 'node_modules', '.cache', 'lmdb-close-guard-tests', v4());
 
-    beforeEach(() => {
+    beforeEach(async () => {
         fs.mkdirSync(testDir, { recursive: true });
         factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
         store = factory.get(StoreName.public_schemas);
     });
 

--- a/tst/unit/datastore/LMDB.corruption.test.ts
+++ b/tst/unit/datastore/LMDB.corruption.test.ts
@@ -24,10 +24,11 @@ describe('LMDB error recovery', () => {
     let testDir: string;
     let factory: LMDBStoreFactory;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         testDir = join(process.cwd(), 'node_modules', '.cache', 'lmdb-corruption-recovery-test', `test-${Date.now()}`);
         fs.mkdirSync(testDir, { recursive: true });
         factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
     });
 
     afterEach(async () => {

--- a/tst/unit/datastore/LMDB.recovery.test.ts
+++ b/tst/unit/datastore/LMDB.recovery.test.ts
@@ -4,17 +4,19 @@ import { join } from 'path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StoreName } from '../../../src/datastore/DataStore';
 import { LMDBStoreFactory } from '../../../src/datastore/LMDBStoreFactory';
+import { LMDBOwnershipTracker } from '../../../src/datastore/lmdb/OwnershipTracker';
 
 describe('LMDB fork detection and recovery', () => {
     let testDir: string;
     let factory: LMDBStoreFactory;
     let originalPid: number;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         testDir = join(process.cwd(), 'node_modules', '.cache', 'lmdb-recovery-test', v4());
         originalPid = process.pid;
         fs.mkdirSync(testDir, { recursive: true });
         factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
     });
 
     afterEach(async () => {
@@ -217,6 +219,7 @@ describe('LMDB fork detection and recovery', () => {
             fs.rmSync(testDir, { recursive: true, force: true });
 
             const newFactory = new LMDBStoreFactory(testDir);
+            await newFactory.initialize();
 
             await expect(newFactory.close()).resolves.not.toThrow();
         });
@@ -234,6 +237,18 @@ describe('LMDB fork detection and recovery', () => {
             expect(fs.existsSync(join(lmdbDir, 'v2'))).toBe(true);
 
             await factory.close();
+        });
+
+        it('should remove old version directories but preserve the markers directory', () => {
+            const lmdbDir = join(testDir, 'lmdb');
+            const markersDir = join(lmdbDir, LMDBOwnershipTracker.DirName);
+            fs.mkdirSync(join(lmdbDir, 'v1'), { recursive: true });
+
+            (factory as unknown as { cleanupOldVersions(): void }).cleanupOldVersions();
+
+            expect(fs.existsSync(join(lmdbDir, 'v1'))).toBe(false);
+            expect(fs.existsSync(markersDir)).toBe(true);
+            expect(fs.existsSync(join(lmdbDir, 'v6'))).toBe(true);
         });
     });
 });

--- a/tst/unit/datastore/LMDB.retry.test.ts
+++ b/tst/unit/datastore/LMDB.retry.test.ts
@@ -9,10 +9,11 @@ describe('LMDB retry after recovery', () => {
     let testDir: string;
     let factory: LMDBStoreFactory;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         testDir = join(process.cwd(), 'node_modules', '.cache', 'lmdb-retry-test', v4());
         fs.mkdirSync(testDir, { recursive: true });
         factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
     });
 
     afterEach(async () => {

--- a/tst/unit/datastore/LMDB.startup.test.ts
+++ b/tst/unit/datastore/LMDB.startup.test.ts
@@ -158,6 +158,32 @@ describe('LMDB startup crash detection', () => {
         await factory.close();
     });
 
+    it('should wipe version directory when a stale opening marker PID was recycled to a live process', async () => {
+        // Reproduces the PID-recycling gap: a mid-open crash left an opening marker whose PID the
+        // OS later handed to an unrelated, still-live process. A bare liveness check would count it
+        // as a live owner and suppress recovery; the marker's stale timestamp proves it is a crash.
+        fs.mkdirSync(versionDir, { recursive: true });
+        fs.writeFileSync(join(versionDir, 'stale-data.mdb'), 'pretend-corrupt');
+        fs.mkdirSync(markersDir, { recursive: true });
+        const recycledPid = 99994;
+        const staleIso = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+        fs.writeFileSync(
+            join(markersDir, markerName(recycledPid, OwnershipPhase.opening)),
+            `${recycledPid}\n${staleIso}`,
+        );
+        vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+            if (pid === recycledPid || pid === process.pid) return true; // recycled PID reads as alive
+            throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+        });
+
+        const factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
+
+        expect(fs.existsSync(join(versionDir, 'stale-data.mdb'))).toBe(false);
+
+        await factory.close();
+    });
+
     it('should preserve version directory when a dead owner shut down healthily', async () => {
         fs.mkdirSync(versionDir, { recursive: true });
         const sentinel = join(versionDir, 'must-not-be-wiped');

--- a/tst/unit/datastore/LMDB.startup.test.ts
+++ b/tst/unit/datastore/LMDB.startup.test.ts
@@ -4,6 +4,7 @@ import { open } from 'lmdb';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StoreName } from '../../../src/datastore/DataStore';
 import { LMDBStoreFactory } from '../../../src/datastore/LMDBStoreFactory';
+import { LMDBOwnershipTracker, OwnershipPhase } from '../../../src/datastore/lmdb/OwnershipTracker';
 
 vi.mock('lmdb', async () => {
     const actual = await vi.importActual<typeof import('lmdb')>('lmdb');
@@ -14,6 +15,12 @@ vi.mock('lmdb', async () => {
 });
 
 const mockedOpen = vi.mocked(open);
+
+const OWNER_MARKER_PREFIX = 'owner.';
+
+function markerName(pid: number, phase: OwnershipPhase): string {
+    return `${OWNER_MARKER_PREFIX}${pid}.${phase}`;
+}
 
 describe('LMDB startup corruption recovery', () => {
     let testDir: string;
@@ -27,6 +34,7 @@ describe('LMDB startup corruption recovery', () => {
     });
 
     afterEach(async () => {
+        vi.restoreAllMocks();
         await new Promise((resolve) => setTimeout(resolve, 100));
         if (fs.existsSync(testDir)) {
             fs.rmSync(testDir, { recursive: true, force: true });
@@ -44,6 +52,7 @@ describe('LMDB startup corruption recovery', () => {
             .mockImplementation(actual.open);
 
         const factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
         const store = factory.get(StoreName.public_schemas);
 
         await store.put('key', 'value');
@@ -71,6 +80,7 @@ describe('LMDB startup corruption recovery', () => {
         });
 
         const factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
         const store = factory.get(StoreName.public_schemas);
 
         await store.put('key', 'value');
@@ -81,7 +91,7 @@ describe('LMDB startup corruption recovery', () => {
 
     it('should delete the version directory during env recovery', async () => {
         const actual = await vi.importActual<typeof import('lmdb')>('lmdb');
-        const versionDir = join(testDir, 'lmdb', 'v5');
+        const versionDir = join(testDir, 'lmdb', 'v6');
 
         fs.mkdirSync(versionDir, { recursive: true });
         fs.writeFileSync(join(versionDir, 'dummy'), 'data');
@@ -93,6 +103,7 @@ describe('LMDB startup corruption recovery', () => {
             .mockImplementation(actual.open);
 
         const factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
 
         // The dummy file should be gone (directory was deleted and recreated)
         expect(fs.existsSync(join(versionDir, 'dummy'))).toBe(false);
@@ -100,3 +111,162 @@ describe('LMDB startup corruption recovery', () => {
         await factory.close();
     });
 });
+
+describe('LMDB startup crash detection', () => {
+    let testDir: string;
+    let markersDir: string;
+    let versionDir: string;
+
+    beforeEach(async () => {
+        testDir = join(process.cwd(), 'node_modules', '.cache', 'lmdb-startup-crash-test', `test-${Date.now()}`);
+        markersDir = join(testDir, 'lmdb', LMDBOwnershipTracker.DirName);
+        versionDir = join(testDir, 'lmdb', 'v6');
+        fs.mkdirSync(testDir, { recursive: true });
+
+        const actual = await vi.importActual<typeof import('lmdb')>('lmdb');
+        mockedOpen.mockReset();
+        mockedOpen.mockImplementation(actual.open);
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        if (fs.existsSync(testDir)) {
+            fs.rmSync(testDir, { recursive: true, force: true });
+        }
+    });
+
+    function killAllForeignProcesses(): void {
+        vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+            if (pid === process.pid) return true;
+            throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+        });
+    }
+
+    it('should wipe version directory when a dead owner crashed mid-open', async () => {
+        fs.mkdirSync(versionDir, { recursive: true });
+        fs.writeFileSync(join(versionDir, 'stale-data.mdb'), 'pretend-corrupt');
+        fs.mkdirSync(markersDir, { recursive: true });
+        fs.writeFileSync(join(markersDir, markerName(123456, OwnershipPhase.opening)), '123456');
+        killAllForeignProcesses();
+
+        const factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
+
+        expect(fs.existsSync(join(versionDir, 'stale-data.mdb'))).toBe(false);
+
+        await factory.close();
+    });
+
+    it('should preserve version directory when a dead owner shut down healthily', async () => {
+        fs.mkdirSync(versionDir, { recursive: true });
+        const sentinel = join(versionDir, 'must-not-be-wiped');
+        fs.mkdirSync(markersDir, { recursive: true });
+        fs.writeFileSync(join(markersDir, markerName(123456, OwnershipPhase.running)), '123456');
+        fs.writeFileSync(sentinel, 'keep-me');
+        killAllForeignProcesses();
+
+        const factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
+
+        expect(fs.existsSync(sentinel)).toBe(true);
+
+        await factory.close();
+    });
+
+    it('should preserve version directory when a marker PID is still alive (multi-IDE)', async () => {
+        fs.mkdirSync(versionDir, { recursive: true });
+        const sentinel = join(versionDir, 'must-not-be-wiped');
+        fs.mkdirSync(markersDir, { recursive: true });
+        const liveForeignPid = 99995;
+        fs.writeFileSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)), String(liveForeignPid));
+        vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+            if (pid === liveForeignPid || pid === process.pid) return true;
+            throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+        });
+        fs.writeFileSync(sentinel, 'keep-me');
+
+        const factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
+
+        expect(fs.existsSync(sentinel)).toBe(true);
+        expect(fs.existsSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)))).toBe(true);
+
+        await factory.close();
+    });
+
+    it('should record a running marker after a successful open and remove it on clean close', async () => {
+        const factory = new LMDBStoreFactory(testDir);
+        await factory.initialize();
+        const ownMarker = join(markersDir, markerName(process.pid, OwnershipPhase.running));
+        expect(fs.existsSync(ownMarker)).toBe(true);
+
+        await factory.close();
+
+        expect(fs.existsSync(ownMarker)).toBe(false);
+    });
+
+    it('should not wipe data on clean restart', async () => {
+        const first = new LMDBStoreFactory(testDir);
+        await first.initialize();
+        const store = first.get(StoreName.public_schemas);
+        await store.put('persist-key', 'persist-value');
+        await first.close();
+
+        const second = new LMDBStoreFactory(testDir);
+        await second.initialize();
+        const secondStore = second.get(StoreName.public_schemas);
+
+        expect(secondStore.get<string>('persist-key')).toBe('persist-value');
+
+        await second.close();
+    });
+
+    it('should not wipe data when a healthy server was killed abruptly', async () => {
+        const first = new LMDBStoreFactory(testDir);
+        await first.initialize();
+        const store = first.get(StoreName.public_schemas);
+        await store.put('survives-key', 'survives-value');
+        await simulateAbruptKill(first);
+
+        killAllForeignProcesses();
+        const second = new LMDBStoreFactory(testDir);
+        await second.initialize();
+        const secondStore = second.get(StoreName.public_schemas);
+
+        expect(secondStore.get<string>('survives-key')).toBe('survives-value');
+
+        await second.close();
+    });
+
+    it('should wipe data when the prior instance crashed mid-open (simulated crash loop)', async () => {
+        const first = new LMDBStoreFactory(testDir);
+        await first.initialize();
+        const store = first.get(StoreName.public_schemas);
+        await store.put('doomed-key', 'doomed-value');
+        await simulateAbruptKill(first);
+
+        // A startup crash leaves an `opening` marker for a now-dead PID.
+        fs.renameSync(
+            join(markersDir, markerName(process.pid, OwnershipPhase.running)),
+            join(markersDir, markerName(123456, OwnershipPhase.opening)),
+        );
+        killAllForeignProcesses();
+
+        const second = new LMDBStoreFactory(testDir);
+        await second.initialize();
+        const secondStore = second.get(StoreName.public_schemas);
+
+        expect(secondStore.get<string>('doomed-key')).toBeUndefined();
+
+        await second.close();
+    });
+});
+
+async function simulateAbruptKill(factory: LMDBStoreFactory): Promise<void> {
+    // Release OS resources without the marker cleanup that a clean close() performs.
+    await (factory as any).env.close();
+    (factory as any).closed = true;
+    if ((factory as any).metricsInterval !== undefined) clearInterval((factory as any).metricsInterval);
+    if ((factory as any).cleanupTimeout !== undefined) clearTimeout((factory as any).cleanupTimeout);
+}

--- a/tst/unit/datastore/LMDB.test.ts
+++ b/tst/unit/datastore/LMDB.test.ts
@@ -10,12 +10,13 @@ describe('LMDB', () => {
     let lmdbStore: DataStore;
     const testDir = join(process.cwd(), 'node_modules', '.cache', 'lmdb-tests', v4());
 
-    beforeEach(() => {
+    beforeEach(async () => {
         if (!fs.existsSync(testDir)) {
             fs.mkdirSync(testDir, { recursive: true });
         }
 
         lmdbFactory = new LMDBStoreFactory(testDir);
+        await lmdbFactory.initialize();
         lmdbStore = lmdbFactory.get(StoreName.public_schemas);
     });
 
@@ -196,6 +197,7 @@ describe('LMDB', () => {
 
             // Create new instance that should load from the same files
             const newFactory = new LMDBStoreFactory(testDir);
+            await newFactory.initialize();
             const newStore = newFactory.get(StoreName.public_schemas);
             const result = newStore.get<typeof value>(key);
 

--- a/tst/unit/datastore/lmdb/OwnershipTracker.test.ts
+++ b/tst/unit/datastore/lmdb/OwnershipTracker.test.ts
@@ -10,6 +10,11 @@ function markerName(pid: number, phase: OwnershipPhase): string {
     return `${OWNER_MARKER_PREFIX}${pid}.${phase}`;
 }
 
+/** Marker body in the format writeOwnMarker persists: `<pid>\n<ISO timestamp>`, dated `ageMs` ago. */
+function markerBody(pid: number, ageMs: number): string {
+    return `${pid}\n${new Date(Date.now() - ageMs).toISOString()}`;
+}
+
 describe('LMDBOwnershipTracker', () => {
     let testRoot: string;
     let lmdbDir: string;
@@ -166,6 +171,89 @@ describe('LMDBOwnershipTracker', () => {
 
             expect(onCrash).toHaveBeenCalledTimes(1);
             expect(ownerMarkers()).toEqual([markerName(process.pid, OwnershipPhase.opening)]);
+        });
+
+        it('reports a crash for a stale opening marker whose recycled PID reads as alive', async () => {
+            // The crashed opener's PID was recycled to an unrelated, still-live process, so
+            // isProcessAlive would say "alive". The marker's age (well past any real open)
+            // proves it is a crashed startup, so recovery must still fire.
+            mkdirSync(markersDir, { recursive: true });
+            const recycledPid = 99994;
+            writeFileSync(
+                join(markersDir, markerName(recycledPid, OwnershipPhase.opening)),
+                markerBody(recycledPid, 10 * 60 * 1000),
+            );
+            vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+                if (pid === recycledPid || pid === process.pid) return true; // recycled PID appears alive
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).toHaveBeenCalledTimes(1);
+            // The stale marker must be cleared, not left to suppress future scans.
+            expect(existsSync(join(markersDir, markerName(recycledPid, OwnershipPhase.opening)))).toBe(false);
+        });
+
+        it('treats a live PID with a fresh opening marker as a live owner (sibling still opening)', async () => {
+            // A genuine in-progress open is recent, so a fresh opening marker on a live PID is a
+            // real sibling and its data must be preserved — the age override must not misfire.
+            mkdirSync(markersDir, { recursive: true });
+            const liveForeignPid = 99993;
+            writeFileSync(
+                join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)),
+                markerBody(liveForeignPid, 1000),
+            );
+            vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+                if (pid === liveForeignPid || pid === process.pid) return true;
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+            expect(existsSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)))).toBe(true);
+        });
+
+        it('does not treat a stale running marker on a live PID as a crash', async () => {
+            // The age override applies only to the opening phase; a running marker means the env
+            // opened successfully, so an old one on a live PID is just a long-lived healthy sibling.
+            mkdirSync(markersDir, { recursive: true });
+            const liveForeignPid = 99992;
+            writeFileSync(
+                join(markersDir, markerName(liveForeignPid, OwnershipPhase.running)),
+                markerBody(liveForeignPid, 10 * 60 * 1000),
+            );
+            vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+                if (pid === liveForeignPid || pid === process.pid) return true;
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+            expect(existsSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.running)))).toBe(true);
+        });
+
+        it('falls back to PID liveness for an opening marker whose body has no timestamp', async () => {
+            // Legacy/unreadable bodies carry no timestamp, so the age override cannot apply and the
+            // scan must behave exactly as before: a live PID is a live owner, no crash reported.
+            mkdirSync(markersDir, { recursive: true });
+            const liveForeignPid = 99991;
+            writeFileSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)), 'legacy-no-timestamp');
+            vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+                if (pid === liveForeignPid || pid === process.pid) return true;
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+            expect(existsSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)))).toBe(true);
         });
 
         it('does not report a crash on retry from its own earlier opening marker', async () => {

--- a/tst/unit/datastore/lmdb/OwnershipTracker.test.ts
+++ b/tst/unit/datastore/lmdb/OwnershipTracker.test.ts
@@ -1,0 +1,268 @@
+import { randomUUID as v4 } from 'crypto';
+import { existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LMDBOwnershipTracker, OwnershipPhase } from '../../../../src/datastore/lmdb/OwnershipTracker';
+
+const OWNER_MARKER_PREFIX = 'owner.';
+
+function markerName(pid: number, phase: OwnershipPhase): string {
+    return `${OWNER_MARKER_PREFIX}${pid}.${phase}`;
+}
+
+describe('LMDBOwnershipTracker', () => {
+    let testRoot: string;
+    let lmdbDir: string;
+    let markersDir: string;
+    let onCrash: ReturnType<typeof vi.fn<() => void>>;
+    const originalPid = process.pid;
+
+    beforeEach(() => {
+        testRoot = join(process.cwd(), 'node_modules', '.cache', 'lmdb-ownership-tracker-test', v4());
+        lmdbDir = join(testRoot, 'lmdb');
+        markersDir = join(lmdbDir, LMDBOwnershipTracker.DirName);
+        mkdirSync(testRoot, { recursive: true });
+        onCrash = vi.fn<() => void>();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        Object.defineProperty(process, 'pid', { value: originalPid, configurable: true });
+        if (existsSync(testRoot)) {
+            rmSync(testRoot, { recursive: true, force: true });
+        }
+    });
+
+    function asProcess(pid: number): void {
+        Object.defineProperty(process, 'pid', { value: pid, configurable: true });
+    }
+
+    function ownerMarkers(): string[] {
+        return readdirSync(markersDir)
+            .filter((name) => name.startsWith(OWNER_MARKER_PREFIX))
+            .toSorted();
+    }
+
+    /** Make every foreign PID appear dead while keeping the current process alive. */
+    function killAllForeignProcesses(): void {
+        vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+            if (pid === process.pid) return true;
+            throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+        });
+    }
+
+    describe('beginStartup', () => {
+        it('does not report a crash and records an opening marker on a fresh directory', async () => {
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+            expect(ownerMarkers()).toEqual([markerName(process.pid, OwnershipPhase.opening)]);
+        });
+
+        it('reports a crash when a dead owner is stuck in the opening phase', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            writeFileSync(join(markersDir, markerName(123456, OwnershipPhase.opening)), 'dead');
+            killAllForeignProcesses();
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not report a crash for a dead owner that reached the running phase', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            writeFileSync(join(markersDir, markerName(123456, OwnershipPhase.running)), 'dead-but-healthy');
+            killAllForeignProcesses();
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+        });
+
+        it('does not report a crash while another process owns the directory (multi-IDE)', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            const liveForeignPid = 99999;
+            writeFileSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)), String(liveForeignPid));
+            vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+                if (pid === liveForeignPid || pid === process.pid) return true;
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+            expect(existsSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)))).toBe(true);
+        });
+
+        it('preserves a live owner marker but clears dead ones', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            const liveForeignPid = 99998;
+            writeFileSync(join(markersDir, markerName(123456, OwnershipPhase.running)), 'dead');
+            writeFileSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)), String(liveForeignPid));
+            vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+                if (pid === liveForeignPid || pid === process.pid) return true;
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(existsSync(join(markersDir, markerName(123456, OwnershipPhase.running)))).toBe(false);
+            expect(existsSync(join(markersDir, markerName(liveForeignPid, OwnershipPhase.opening)))).toBe(true);
+            expect(existsSync(join(markersDir, markerName(process.pid, OwnershipPhase.opening)))).toBe(true);
+        });
+
+        it('treats a marker with a non-numeric PID as a removable, non-crash file', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            writeFileSync(join(markersDir, `${OWNER_MARKER_PREFIX}not-a-pid.${OwnershipPhase.opening}`), 'garbage');
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+            expect(existsSync(join(markersDir, `${OWNER_MARKER_PREFIX}not-a-pid.${OwnershipPhase.opening}`))).toBe(
+                false,
+            );
+        });
+
+        it('ignores markers with an unrecognised phase', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            writeFileSync(join(markersDir, `${OWNER_MARKER_PREFIX}123456.bogus`), 'dead');
+            killAllForeignProcesses();
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+        });
+
+        it('treats EPERM from process.kill as a live owner', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            const protectedPid = 99996;
+            writeFileSync(join(markersDir, markerName(protectedPid, OwnershipPhase.opening)), String(protectedPid));
+            vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+                if (pid === protectedPid) throw Object.assign(new Error('EPERM'), { code: 'EPERM' });
+                if (pid === process.pid) return true;
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+        });
+
+        it('recovers a crash left by a predecessor that reused this process PID', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            writeFileSync(join(markersDir, markerName(process.pid, OwnershipPhase.opening)), 'recycled-pid');
+
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).toHaveBeenCalledTimes(1);
+            expect(ownerMarkers()).toEqual([markerName(process.pid, OwnershipPhase.opening)]);
+        });
+
+        it('does not report a crash on retry from its own earlier opening marker', async () => {
+            killAllForeignProcesses();
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+
+            // First attempt claims an opening marker, then "fails" before markRunning(),
+            // leaving the marker on disk. A retry must recognise it as our own, not a crash.
+            await tracker.beginStartup(onCrash);
+            expect(existsSync(join(markersDir, markerName(process.pid, OwnershipPhase.opening)))).toBe(true);
+
+            await tracker.beginStartup(onCrash);
+
+            expect(onCrash).not.toHaveBeenCalled();
+            expect(ownerMarkers()).toEqual([markerName(process.pid, OwnershipPhase.opening)]);
+        });
+
+        it('serializes concurrent startups so only one observes the crash', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            writeFileSync(join(markersDir, markerName(123456, OwnershipPhase.opening)), 'dead');
+
+            const pidA = 50001;
+            const pidB = 50002;
+            vi.spyOn(process, 'kill').mockImplementation((pid: number) => {
+                if (pid === pidA || pid === pidB) return true;
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+
+            asProcess(pidA);
+            const trackerA = new LMDBOwnershipTracker(lmdbDir);
+            asProcess(pidB);
+            const trackerB = new LMDBOwnershipTracker(lmdbDir);
+
+            let crashes = 0;
+            await Promise.all([trackerA.beginStartup(() => crashes++), trackerB.beginStartup(() => crashes++)]);
+
+            expect(crashes).toBe(1);
+        });
+
+        it('proceeds without a crash when marker setup fails', async () => {
+            mkdirSync(markersDir, { recursive: true });
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            vi.spyOn(process, 'kill').mockImplementation(() => {
+                throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+            });
+            writeFileSync(join(markersDir, markerName(123456, OwnershipPhase.opening)), 'dead');
+            rmSync(markersDir, { recursive: true, force: true });
+            writeFileSync(markersDir, 'not a directory');
+
+            await expect(tracker.beginStartup(onCrash)).resolves.toBeUndefined();
+            expect(onCrash).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('markRunning', () => {
+        it('promotes the opening marker to running', async () => {
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+
+            tracker.markRunning();
+
+            expect(ownerMarkers()).toEqual([markerName(process.pid, OwnershipPhase.running)]);
+        });
+
+        it('records a running marker even if no opening marker exists', () => {
+            mkdirSync(markersDir, { recursive: true });
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+
+            tracker.markRunning();
+
+            expect(existsSync(join(markersDir, markerName(process.pid, OwnershipPhase.running)))).toBe(true);
+        });
+    });
+
+    describe('release', () => {
+        it('removes this process markers in either phase', async () => {
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+            tracker.markRunning();
+
+            tracker.release();
+
+            expect(ownerMarkers()).toEqual([]);
+        });
+
+        it('is idempotent without a prior claim', () => {
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+
+            expect(() => tracker.release()).not.toThrow();
+        });
+
+        it('is idempotent when called twice', async () => {
+            const tracker = new LMDBOwnershipTracker(lmdbDir);
+            await tracker.beginStartup(onCrash);
+            tracker.release();
+
+            expect(() => tracker.release()).not.toThrow();
+        });
+    });
+});

--- a/tst/utils/TestExtension.ts
+++ b/tst/utils/TestExtension.ts
@@ -131,7 +131,7 @@ export class TestExtension implements Closeable {
         this.serverConnection = new LspConnection(
             createConnection(new StreamMessageReader(this.readStream), new StreamMessageWriter(this.writeStream)),
             {
-                onInitialize: (params) => {
+                onInitialize: async (params) => {
                     const lsp = this.serverConnection.components;
                     LoggerFactory.reconfigure('warn');
 
@@ -140,6 +140,7 @@ export class TestExtension implements Closeable {
                         return Promise.resolve(JSON.parse(readFileSync(ffFile, 'utf8')));
                     }, ffFile);
                     const dataStoreFactory = new MultiDataStoreFactoryProvider(featureFlags.get('FileDb'));
+                    await dataStoreFactory.initialize();
                     this.core = new CfnInfraCore(lsp, params, {
                         dataStoreFactory,
                         featureFlags,


### PR DESCRIPTION
**Problem**
The LMDB schema cache lives at a single machine-wide path shared by every IDE/language-server process. If opening that database trips a C-level assertion in the native lmdb library, the process is aborted - no JS catch/finally runs. The editor restarts the server, it aborts on the same corrupt data again, and the user is stuck in an infinite startup crash loop with no way for normal try/catch recovery to help.

**How it fixes it** - a cross-process startup "dirty bit":
* New LMDBOwnershipTracker writes a per-PID marker file before the risky open `owner.<pid>.opening` and renames it to `owner.<pid>.running` once the open succeeds; both are removed on clean shutdown.
* On the next startup, under a proper-lockfile cross-process lock, it scans markers and wipes the (presumed corrupt) data directory only when both: no marker belongs to a live process, and a dead owner is stuck in the opening phase - the signature of a mid-open crash. A dead running marker (an ordinary abrupt kill of a healthy process) never triggers a wipe, so reboots/force-quits preserve the cache.

**Changes**
* LMDBStoreFactory refactored from a do-everything constructor into a two-phase construct → async initialize() lifecycle (env open, crash recovery, and background tasks now happen in initialize()), with cleaner tryOpen/recreateAfterCorruption recovery helpers.
* initialize() added to the DataStoreFactory/DataStoreFactoryProvider interfaces; MemoryStore/FileStore implement it as no-ops; standalone.ts awaits it before constructing the server.