### PR TITLE
Add code-quality write permissions to release workflows

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -46,5 +46,6 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+      code-quality: write
     with:
       tag: ${{ needs.create-beta-tag.outputs.tag }}

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -62,5 +62,6 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+      code-quality: write
     with:
       tag: ${{ needs.promote-beta-to-prod.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
 
   build-and-test:
     needs: [ get-configs, version-and-tag ]
+    permissions:
+      contents: read
+      code-quality: write
     uses: ./.github/workflows/build-and-test.yml
     strategy:
       fail-fast: true


### PR DESCRIPTION
*Description of changes:*
- Release workflows are failing with error `The nested job 'build-test-nodejs' is requesting 'code-quality: write', but is only allowed 'code-quality: none'.`
- Adding `code-quality: write` permission

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
