### PR TITLE
feat(hooks): TTL HookCache and persistent hook schema store (1/7)

### DIFF
--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -15,9 +15,14 @@ export enum StoreName {
     public_schemas = 'public_schemas',
     sam_schemas = 'sam_schemas',
     private_schemas = 'private_schemas',
+    hook_schemas = 'hook_schemas',
 }
 
-export const PersistedStores: ReadonlyArray<StoreName> = [StoreName.public_schemas, StoreName.sam_schemas];
+export const PersistedStores: ReadonlyArray<StoreName> = [
+    StoreName.public_schemas,
+    StoreName.sam_schemas,
+    StoreName.hook_schemas,
+];
 
 export interface DataStore {
     get<T>(key: string): T | undefined;

--- a/src/hooks/HookCache.ts
+++ b/src/hooks/HookCache.ts
@@ -1,0 +1,132 @@
+interface CacheEntry<T> {
+    value: T;
+    expiresAt: number;
+}
+
+export class TtlCache<T> {
+    private readonly entries = new Map<string, CacheEntry<T>>();
+    private readonly inflight = new Map<string, Promise<T>>();
+
+    constructor(
+        private readonly ttlMs: number,
+        private readonly now: () => number = Date.now,
+    ) {}
+
+    async get(key: string, loader: () => Promise<T>): Promise<T> {
+        const cached = this.entries.get(key);
+        if (cached) {
+            if (cached.expiresAt > this.now()) {
+                return cached.value;
+            }
+            this.entries.delete(key);
+        }
+
+        const existing = this.inflight.get(key);
+        if (existing) {
+            return await existing;
+        }
+
+        const load = loader()
+            .then((value) => {
+                if (this.inflight.get(key) === load) {
+                    this.prune();
+                    this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
+                }
+                return value;
+            })
+            .finally(() => {
+                if (this.inflight.get(key) === load) {
+                    this.inflight.delete(key);
+                }
+            });
+
+        this.inflight.set(key, load);
+        return await load;
+    }
+
+    peek(key: string): T | undefined {
+        const cached = this.entries.get(key);
+        if (cached) {
+            if (cached.expiresAt > this.now()) {
+                return cached.value;
+            }
+            this.entries.delete(key);
+        }
+        return undefined;
+    }
+
+    set(key: string, value: T): void {
+        this.prune();
+        this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
+    }
+
+    invalidate(key: string): void {
+        this.entries.delete(key);
+        this.inflight.delete(key);
+    }
+
+    clear(): void {
+        this.entries.clear();
+        this.inflight.clear();
+    }
+
+    private prune(): void {
+        const now = this.now();
+        for (const [key, entry] of this.entries) {
+            if (entry.expiresAt <= now) {
+                this.entries.delete(key);
+            }
+        }
+    }
+
+    get size(): number {
+        let count = 0;
+        for (const entry of this.entries.values()) {
+            if (entry.expiresAt > this.now()) {
+                count++;
+            }
+        }
+        return count;
+    }
+}
+
+const DEFAULT_TTL_MS = 60_000;
+
+export class HookCache {
+    private readonly configs: TtlCache<string>;
+    private readonly rules: TtlCache<string>;
+
+    constructor(ttlMs: number = DEFAULT_TTL_MS, now: () => number = Date.now) {
+        this.configs = new TtlCache<string>(ttlMs, now);
+        this.rules = new TtlCache<string>(ttlMs, now);
+    }
+
+    async getConfiguration(typeName: string, loader: () => Promise<string>): Promise<string> {
+        return await this.configs.get(typeName, loader);
+    }
+
+    async getRuleContent(s3Uri: string, loader: () => Promise<string>): Promise<string> {
+        return await this.rules.get(s3Uri, loader);
+    }
+
+    peekConfiguration(typeName: string): string | undefined {
+        return this.configs.peek(typeName);
+    }
+
+    peekRuleContent(s3Uri: string): string | undefined {
+        return this.rules.peek(s3Uri);
+    }
+
+    invalidateHook(typeName: string): void {
+        this.configs.invalidate(typeName);
+    }
+
+    invalidateRule(s3Uri: string): void {
+        this.rules.invalidate(s3Uri);
+    }
+
+    invalidateAll(): void {
+        this.configs.clear();
+        this.rules.clear();
+    }
+}

--- a/src/hooks/HookSchemaStore.ts
+++ b/src/hooks/HookSchemaStore.ts
@@ -1,0 +1,57 @@
+import { DataStore, DataStoreFactoryProvider, Persistence, StoreName } from '../datastore/DataStore';
+import type { DescribeHookResult } from './HooksRequestType';
+
+export type HookSchemaRecord = {
+    version: string;
+    typeName: string;
+    schema: DescribeHookResult;
+    firstCreatedMs: number;
+    lastModifiedMs: number;
+};
+
+const HookSchemaVersion = 'v1';
+
+export class HookSchemaStore {
+    private readonly store: DataStore;
+
+    constructor(
+        dataStoreFactory: DataStoreFactoryProvider,
+        private readonly now: () => number = Date.now,
+    ) {
+        this.store = dataStoreFactory.get(StoreName.hook_schemas, Persistence.local);
+    }
+
+    get(typeName: string): HookSchemaRecord | undefined {
+        return this.store.get<HookSchemaRecord>(this.key(typeName));
+    }
+
+    async put(typeName: string, schema: DescribeHookResult): Promise<boolean> {
+        const now = this.now();
+        const existing = this.get(typeName);
+        const record: HookSchemaRecord = {
+            version: HookSchemaVersion,
+            typeName,
+            schema,
+            firstCreatedMs: existing?.firstCreatedMs ?? now,
+            lastModifiedMs: now,
+        };
+        return await this.store.put(this.key(typeName), record);
+    }
+
+    async remove(typeName: string): Promise<void> {
+        await this.store.remove(this.key(typeName));
+    }
+
+    async clear(): Promise<void> {
+        await this.store.clear();
+    }
+
+    getAgeMs(typeName: string): number | undefined {
+        const record = this.get(typeName);
+        return record === undefined ? undefined : this.now() - record.lastModifiedMs;
+    }
+
+    private key(typeName: string): string {
+        return `hook:${typeName}`;
+    }
+}

--- a/src/hooks/HooksRequestType.ts
+++ b/src/hooks/HooksRequestType.ts
@@ -1,0 +1,400 @@
+import { RequestType } from 'vscode-languageserver';
+
+export type ListHooksParams = {
+    loadMore?: boolean;
+};
+
+export type HookSummary = {
+    typeName: string;
+    typeArn: string;
+    defaultVersionId?: string;
+    description?: string;
+    lastUpdated?: string;
+};
+
+export type ListHooksResult = {
+    hooks: HookSummary[];
+    nextToken?: string;
+};
+
+export const ListHooksRequest = new RequestType<ListHooksParams, ListHooksResult, void>('aws/cfn/hooks/list');
+
+export type DetailedHook = HookSummary & {
+    configured: boolean;
+    configuration?: string;
+    failureMode?: string;
+    invocationStatus?: string;
+    targetOperations?: string[];
+    ruleUri?: string;
+};
+
+export type ListHooksDetailedResult = {
+    hooks: DetailedHook[];
+    nextToken?: string;
+};
+
+export const ListHooksDetailedRequest = new RequestType<ListHooksParams, ListHooksDetailedResult, void>(
+    'aws/cfn/hooks/listDetailed',
+);
+
+export type ListPublicHooksParams = {
+    typeNamePrefix?: string;
+};
+
+export type PublicHookSummary = {
+    typeName: string;
+    publisherId: string;
+    description?: string;
+};
+
+export type ListPublicHooksResult = {
+    hooks: PublicHookSummary[];
+};
+
+export const ListPublicHooksRequest = new RequestType<ListPublicHooksParams, ListPublicHooksResult, void>(
+    'aws/cfn/hooks/listPublic',
+);
+
+export type DescribeHookParams = {
+    typeName?: string;
+    arn?: string;
+};
+
+export type HookTargetInfo = {
+    targetName: string;
+    invocationPoint: string;
+    failureMode: string;
+};
+
+export type DescribeHookResult = {
+    typeName: string;
+    arn: string;
+    description?: string;
+    schema?: string;
+    configurationSchema?: string;
+    visibility: string;
+    defaultVersionId?: string;
+    lastUpdated?: string;
+    targets?: HookTargetInfo[];
+};
+
+export const DescribeHookRequest = new RequestType<DescribeHookParams, DescribeHookResult, void>(
+    'aws/cfn/hooks/describe',
+);
+
+export type ListHookResultsParams = {
+    typeArn?: string;
+    status?: string;
+    targetId?: string;
+    targetType?: string;
+    nextToken?: string;
+};
+
+export type HookResultSummary = {
+    hookResultId: string;
+    hookTypeArn: string;
+    hookTypeName: string;
+    invocationPoint: string;
+    hookStatus: string;
+    failureMode: string;
+    targetId?: string;
+    targetType?: string;
+    timestamp?: string;
+};
+
+export type ListHookResultsResult = {
+    hookResults: HookResultSummary[];
+    nextToken?: string;
+};
+
+export const ListHookResultsRequest = new RequestType<ListHookResultsParams, ListHookResultsResult, void>(
+    'aws/cfn/hooks/results/list',
+);
+
+export type GetHookResultParams = {
+    hookResultId: string;
+};
+
+export type HookAnnotation = {
+    severity: string;
+    statusMessage: string;
+    remediationLink?: string;
+};
+
+export type HookTarget = {
+    targetType: string;
+    targetName: string;
+    targetId?: string;
+    action?: string;
+};
+
+export type GetHookResultResult = {
+    hookResultId: string;
+    hookTypeName: string;
+    hookStatus: string;
+    failureMode: string;
+    invocationPoint: string;
+    annotations?: HookAnnotation[];
+    target?: HookTarget;
+    timestamp?: string;
+};
+
+export const GetHookResultRequest = new RequestType<GetHookResultParams, GetHookResultResult, void>(
+    'aws/cfn/hooks/result/get',
+);
+
+export type ConfigureHookParams = {
+    typeName: string;
+    failureMode: string;
+};
+
+export type ConfigureHookResult = {
+    configurationArn?: string;
+};
+
+export const ConfigureHookRequest = new RequestType<ConfigureHookParams, ConfigureHookResult, void>(
+    'aws/cfn/hooks/configure',
+);
+
+export type SetInvocationStatusParams = {
+    typeName: string;
+    invocationStatus: 'ENABLED' | 'DISABLED';
+};
+
+export type SetInvocationStatusResult = {
+    configurationArn?: string;
+    invocationStatus: 'ENABLED' | 'DISABLED';
+};
+
+export const SetInvocationStatusRequest = new RequestType<SetInvocationStatusParams, SetInvocationStatusResult, void>(
+    'aws/cfn/hooks/setInvocationStatus',
+);
+
+export type CreateGuardHookParams = {
+    /** JSON string of the AWS::CloudFormation::GuardHook DesiredState. */
+    desiredState: string;
+};
+
+export type CreateGuardHookResult = {
+    operationStatus?: string;
+    identifier?: string;
+    errorCode?: string;
+    statusMessage?: string;
+};
+
+export const CreateGuardHookRequest = new RequestType<CreateGuardHookParams, CreateGuardHookResult, void>(
+    'aws/cfn/hooks/createGuardHook',
+);
+
+export type ListIamRolesParams = Record<string, never>;
+
+export type IamRoleSummary = {
+    roleName: string;
+    arn: string;
+};
+
+export type ListIamRolesResult = {
+    roles: IamRoleSummary[];
+};
+
+export const ListIamRolesRequest = new RequestType<ListIamRolesParams, ListIamRolesResult, void>(
+    'aws/cfn/hooks/listIamRoles',
+);
+
+export type ListS3BucketsParams = Record<string, never>;
+
+export type ListS3BucketsResult = {
+    buckets: string[];
+};
+
+export const ListS3BucketsRequest = new RequestType<ListS3BucketsParams, ListS3BucketsResult, void>(
+    'aws/cfn/hooks/listS3Buckets',
+);
+
+export type ListS3ObjectsParams = {
+    bucketName: string;
+    prefix?: string;
+};
+
+export type ListS3ObjectsResult = {
+    keys: string[];
+};
+
+export const ListS3ObjectsRequest = new RequestType<ListS3ObjectsParams, ListS3ObjectsResult, void>(
+    'aws/cfn/hooks/listS3Objects',
+);
+
+export type ListProactiveControlsParams = Record<string, never>;
+
+export type ProactiveControlSummary = {
+    controlId: string;
+    name: string;
+    resource?: string;
+};
+
+export type ListProactiveControlsResult = {
+    controls: ProactiveControlSummary[];
+};
+
+export const ListProactiveControlsRequest = new RequestType<
+    ListProactiveControlsParams,
+    ListProactiveControlsResult,
+    void
+>('aws/cfn/hooks/listProactiveControls');
+
+export type CreateS3BucketParams = {
+    bucketName: string;
+};
+
+export type CreateS3BucketResult = {
+    bucketName: string;
+};
+
+export const CreateS3BucketRequest = new RequestType<CreateS3BucketParams, CreateS3BucketResult, void>(
+    'aws/cfn/hooks/createS3Bucket',
+);
+
+export type CreateHookExecutionRoleParams = {
+    roleName: string;
+    ruleBucket?: string;
+};
+
+export type CreateHookExecutionRoleResult = {
+    roleName: string;
+    arn: string;
+};
+
+export const CreateHookExecutionRoleRequest = new RequestType<
+    CreateHookExecutionRoleParams,
+    CreateHookExecutionRoleResult,
+    void
+>('aws/cfn/hooks/createExecutionRole');
+
+export type DeactivateHookParams = {
+    typeName?: string;
+    arn?: string;
+};
+
+export type DeactivateHookResult = Record<string, never>;
+
+export const DeactivateHookRequest = new RequestType<DeactivateHookParams, DeactivateHookResult, void>(
+    'aws/cfn/hooks/deactivate',
+);
+
+export type ActivateHookParams = {
+    typeName: string;
+    publisherId?: string;
+    typeNameAlias?: string;
+    executionRoleArn?: string;
+};
+
+export type ActivateHookResult = {
+    arn?: string;
+};
+
+export const ActivateHookRequest = new RequestType<ActivateHookParams, ActivateHookResult, void>(
+    'aws/cfn/hooks/activate',
+);
+
+export type SetHookConfigurationParams = {
+    typeName: string;
+    configuration: string;
+};
+
+export type SetHookConfigurationResult = {
+    configurationArn?: string;
+};
+
+export const SetHookConfigurationRequest = new RequestType<
+    SetHookConfigurationParams,
+    SetHookConfigurationResult,
+    void
+>('aws/cfn/hooks/setConfiguration');
+
+export type GetHookConfigurationParams = {
+    typeName: string;
+};
+
+export type GetHookConfigurationResult = {
+    configuration: string;
+};
+
+export const GetHookConfigurationRequest = new RequestType<
+    GetHookConfigurationParams,
+    GetHookConfigurationResult,
+    void
+>('aws/cfn/hooks/getConfiguration');
+
+export type GetRuleContentParams = {
+    s3Uri: string;
+};
+
+export type GetRuleContentResult = {
+    content: string;
+};
+
+export const GetRuleContentRequest = new RequestType<GetRuleContentParams, GetRuleContentResult, void>(
+    'aws/cfn/hooks/getRuleContent',
+);
+
+export type ValidateRuleParams = {
+    ruleContent: string;
+    sampleTemplate?: string;
+};
+
+export type RuleViolation = {
+    ruleName: string;
+    message: string;
+    line: number;
+    column: number;
+};
+
+export type ValidateRuleResult = {
+    valid: boolean;
+    parseErrors: string[];
+    violations: RuleViolation[];
+};
+
+export const ValidateRuleRequest = new RequestType<ValidateRuleParams, ValidateRuleResult, void>(
+    'aws/cfn/hooks/validateRule',
+);
+
+export type UploadRuleParams = {
+    ruleContent: string;
+    s3Uri: string;
+};
+
+export type UploadRuleResult = {
+    s3Uri: string;
+};
+
+export const UploadRuleRequest = new RequestType<UploadRuleParams, UploadRuleResult, void>('aws/cfn/hooks/uploadRule');
+
+export type PreviewGuardHooksParams = {
+    templateContent: string;
+};
+
+export type GuardHookPreviewViolation = {
+    ruleName: string;
+    message: string;
+    line: number;
+    column: number;
+    path?: string;
+};
+
+export type GuardHookPreviewEntry = {
+    typeName: string;
+    ruleUri: string;
+    failureMode?: string;
+    valid: boolean;
+    violations: GuardHookPreviewViolation[];
+    error?: string;
+};
+
+export type PreviewGuardHooksResult = {
+    hooks: GuardHookPreviewEntry[];
+};
+
+export const PreviewGuardHooksRequest = new RequestType<PreviewGuardHooksParams, PreviewGuardHooksResult, void>(
+    'aws/cfn/hooks/previewGuard',
+);

--- a/tst/unit/hooks/HookCache.test.ts
+++ b/tst/unit/hooks/HookCache.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HookCache, TtlCache } from '../../../src/hooks/HookCache';
+
+describe('TtlCache', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('loads and caches a value within the TTL', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValue('v1');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads after the TTL expires', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValueOnce('v1').mockResolvedValueOnce('v2');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        clock += 101;
+        expect(await cache.get('k', loader)).toBe('v2');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('reloads when the clock reaches expiresAt (exclusive upper bound)', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValueOnce('v1').mockResolvedValueOnce('v2');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        clock += 99;
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(loader).toHaveBeenCalledTimes(1);
+        clock += 1;
+        expect(await cache.get('k', loader)).toBe('v2');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates concurrent loads for the same key', async () => {
+        const cache = new TtlCache<string>(100, now);
+        let resolveLoad!: (v: string) => void;
+        const loader = vi.fn().mockReturnValue(new Promise<string>((resolve) => (resolveLoad = resolve)));
+
+        const a = cache.get('k', loader);
+        const b = cache.get('k', loader);
+        resolveLoad('shared');
+
+        expect(await a).toBe('shared');
+        expect(await b).toBe('shared');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a failed load and retries next time', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce('ok');
+
+        await expect(cache.get('k', loader)).rejects.toThrow('boom');
+        expect(await cache.get('k', loader)).toBe('ok');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('peek returns unexpired values only', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('k', () => Promise.resolve('v1'));
+
+        expect(cache.peek('k')).toBe('v1');
+        clock += 101;
+        expect(cache.peek('k')).toBeUndefined();
+        expect(cache.peek('missing')).toBeUndefined();
+    });
+
+    it('set stores a value with a fresh TTL', () => {
+        const cache = new TtlCache<string>(100, now);
+        cache.set('k', 'v1');
+        expect(cache.peek('k')).toBe('v1');
+    });
+
+    it('invalidate removes a single key', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValue('v1');
+        await cache.get('k', loader);
+        cache.invalidate('k');
+        await cache.get('k', loader);
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidate during an in-flight load does not cache the resolved value', async () => {
+        const cache = new TtlCache<string>(100, now);
+        let resolveLoad!: (v: string) => void;
+        const loader = vi.fn().mockReturnValue(new Promise<string>((resolve) => (resolveLoad = resolve)));
+
+        const pending = cache.get('k', loader);
+        cache.invalidate('k');
+        resolveLoad('stale');
+        await pending;
+
+        expect(cache.peek('k')).toBeUndefined();
+    });
+
+    it('clear removes all keys', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('a', () => Promise.resolve('1'));
+        await cache.get('b', () => Promise.resolve('2'));
+        cache.clear();
+        expect(cache.size).toBe(0);
+    });
+
+    it('size counts only unexpired entries', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('a', () => Promise.resolve('1'));
+        expect(cache.size).toBe(1);
+        clock += 101;
+        expect(cache.size).toBe(0);
+    });
+});
+
+describe('HookCache', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('caches hook configuration by type name', async () => {
+        const cache = new HookCache(100, now);
+        const loader = vi.fn().mockResolvedValue('{"cfg":1}');
+
+        expect(await cache.getConfiguration('Private::Guard::A', loader)).toBe('{"cfg":1}');
+        expect(await cache.getConfiguration('Private::Guard::A', loader)).toBe('{"cfg":1}');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches rule content by S3 URI independently of config', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule R {}');
+
+        await cache.getConfiguration('T', cfgLoader);
+        expect(await cache.getRuleContent('s3://b/r.guard', ruleLoader)).toBe('rule R {}');
+        expect(await cache.getRuleContent('s3://b/r.guard', ruleLoader)).toBe('rule R {}');
+        expect(ruleLoader).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateHook forces a config reload but keeps rules', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateHook('T');
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+
+        expect(cfgLoader).toHaveBeenCalledTimes(2);
+        expect(ruleLoader).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateRule forces a rule reload', async () => {
+        const cache = new HookCache(100, now);
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateRule('s3://b/r');
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        expect(ruleLoader).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidateAll clears both configs and rules', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateAll();
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        expect(cfgLoader).toHaveBeenCalledTimes(2);
+        expect(ruleLoader).toHaveBeenCalledTimes(2);
+    });
+
+    it('peek helpers return cached values without loading', async () => {
+        const cache = new HookCache(100, now);
+        await cache.getConfiguration('T', () => Promise.resolve('cfg'));
+        expect(cache.peekConfiguration('T')).toBe('cfg');
+        expect(cache.peekRuleContent('s3://none')).toBeUndefined();
+    });
+});
+
+describe('TtlCache pruning', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('evicts expired entries on write so the map does not retain stale keys', () => {
+        const cache = new TtlCache<string>(100, now);
+        cache.set('a', 'va');
+        cache.set('b', 'vb');
+        expect(cache.size).toBe(2);
+
+        clock += 200;
+        cache.set('c', 'vc');
+
+        expect(cache.size).toBe(1);
+        expect(cache.peek('a')).toBeUndefined();
+        expect(cache.peek('b')).toBeUndefined();
+        expect(cache.peek('c')).toBe('vc');
+    });
+});


