### PR TITLE
Fix flaky CI workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -99,24 +99,23 @@ jobs:
             feature-flags:
               - 'assets/featureFlag/*.json'
 
-  validate-release-manifest:
+  validate-release-manifest-file:
     needs: [ detect-changes ]
     if: needs.detect-changes.outputs.release-manifest == 'true'
     uses: ./.github/workflows/validate-release-manifest.yml
 
-  validate-feature-flags:
+  validate-feature-flag-files:
     needs: [ detect-changes ]
     if: needs.detect-changes.outputs.feature-flags == 'true'
     uses: ./.github/workflows/validate-feature-flags.yml
 
-  # Single always-running gate so branch protection can require one stable
-  # check. The validate-* jobs are conditional and report "skipped" on PRs that
+  # Single always-running gate for file changes
+  # The validate file jobs are conditional and report "skipped" on PRs that
   # don't touch their paths; a skipped job used directly as a required check
   # would leave the PR pending forever. This job runs unconditionally and only
   # fails if an upstream job actually failed or was cancelled (skipped is OK).
-  # Make "PR Checks" the single required status check in branch protection.
-  pr-checks:
-    needs: [ detect-changes, validate-release-manifest, validate-feature-flags ]
+  file-change-checks:
+    needs: [ detect-changes, validate-release-manifest-file, validate-feature-flag-files ]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -131,4 +130,4 @@ jobs:
               exit 1
             fi
           done
-          echo "All required PR checks passed or were skipped as expected."
+          echo "All file change checks passed or were skipped as expected."

--- a/src/datastore/LMDBStoreFactory.ts
+++ b/src/datastore/LMDBStoreFactory.ts
@@ -166,6 +166,9 @@ export class LMDBStoreFactory implements DataStoreFactory {
         this.cleanupTimeout = setTimeout(() => {
             this.cleanupOldVersions();
         }, CleanupDelayMs);
+
+        this.metricsInterval.unref();
+        this.cleanupTimeout.unref();
     }
 
     private beginOp(): () => void {

--- a/tst/utils/TestExtension.ts
+++ b/tst/utils/TestExtension.ts
@@ -259,6 +259,7 @@ export class TestExtension implements Closeable {
         await this.clientConnection.sendRequest(ShutdownRequest.type);
         await this.clientConnection.sendNotification(ExitNotification.type);
         this.clientConnection.dispose();
+        await this.server?.close();
     }
 
     // ====================================================================

--- a/tst/utils/Utils.ts
+++ b/tst/utils/Utils.ts
@@ -15,7 +15,6 @@ export class WaitFor {
     ) {}
 
     async wait(block: () => void | Promise<void>): Promise<void> {
-        let lastError: Error | null = null;
         const start = performance.now();
 
         while (performance.now() - start <= this.maxWaitMs) {
@@ -24,16 +23,20 @@ export class WaitFor {
                 return;
             } catch (e) {
                 const error = e as Error;
-                if (this.throwableTypesToExpect.some((type) => error instanceof type)) {
-                    lastError = error;
-                } else {
+                if (!this.throwableTypesToExpect.some((type) => error instanceof type)) {
                     throw error;
                 }
             }
             await flushAllPromises();
             await new Promise((resolve) => setTimeout(resolve, this.delayIntervalMs));
         }
-        throw lastError!;
+
+        // The deadline is wall-clock (performance.now). On a loaded runner a scheduling or
+        // GC stall can consume the whole budget *after* the awaited condition already became
+        // true, so the loop would otherwise throw a stale error for an operation that has in
+        // fact completed. Evaluate the condition one final time before giving up: if it now
+        // passes we return, and if it genuinely still fails this rethrows the current error.
+        await block();
     }
 
     static async waitFor(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,9 +25,11 @@ export default defineConfig({
                 'src/services/guard/assets/**',
             ],
         },
-        isolate: true, // Ensure each test file runs in isolation
+        isolate: true,
+        pool: 'forks',
         maxWorkers: 4,
         execArgv: ['--max-old-space-size=4096'],
-        testTimeout: 30000, // Increase timeout for longer-running tests
+        testTimeout: 10_000,
+        teardownTimeout: 15_000,
     },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,11 +25,11 @@ export default defineConfig({
                 'src/services/guard/assets/**',
             ],
         },
-        isolate: true,
+        isolate: true, // Ensure each test file runs in isolation
         pool: 'forks',
         maxWorkers: 4,
         execArgv: ['--max-old-space-size=4096'],
-        testTimeout: 10_000,
-        teardownTimeout: 15_000,
+        testTimeout: 30000, // Increase timeout for longer-running tests
+        teardownTimeout: 15000,
     },
 });


### PR DESCRIPTION
1. `tst/utils/Utils.ts` - Fix stale-error in WaitFor
The core polling helper had a bug: it stored the lastError from each failed attempt and threw it when the wall-clock deadline (performance.now) expired. On a loaded CI runner, a scheduling/GC stall could burn the entire time budget after the awaited condition had already become true - throwing a stale error for an operation that actually succeeded. The fix removes lastError tracking and instead evaluates the condition one final time after the loop: if it now passes, return; if it genuinely still fails, that final call rethrows the live error.

2. `src/datastore/LMDBStoreFactory.ts` - Prevent worker teardown crash
Adds `.unref()` to both the metricsInterval and cleanupTimeout timers. This lets the Node process (test worker) exit cleanly instead of being kept alive by dangling LMDB timers, which was causing worker-teardown crashes.

3. `tst/utils/TestExtension.ts` - Clean server shutdown
Adds await this.server?.close(); to the shutdown sequence so the language server is properly closed during test teardown (complements the timer fix above).

4. `vitest.config.ts` - More stable test isolation
   - Switches to pool: 'forks' (process-based isolation instead of worker threads — more robust against native-module/state leakage like LMDB).
   - Add teardownTimeout: 15_000 to give teardown enough room.

5. `.github/workflows/pr.yml` - Rename gate jobs (cosmetic/clarity)
Renames the workflow jobs for clarity:
   - validate-release-manifest → validate-release-manifest-file
   - validate-feature-flags → validate-feature-flag-files
   - pr-checks → file-change-checks