### PR TITLE
fix(webpack): exclude dev-only transitive deps from externals

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
         "@msgpackr-extract/msgpackr-extract-linux-x64",
         "@msgpackr-extract/msgpackr-extract-win32-x64"
     ],
-    "unusedDependencies": [
+    "requiredPeerDeps": [
         "cbor-x"
     ],
     "rebuildDependencies": [

--- a/tools/lspClient/LspClient.ts
+++ b/tools/lspClient/LspClient.ts
@@ -24,15 +24,11 @@ import { DocumentMetadata } from '../../src/document/DocumentProtocol';
 import { Logger } from 'pino';
 import { CompletionItem, CompletionList, Diagnostic, Hover } from 'vscode-languageserver-types';
 
-/**
- * Common LSP client for CloudFormation Language Server testing.
- * Handles server startup, LSP protocol communication, and external service initialization detection.
- */
 export class LspClient implements LspConnection {
     private readonly serverProcess!: ChildProcess;
     private connection!: MessageConnection;
 
-    private readonly encryptionKey: Buffer = randomBytes(32);
+    public readonly encryptionKey: Buffer;
     private isShutdown = false;
     private workspaceConfig: Record<string, unknown>[];
 
@@ -46,6 +42,7 @@ export class LspClient implements LspConnection {
         this.workspaceConfig = config.workspaceConfig ?? [];
         this.clientLogger = config.clientLogger ?? createLspClientLogger();
         this.serverLogger = config.serverLogger ?? createLspServerLogger();
+        this.encryptionKey = config.encryptionKey ?? randomBytes(32);
 
         const args = this.config.mode === 'ipc' ? ['--node-ipc'] : ['--stdio'];
         this.clientLogger.info(`Spawning server with args: node ${this.config.serverPath} ${args.join(' ')}`);
@@ -142,7 +139,7 @@ export class LspClient implements LspConnection {
             this.serverLogger.error(output);
         } else if (lower.includes('warn:')) {
             this.serverLogger.warn(output);
-        } else if (lower.includes('initializing')) {
+        } else if (lower.includes('initializing') || lower.includes('listening') || lower.includes('launched')) {
             this.serverLogger.info(output);
         } else if (lower.includes('debug:')) {
             this.serverLogger.debug(output);

--- a/tools/lspClient/LspClient.ts
+++ b/tools/lspClient/LspClient.ts
@@ -53,6 +53,7 @@ export class LspClient implements LspConnection {
         this.serverProcess = spawn('node', [this.config.serverPath, ...args], {
             stdio: this.config.mode === 'ipc' ? ['pipe', 'pipe', 'pipe', 'ipc'] : ['pipe', 'pipe', 'pipe'],
             env: { ...process.env, ...this.config.env },
+            cwd: this.config.cwd,
         });
         this.clientLogger.info(`Server process spawned with PID: ${this.serverProcess.pid}`);
         this.attachOutputListeners();

--- a/tools/lspClient/LspConnection.ts
+++ b/tools/lspClient/LspConnection.ts
@@ -42,6 +42,7 @@ export type LspClientConfig = {
     mode: 'stdio' | 'ipc';
     clientConfig: _InitializeParams['clientInfo'];
     awsConfig: AwsMetadata;
+    cwd?: string;
     env?: NodeJS.ProcessEnv;
     workspaceConfig?: Record<string, unknown>[];
     clientLogger?: Logger;

--- a/tools/lspClient/LspConnection.ts
+++ b/tools/lspClient/LspConnection.ts
@@ -42,6 +42,7 @@ export type LspClientConfig = {
     mode: 'stdio' | 'ipc';
     clientConfig: _InitializeParams['clientInfo'];
     awsConfig: AwsMetadata;
+    encryptionKey?: Buffer;
     cwd?: string;
     env?: NodeJS.ProcessEnv;
     workspaceConfig?: Record<string, unknown>[];

--- a/tst/e2e/LspStartup.test.ts
+++ b/tst/e2e/LspStartup.test.ts
@@ -1,13 +1,21 @@
 import { execSync } from 'child_process';
-import { existsSync } from 'fs';
+import { cpSync, existsSync, mkdirSync, rmSync } from 'fs';
 import { join, resolve } from 'path';
+import { tmpdir } from 'os';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { LspClient } from '../../tools/lspClient/LspClient';
 import { randomUUID as v4 } from 'node:crypto';
 
 describe('LSP standalone bundle startup', () => {
     const repoRoot = resolve(__dirname, '..', '..');
-    const standalonePath = join(repoRoot, 'bundle', 'production', 'cfn-lsp-server-standalone.js');
+    const bundleSrc = join(repoRoot, 'bundle', 'production');
+
+    // Run the bundle from an isolated temp directory outside the project tree.
+    // This prevents Node's module resolution from walking up to the project
+    // root's node_modules/, which would mask missing externals that cause
+    // failures in canary/Hydra environments.
+    const isolatedDir = join(tmpdir(), `cfn-lsp-startup-test-${v4()}`);
+    const standalonePath = join(isolatedDir, 'cfn-lsp-server-standalone.js');
 
     const BUILD_TIMEOUT_MS = 10 * 60 * 1000;
     const TEST_TIMEOUT_MS = 4 * 60 * 1000;
@@ -21,13 +29,21 @@ describe('LSP standalone bundle startup', () => {
             stdio: 'ignore',
         });
 
+        if (!existsSync(bundleSrc)) {
+            throw new Error(`Bundle build did not produce output at: ${bundleSrc}`);
+        }
+
+        mkdirSync(isolatedDir, { recursive: true });
+        cpSync(bundleSrc, isolatedDir, { recursive: true });
+
         if (!existsSync(standalonePath)) {
-            throw new Error(`Bundle build did not produce a standalone server at: ${standalonePath}`);
+            throw new Error(`Standalone server not found at: ${standalonePath}`);
         }
     }, BUILD_TIMEOUT_MS);
 
     afterAll(async () => {
         await client?.shutdown();
+        rmSync(isolatedDir, { recursive: true, force: true });
     }, SHUTDOWN_TIMEOUT_MS);
 
     it(
@@ -36,6 +52,7 @@ describe('LSP standalone bundle startup', () => {
             client = new LspClient({
                 serverPath: standalonePath,
                 mode: 'ipc',
+                cwd: isolatedDir,
                 clientConfig: {
                     name: 'CFN LSP Startup Test',
                     version: '1.0.0',
@@ -49,7 +66,7 @@ describe('LSP standalone bundle startup', () => {
                         },
                     },
                     telemetryEnabled: false,
-                    storageDir: join(process.cwd(), 'node_modules', '.cache', 'lsp-startup', v4()),
+                    storageDir: join(isolatedDir, '.storage', v4()),
                     logLevel: 'info',
                 },
             });

--- a/tst/e2e/LspStartup.test.ts
+++ b/tst/e2e/LspStartup.test.ts
@@ -12,8 +12,7 @@ describe('LSP standalone bundle startup', () => {
 
     // Run the bundle from an isolated temp directory outside the project tree.
     // This prevents Node's module resolution from walking up to the project
-    // root's node_modules/, which would mask missing externals that cause
-    // failures in canary/Hydra environments.
+    // root's node_modules/, which would mask missing dependencies issues
     const isolatedDir = join(tmpdir(), `cfn-lsp-startup-test-${v4()}`);
     const standalonePath = join(isolatedDir, 'cfn-lsp-server-standalone.js');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ const Package = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 const PackageLock = JSON.parse(fs.readFileSync('package-lock.json', 'utf8'));
 const ExternalsDeps = Package.externalDependencies;
 const NativePrebuilds = Package.nativePrebuilds;
-const UnusedDeps = Package.unusedDependencies;
+const RequiredPeerDeps = Package.requiredPeerDeps;
 
 const COPY_FILES = ['LICENSE', 'NOTICE', 'THIRD-PARTY-LICENSES.txt', 'README.md'];
 const KEEP_FILES = [
@@ -31,7 +31,7 @@ const KEEP_FILES = [
 const IGNORE_PATHS = ['/bin/', '/test/', '/benchmarks/', '/examples/'];
 
 function generateExternals() {
-    const externals = [...ExternalsDeps, ...UnusedDeps];
+    const externals = [...ExternalsDeps, ...RequiredPeerDeps];
     const collected = new Set(externals);
     const queue = [...externals];
 
@@ -66,7 +66,7 @@ function generateExternals() {
     // is dev-only. Webpack will bundle it inline instead.
     const filtered = Array.from(collected).filter((dep) => {
         const topLevelInfo = PackageLock.packages?.[`node_modules/${dep}`];
-        if (topLevelInfo?.dev && !ExternalsDeps.includes(dep) && !UnusedDeps.includes(dep) && !NativePrebuilds.includes(dep)) {
+        if (topLevelInfo?.dev && !ExternalsDeps.includes(dep) && !RequiredPeerDeps.includes(dep) && !NativePrebuilds.includes(dep)) {
             console.warn(`[generateExternals] Excluding "${dep}" - dev-only at top level, would not resolve at runtime`);
             return false;
         }
@@ -161,6 +161,12 @@ function createPlugins(isDevelopment, outputPath, mode, env, rebuild = false, bu
                         delete tmpPkg['devDependencies'];
                         delete tmpPkg['externalDependencies'];
                         delete tmpPkg['nativePrebuilds'];
+                        delete tmpPkg['requiredPeerDeps'];
+                        delete tmpPkg['rebuildDependencies'];
+
+                        tmpPkg['scripts'] = {
+                            start: `node ./${BUNDLE_NAME}.js --stdio`,
+                        };
 
                         console.log('[InstallDependencies] Cleaning temp directory...');
                         if (fs.existsSync(tmpDir)) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,28 @@ function generateExternals() {
     for (const dep of NativePrebuilds) {
         collected.add(dep);
     }
-    return Array.from(collected).sort();
+
+    // When a package is externalized, webpack emits `require("pkg")` and expects
+    // it to exist at `bundle/production/node_modules/pkg/` at runtime.
+    //
+    // The transitive walk above can collect packages like "minimatch" that appear
+    // in the lockfile only as a dev dependency at the top level (e.g. v10 for eslint),
+    // while the production copy lives nested (e.g. glob/node_modules/minimatch v9).
+    // The bundle's node_modules/ (built with --omit=dev) won't have them at the
+    // top level, so `require("minimatch")` fails at runtime.
+    //
+    // Fix: exclude any transitively-collected dep whose top-level lockfile entry
+    // is dev-only. Webpack will bundle it inline instead.
+    const filtered = Array.from(collected).filter((dep) => {
+        const topLevelInfo = PackageLock.packages?.[`node_modules/${dep}`];
+        if (topLevelInfo?.dev && !ExternalsDeps.includes(dep) && !UnusedDeps.includes(dep) && !NativePrebuilds.includes(dep)) {
+            console.warn(`[generateExternals] Excluding "${dep}" - dev-only at top level, would not resolve at runtime`);
+            return false;
+        }
+        return true;
+    });
+
+    return filtered.sort();
 }
 
 const EXTERNALS = generateExternals();


### PR DESCRIPTION
## Description

Fixes the `Cannot find module 'minimatch'` in legacy bundles

### Root Cause

`generateExternals()` in `webpack.config.js` transitively walks all dependencies of externalized packages and adds them to the webpack externals list. This caused `minimatch` to be externalized via the chain:

```
@opentelemetry/auto-instrumentations-node → @opentelemetry/resource-detector-gcp → gcp-metadata → gaxios → rimraf → glob → minimatch
```

However, the top-level `node_modules/minimatch` (v10.2.5) is a **dev-only** package. When the bundle runs in isolation, `require('minimatch')` fails because:
- No top-level minimatch in `bundle/production/node_modules/`
- The production copy (v9.0.9) is nested at `glob/node_modules/minimatch/`, unreachable via bare `require()`