### PR TITLE
Fix deployment bug for nested templates

### DIFF
--- a/src/artifactexporter/ResourceExporters.ts
+++ b/src/artifactexporter/ResourceExporters.ts
@@ -7,6 +7,7 @@ import { dump } from 'js-yaml';
 import { detectDocumentType } from '../document/DocumentUtils';
 import { S3Service } from '../services/S3Service';
 import { readFileIfExists } from '../utils/File';
+import { toHttpsPathStyleS3Url } from '../utils/S3Url';
 import { ArtifactExporter } from './ArtifactExporter';
 
 export function isS3Url(url: string): boolean {
@@ -265,9 +266,10 @@ class CloudFormationStackResource extends Resource {
 
         const key = getS3Key(s3KeyPrefix, templateAbsPath);
         await this.s3Service.putObjectContent(exportedTemplateStr, bucketName, key);
-        const s3Url = `s3://${bucketName}/${key}`;
 
-        resourcePropertyDict[this.propertyName] = s3Url;
+        // CloudFormation requires an HTTPS URL for nested-template locations (TemplateURL / Location);
+        // an s3:// URI is rejected with "Domain name specified in <bucket> is not a valid S3 domain".
+        resourcePropertyDict[this.propertyName] = toHttpsPathStyleS3Url(this.s3Service.getRegion(), bucketName, key);
     }
 }
 

--- a/src/artifactexporter/ResourceExporters.ts
+++ b/src/artifactexporter/ResourceExporters.ts
@@ -268,7 +268,7 @@ class CloudFormationStackResource extends Resource {
         await this.s3Service.putObjectContent(exportedTemplateStr, bucketName, key);
 
         // CloudFormation requires an HTTPS URL for nested-template locations (TemplateURL / Location);
-        // an s3:// URI is rejected with "Domain name specified in <bucket> is not a valid S3 domain".
+        // a s3:// URI is rejected with "Domain name specified in <bucket> is not a valid S3 domain".
         resourcePropertyDict[this.propertyName] = toHttpsPathStyleS3Url(this.s3Service.getRegion(), bucketName, key);
     }
 }

--- a/src/services/AwsClient.ts
+++ b/src/services/AwsClient.ts
@@ -37,6 +37,10 @@ export class AwsClient {
         return new STSClient(this.iamClientConfig());
     }
 
