### PR TITLE
Reduce server and lint worker memory usage

### DIFF
--- a/src/app/standalone.ts
+++ b/src/app/standalone.ts
@@ -52,3 +52,9 @@ process.on('unhandledRejection', (reason, _promise) => {
 process.on('uncaughtException', (error, origin) => {
     console.error(error, `Unhandled exception ${origin}`);
 });
+
+// Exit when the client drops the connection. Without this, active
+// handles keep the event loop alive and the process leaks.
+// Normal shutdown flushes telemetry and exits via the library before stdin closes.
+// eslint-disable-next-line unicorn/no-process-exit
+process.stdin.on('close', () => process.exit(0));

--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -176,6 +176,11 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      * @throws Error if initialization fails at any step
      */
     public async initialize(): Promise<void> {
+        if (!this.settings.enabled) {
+            this.log.info('cfn-lint is disabled, skipping Pyodide initialization');
+            return;
+        }
+
         if (this.status !== STATUS.Uninitialized) {
             return;
         }
@@ -243,6 +248,10 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      * @throws Error if the service is not initialized or mounting fails
      */
     public async mountFolder(folder: WorkspaceFolder): Promise<void> {
+        if (!this.settings.enabled) {
+            return;
+        }
+
         if (this.status === STATUS.Uninitialized) {
             throw new Error('CfnLintService not initialized. Call initialize() first.');
         }

--- a/src/services/cfnLint/PyodideWorkerManager.ts
+++ b/src/services/cfnLint/PyodideWorkerManager.ts
@@ -86,7 +86,9 @@ export class PyodideWorkerManager {
                 // Use a path relative to the current file
                 const workerPath = path.join(__dirname, 'pyodide-worker.js');
                 this.log.info(`Loading worker from: ${workerPath}`);
-                this.worker = new Worker(workerPath);
+                this.worker = new Worker(workerPath, {
+                    resourceLimits: { maxOldGenerationSizeMb: 128 },
+                });
 
                 // Add exit event handler to detect crashes
                 this.worker.on('exit', (code) => {

--- a/tst/unit/services/cfnLint/PyodideWorkerManager.test.ts
+++ b/tst/unit/services/cfnLint/PyodideWorkerManager.test.ts
@@ -125,7 +125,9 @@ describe('PyodideWorkerManager', () => {
             const initPromise = workerManager.initialize();
 
             // Verify worker was created
-            expect(workerConstructor).toHaveBeenCalledWith(expect.stringContaining('pyodide-worker.js'));
+            expect(workerConstructor).toHaveBeenCalledWith(expect.stringContaining('pyodide-worker.js'), {
+                resourceLimits: { maxOldGenerationSizeMb: 128 },
+            });
 
             // Verify event handlers were set up
             expect(mockWorker.on.calledWith('message', sinon.match.func)).toBe(true);
@@ -271,7 +273,9 @@ describe('PyodideWorkerManager', () => {
             // expect(path.join).toHaveBeenCalledWith(expect.any(String), 'pyodide-worker.js');
 
             // Verify Worker constructor was called with a string path
-            expect(workerConstructor).toHaveBeenCalledWith(expect.any(String));
+            expect(workerConstructor).toHaveBeenCalledWith(expect.any(String), {
+                resourceLimits: { maxOldGenerationSizeMb: 128 },
+            });
         });
     });
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-toolkit-jetbrains/issues/6380

*Description of changes:*
Reducing memory usage by skipping pyodide if lint is not enabled and reducing the lint worker memory limits. Also, fixed a bug where failed lsp exit handshake could cause the servers to stay open after closing the clients

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
