### PR TITLE
fix(cfn-lint): Decode percent-encoded URIs in workspace lint paths

### DIFF
--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -252,9 +252,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             return;
         }
 
-        const folderName =
-            folder.name.length > 0 ? folder.name : (folder.uri.replace('file://', '').split('/').pop() ?? '');
-        folder.name = folderName; // Update folder name to ensure consistent mounting and path resolution
+        folder.name = this.resolveFolderName(folder); // Update folder name to ensure consistent mounting and path resolution
 
         const fsDir = URI.parse(folder.uri).fsPath;
         const mountDir = '/'.concat(folder.name);
@@ -280,6 +278,45 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             });
             throw new MountError(`Failed to mount folder ${mountDir}`, error instanceof Error ? error : undefined);
         }
+    }
+
+    /**
+     * Resolve the display name for a workspace folder.
+     *
+     * Falls back to the last segment of the decoded URI path when the folder has no name,
+     * so percent-encoded characters (e.g. `%20`) never end up in the mount directory name.
+     *
+     * @param folder The workspace folder
+     * @returns The folder name
+     */
+    private resolveFolderName(folder: WorkspaceFolder): string {
+        if (folder.name.length > 0) {
+            return folder.name;
+        }
+        return URI.parse(folder.uri).path.split('/').findLast(Boolean) ?? '';
+    }
+
+    /**
+     * Convert a document URI to its path inside the Pyodide mount for its workspace folder.
+     *
+     * Both URIs are decoded via URI.parse before computing the relative path, so
+     * percent-encoded characters (e.g. `%20` for spaces) are translated to the real
+     * filesystem characters. Passing the raw URI suffix would make cfn-lint's
+     * glob-based file resolution fail for paths containing spaces or other
+     * percent-encoded characters (aws/aws-toolkit-vscode#8829).
+     *
+     * @param uri The document URI (percent-encoded)
+     * @param folder The workspace folder containing the document
+     * @returns The decoded path of the document under `/<folder.name>`
+     */
+    private toMountRelativePath(uri: string, folder: WorkspaceFolder): string {
+        const documentPath = URI.parse(uri).path;
+        let folderPath = URI.parse(folder.uri).path;
+        if (folderPath.endsWith('/')) {
+            folderPath = folderPath.slice(0, -1);
+        }
+        const suffix = documentPath.startsWith(folderPath) ? documentPath.slice(folderPath.length) : documentPath;
+        return `/${folder.name}${suffix}`;
     }
 
     /**
@@ -476,11 +513,8 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
                 throw error;
             }
 
-            const folderName =
-                folder.name.length > 0 ? folder.name : (folder.uri.replace('file://', '').split('/').pop() ?? '');
-
-            folder.name = folderName; // Update folder name to ensure consistent mounting and path resolution
-            const relativePath = uri.replace(folder.uri, '/'.concat(folder.name));
+            folder.name = this.resolveFolderName(folder); // Update folder name to ensure consistent mounting and path resolution
+            const relativePath = this.toMountRelativePath(uri, folder);
 
             let diagnosticPayloads;
             if (this.localExecutor) {

--- a/src/services/cfnLint/pyodide-worker.ts
+++ b/src/services/cfnLint/pyodide-worker.ts
@@ -380,13 +380,17 @@ async function initializePyodide(): Promise<InitializeResult> {
           return match_to_diagnostics(lint(template_str, config=ManualArgs(**config) if config else None), uri)
 
       def lint_uri(lint_path, uri, lint_type, settings=None):
+          import glob
           config = parse_cfn_lint_settings(settings)
           path = Path(lint_path)
-          
+
+          # cfn-lint expands these paths with glob.glob and raises ValueError when
+          # nothing matches, so escape glob metacharacters (e.g. [, ], *, ?) to make
+          # sure the path is treated literally.
           if lint_type == "template":
-              config["templates"] = [str(path)]
+              config["templates"] = [glob.escape(str(path))]
           elif lint_type == "gitsync-deployment":
-              config["deployment_files"] = [str(path)]
+              config["deployment_files"] = [glob.escape(str(path))]
 
           return match_to_diagnostics(lint_by_config(ManualArgs(**config)), uri)
     `);

--- a/tst/unit/services/cfnLint/CfnLintService.test.ts
+++ b/tst/unit/services/cfnLint/CfnLintService.test.ts
@@ -106,7 +106,8 @@ vi.mock('pyodide', () => ({
 vi.mock('vscode-uri', () => ({
     URI: {
         parse: vi.fn().mockImplementation((uri: string) => ({
-            fsPath: uri.replace('file://', '/path/to'),
+            fsPath: decodeURIComponent(uri.replace('file://', '/path/to')),
+            path: decodeURIComponent(uri.replace('file://', '')),
         })),
         file: vi.fn().mockImplementation((path: string) => path),
     },
@@ -409,6 +410,71 @@ describe('CfnLintService', () => {
                 ),
             ).toBe(true);
             expect(mockComponents.diagnosticCoordinator.publishDiagnostics.called).toBe(true);
+        });
+
+        test('should decode percent-encoded characters in workspace file paths (aws-toolkit-vscode#8829)', async () => {
+            const folderWithSpaces: WorkspaceFolder = {
+                uri: 'file:///workspace/Gemini%20TF%20AWS%20EKS%20Code',
+                name: 'Gemini TF AWS EKS Code',
+            };
+            const uriWithSpaces = 'file:///workspace/Gemini%20TF%20AWS%20EKS%20Code/CloudFormation%20Example.yaml';
+            mockComponents.workspace.getWorkspaceFolder.returns(folderWithSpaces);
+
+            await service.lint(mockTemplate, uriWithSpaces);
+
+            // Mounted with the decoded filesystem path and decoded mount dir
+            expect(
+                mockWorkerManager.mountFolder.calledWith(
+                    '/path/to/workspace/Gemini TF AWS EKS Code',
+                    '/Gemini TF AWS EKS Code',
+                ),
+            ).toBe(true);
+            // Linted with the decoded path — no %20 leaking into the filesystem path
+            expect(
+                mockWorkerManager.lintFile.calledWith(
+                    '/Gemini TF AWS EKS Code/CloudFormation Example.yaml',
+                    uriWithSpaces,
+                    CloudFormationFileType.Template,
+                ),
+            ).toBe(true);
+        });
+
+        test('should derive decoded folder name for percent-encoded folders without a name', async () => {
+            const unnamedFolderWithSpaces: WorkspaceFolder = {
+                uri: 'file:///workspace/My%20Project',
+                name: '',
+            };
+            const uriInFolder = 'file:///workspace/My%20Project/template.yaml';
+            mockComponents.workspace.getWorkspaceFolder.returns(unnamedFolderWithSpaces);
+
+            await service.lint(mockTemplate, uriInFolder);
+
+            expect(mockWorkerManager.mountFolder.calledWith('/path/to/workspace/My Project', '/My Project')).toBe(true);
+            expect(
+                mockWorkerManager.lintFile.calledWith(
+                    '/My Project/template.yaml',
+                    uriInFolder,
+                    CloudFormationFileType.Template,
+                ),
+            ).toBe(true);
+        });
+
+        test('should handle workspace folder URIs with a trailing slash', async () => {
+            const folderWithTrailingSlash: WorkspaceFolder = {
+                uri: 'file:///workspace/project/',
+                name: 'project',
+            };
+            mockComponents.workspace.getWorkspaceFolder.returns(folderWithTrailingSlash);
+
+            await service.lint(mockTemplate, mockUri);
+
+            expect(
+                mockWorkerManager.lintFile.calledWith(
+                    '/project/template.yaml',
+                    mockUri,
+                    CloudFormationFileType.Template,
+                ),
+            ).toBe(true);
         });
 
         test('should handle templates with triple quotes', async () => {


### PR DESCRIPTION
The cfn-lint pyodide worker crashed with "could not be processed by glob.glob" when linting templates in workspace paths containing spaces. The lint path was built by raw URI string replacement, leaving percent-encoded characters (e.g. %20) in the filesystem path while the Pyodide mount contains the real decoded names.

Compute the mount-relative path from decoded URI paths instead, derive fallback folder names from the decoded path, and glob-escape the path in the worker so files containing glob metacharacters also lint.

Fixes aws/aws-toolkit-vscode#8829

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