### PR DESCRIPTION
## Summary

Foundation slice (**PR 1 of 7**) for the CloudFormation **Hooks** feature. This PR adds the base caching/persistence primitives and the shared LSP request/response types that the rest of the stack builds on. It wires nothing into the server yet — later PRs consume these.

This is the bottom of a stacked series; each subsequent PR targets the previous branch:

1. **cache-infra (this PR)** — TTL cache + hook schema store + request types
2. services (ControlCatalog/IAM + hook APIs on AWS clients)
3. HooksManager + HooksParser
4. Guard hook preview
5. Hook management LSP endpoints & handlers (wiring)
6. Hook failures surfaced as validation/deployment diagnostics
7. Functional test harness

## What's included

- **`src/hooks/HookCache.ts`**
  - `TtlCache<T>` — a generic in-memory cache with per-entry TTL and single-flight loading. Concurrent callers for the same key share one in-flight loader promise (deduplication); failed loads are not cached; an `invalidate()` during an in-flight load prevents caching the stale result via an identity check. Expired entries are pruned on every write so the backing map stays bounded to the live key set.
  - `HookCache` — a small facade over two `TtlCache` instances (hook configurations, keyed by type name; rule content, keyed by S3 URI) so the two domains have independent TTLs and invalidation.
- **`src/hooks/HookSchemaStore.ts`** — persistent, versioned store for hook schemas built on the existing `DataStore` (`Persistence.local`), mirroring the established `SchemaStore` pattern. Tracks first-created / last-modified timestamps and exposes an age helper for staleness checks. Uses an injectable clock for testability.
- **`src/hooks/HooksRequestType.ts`** — the single source of truth for the Hooks LSP request/response types (`Params`/`Result`/`Request` triples), consumed by the handler/protocol wiring in later PRs.
- **`src/datastore/DataStore.ts`** — adds `hook_schemas` to the `StoreName` enum and the `PersistedStores` list so both the LMDB and File backends auto-create the backing store.

## Testing

- `tst/unit/hooks/HookCache.test.ts` — covers cache hit within TTL, reload after expiry, exact TTL boundary, in-flight deduplication, failed-load (no caching + retry), peek, manual set, single-key invalidation, invalidation during an in-flight load, clear, size counting only unexpired entries, expired-entry eviction on write, and the `HookCache` facade's config/rule isolation.
- `HookSchemaStore` is exercised via `HooksManager` tests in PR 3.
- Build (`tsc -b`) and lint pass.