+    public getRegion(): string {
+        return this.credentialsProvider.getIAM().region;
+    }
+
     private iamClientConfig(): IamClientConfig {
         const credential = this.credentialsProvider.getIAM();
         return {

--- a/src/services/S3Service.ts
+++ b/src/services/S3Service.ts
@@ -24,6 +24,10 @@ export class S3Service {
 
     public constructor(private readonly awsClient: AwsClient) {}
 
+    getRegion(): string {
+        return this.awsClient.getRegion();
+    }
+
     protected async withClient<T>(request: (client: S3Client) => Promise<T>): Promise<T> {
         try {
             const client = this.awsClient.getS3Client();

--- a/src/stacks/actions/StackActionOperations.ts
+++ b/src/stacks/actions/StackActionOperations.ts
@@ -24,6 +24,7 @@ import { S3Service } from '../../services/S3Service';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { extractErrorMessage, extractStatusReason } from '../../utils/Errors';
 import { retryWithExponentialBackoff } from '../../utils/Retry';
+import { toHttpsPathStyleS3Url } from '../../utils/S3Url';
 import { toString } from '../../utils/String';
 import { pointToPosition } from '../../utils/TypeConverters';
 import {
@@ -120,7 +121,7 @@ export async function processChangeSet(
         if (params.s3Bucket && params.s3Key) {
             const putResult = await s3Service.putObjectContent(templateBody, params.s3Bucket, params.s3Key);
             expectedETag = putResult.ETag;
-            templateS3Url = `https://s3.amazonaws.com/${params.s3Bucket}/${params.s3Key}`;
+            templateS3Url = toHttpsPathStyleS3Url(s3Service.getRegion(), params.s3Bucket, params.s3Key);
         }
     } catch (error) {
         logger.error(error, 'Failed to upload to S3');

--- a/src/utils/S3Url.ts
+++ b/src/utils/S3Url.ts
@@ -8,10 +8,7 @@ const CHINA_REGIONS: ReadonlySet<string> = new Set([AwsRegion.CN_NORTH_1, AwsReg
  * CloudFormation requires HTTPS URLs (not `s3://` URIs) for template locations such as
  * `AWS::CloudFormation::Stack` `TemplateURL` and `AWS::Serverless::Application` `Location`.
  * An `s3://` URI is rejected with "Domain name specified in <bucket> is not a valid S3 domain".
- * This mirrors the AWS CLI `aws cloudformation package` behavior (`to_path_style_s3_url`).
- *
- * The endpoint is region-aware so the URL resolves in every partition, including China
- * (`amazonaws.com.cn`) and GovCloud.
+ * Mirrors the AWS CLI `aws cloudformation package` behavior (`to_path_style_s3_url`).
  */
 export function toHttpsPathStyleS3Url(region: string, bucketName: string, key: string): string {
     const dnsSuffix = CHINA_REGIONS.has(region) ? 'amazonaws.com.cn' : 'amazonaws.com';

--- a/src/utils/S3Url.ts
+++ b/src/utils/S3Url.ts
@@ -1,0 +1,19 @@
+import { AwsRegion } from './Region';
+
+const CHINA_REGIONS: ReadonlySet<string> = new Set([AwsRegion.CN_NORTH_1, AwsRegion.CN_NORTHWEST_1]);
+
+/**
+ * Builds an HTTPS path-style S3 URL for an uploaded object.
+ *
+ * CloudFormation requires HTTPS URLs (not `s3://` URIs) for template locations such as
+ * `AWS::CloudFormation::Stack` `TemplateURL` and `AWS::Serverless::Application` `Location`.
+ * An `s3://` URI is rejected with "Domain name specified in <bucket> is not a valid S3 domain".
+ * This mirrors the AWS CLI `aws cloudformation package` behavior (`to_path_style_s3_url`).
+ *
+ * The endpoint is region-aware so the URL resolves in every partition, including China
+ * (`amazonaws.com.cn`) and GovCloud.
+ */
+export function toHttpsPathStyleS3Url(region: string, bucketName: string, key: string): string {
+    const dnsSuffix = CHINA_REGIONS.has(region) ? 'amazonaws.com.cn' : 'amazonaws.com';
+    return `https://s3.${region}.${dnsSuffix}/${bucketName}/${key}`;
+}

--- a/tst/unit/artifactexporter/ResourceExporters.test.ts
+++ b/tst/unit/artifactexporter/ResourceExporters.test.ts
@@ -73,6 +73,7 @@ describe('ResourceExporters', () => {
         mockS3Service = {
             putObject: vi.fn().mockResolvedValue({ VersionId: 'version123' }),
             putObjectContent: vi.fn().mockResolvedValue({}),
+            getRegion: vi.fn().mockReturnValue('us-east-1'),
         } as any;
     });
 
@@ -171,6 +172,70 @@ describe('ResourceExporters', () => {
                 expect(resource.resourceType).toBe(resourceType);
                 expect(resource.propertyName).toBeDefined();
             }
+        });
+    });
+
+    describe('CloudFormationStackResource', () => {
+        // Regression test for https://github.com/aws-cloudformation/cloudformation-languageserver/issues/624:
+        // nested-stack TemplateURL must be an HTTPS URL, not an s3:// URI, otherwise CloudFormation
+        // rejects it with "Domain name specified in <bucket> is not a valid S3 domain".
+        beforeEach(() => {
+            vi.mocked(existsSync).mockReturnValue(true);
+            vi.mocked(statSync).mockReturnValue({ isFile: () => true, isDirectory: () => false } as any);
+        });
+
+        it('should set TemplateURL to an HTTPS path-style S3 URL, not an s3:// URI', async () => {
+            const ResourceClass = RESOURCE_EXPORTER_MAP.get('AWS::CloudFormation::Stack')!;
+            const resource = new ResourceClass(mockS3Service);
+            const resourceDict: Record<string, unknown> = { TemplateURL: './nested.yaml' };
+
+            await resource.doExport(resourceDict, '/abs/nested.yaml', 'test-bucket', 'prefix');
+
+            const templateUrl = resourceDict.TemplateURL as string;
+            expect(templateUrl.startsWith('https://')).toBe(true);
+            expect(templateUrl.startsWith('s3://')).toBe(false);
+            expect(templateUrl).toMatch(
+                /^https:\/\/s3\.us-east-1\.amazonaws\.com\/test-bucket\/prefix\/artifact\/nested-\d+\.yaml$/,
+            );
+            expect(mockS3Service.putObjectContent).toHaveBeenCalledWith(
+                'exported template',
+                'test-bucket',
+                expect.any(String),
+            );
+        });
+
+        it('should set Serverless::Application Location to an HTTPS URL', async () => {
+            const ResourceClass = RESOURCE_EXPORTER_MAP.get('AWS::Serverless::Application')!;
+            const resource = new ResourceClass(mockS3Service);
+            const resourceDict: Record<string, unknown> = { Location: './app.yaml' };
+
+            await resource.doExport(resourceDict, '/abs/app.yaml', 'test-bucket', '');
+
+            const location = resourceDict.Location as string;
+            expect(location.startsWith('https://')).toBe(true);
+            expect(location.startsWith('s3://')).toBe(false);
+        });
+
+        it('should use the china endpoint suffix for cn regions', async () => {
+            vi.mocked(mockS3Service.getRegion).mockReturnValue('cn-north-1');
+            const ResourceClass = RESOURCE_EXPORTER_MAP.get('AWS::CloudFormation::Stack')!;
+            const resource = new ResourceClass(mockS3Service);
+            const resourceDict: Record<string, unknown> = { TemplateURL: './nested.yaml' };
+
+            await resource.doExport(resourceDict, '/abs/nested.yaml', 'test-bucket', '');
+
+            expect(resourceDict.TemplateURL).toContain('https://s3.cn-north-1.amazonaws.com.cn/');
+        });
+
+        it('should throw when the template path is not a local file', async () => {
+            vi.mocked(existsSync).mockReturnValue(false);
+            const ResourceClass = RESOURCE_EXPORTER_MAP.get('AWS::CloudFormation::Stack')!;
+            const resource = new ResourceClass(mockS3Service);
+            const resourceDict: Record<string, unknown> = { TemplateURL: './missing.yaml' };
+
+            await expect(resource.doExport(resourceDict, '/abs/missing.yaml', 'test-bucket', '')).rejects.toThrow(
+                'Invalid template path',
+            );
         });
     });
 

--- a/tst/unit/stackActions/StackActionWorkflowOperations.test.ts
+++ b/tst/unit/stackActions/StackActionWorkflowOperations.test.ts
@@ -74,7 +74,9 @@ describe('StackActionWorkflowOperations', () => {
             getLine: vi.fn(),
         } as any;
 
-        mockS3Service = {} as any;
+        mockS3Service = {
+            getRegion: vi.fn().mockReturnValue('us-east-1'),
+        } as any;
 
         vi.clearAllMocks();
     });
@@ -152,7 +154,7 @@ describe('StackActionWorkflowOperations', () => {
                 StackName: 'test-stack',
                 ChangeSetName: expect.stringContaining(ExtensionName.replaceAll(' ', '-')),
                 TemplateBody: undefined,
-                TemplateURL: 'https://s3.amazonaws.com/test-bucket/template.yaml',
+                TemplateURL: 'https://s3.us-east-1.amazonaws.com/test-bucket/template.yaml',
                 Parameters: undefined,
                 Capabilities: undefined,
                 ChangeSetType: 'CREATE',

--- a/tst/unit/utils/S3Url.test.ts
+++ b/tst/unit/utils/S3Url.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { toHttpsPathStyleS3Url } from '../../../src/utils/S3Url';
+
+describe('toHttpsPathStyleS3Url', () => {
+    it('builds a region-scoped HTTPS path-style URL for standard partitions', () => {
+        expect(toHttpsPathStyleS3Url('us-east-1', 'my-bucket', 'artifact/template.yaml')).toBe(
+            'https://s3.us-east-1.amazonaws.com/my-bucket/artifact/template.yaml',
+        );
+        expect(toHttpsPathStyleS3Url('eu-west-1', 'other-bucket', 'nested/child-123.yaml')).toBe(
+            'https://s3.eu-west-1.amazonaws.com/other-bucket/nested/child-123.yaml',
+        );
+    });
+
+    it('uses the amazonaws.com.cn suffix for China regions', () => {
+        expect(toHttpsPathStyleS3Url('cn-north-1', 'cn-bucket', 'key.yaml')).toBe(
+            'https://s3.cn-north-1.amazonaws.com.cn/cn-bucket/key.yaml',
+        );
+        expect(toHttpsPathStyleS3Url('cn-northwest-1', 'cn-bucket', 'key.yaml')).toBe(
+            'https://s3.cn-northwest-1.amazonaws.com.cn/cn-bucket/key.yaml',
+        );
+    });
+
+    it('uses the standard suffix for GovCloud regions', () => {
+        expect(toHttpsPathStyleS3Url('us-gov-west-1', 'gov-bucket', 'key.yaml')).toBe(
+            'https://s3.us-gov-west-1.amazonaws.com/gov-bucket/key.yaml',
+        );
+    });
+
+    it('never produces an s3:// URI', () => {
+        const url = toHttpsPathStyleS3Url('us-west-2', 'bucket', 'key');
+        expect(url.startsWith('https://')).toBe(true);
+        expect(url.startsWith('s3://')).toBe(false);
+    });
+});


### PR DESCRIPTION
When you have a nested stack - a CloudFormation template that references another template file - the language server has to upload that child template to S3 before it can deploy. It then rewrites the TemplateURL in your template to point at the uploaded copy.

**Problem**: it wrote that URL in the wrong format. It used an s3:// address: `TemplateURL: s3://my-bucket/artifact/template2.yml`. So deployment failed with: `Domain name specified in <bucket name> is not a valid S3 domain`. Nested stacks were effectively broken when uploading through the language server.

**Fix**:  Change the nested-stack TemplateURL to use an https:// address instead: `TemplateURL: https://s3.us-east-1.amazonaws.com/my-bucket/artifact/template2.yml`. Matches what the official AWS CLI does.

- Only nested-template locations were changed (AWS::CloudFormation::Stack TemplateURL and the SAM AWS::Serverless::Application Location). Other uploads - like Lambda code, correctly keep using s3://, because those services do accept it.
- The URL is now region-aware, which also fixed a smaller problem where the top-level template URL was hardcoded to a single global endpoint.

https://github.com/aws-cloudformation/cloudformation-languageserver/issues/624