### PR TITLE
feat(hooks): AWS service layer — ControlCatalog, IAM, and hook APIs (2/7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@aws-sdk/client-cloudcontrol": "3.1080.0",
                 "@aws-sdk/client-cloudformation": "3.1080.0",
+                "@aws-sdk/client-controlcatalog": "3.1069.0",
                 "@aws-sdk/client-iam": "3.1080.0",
                 "@aws-sdk/client-s3": "3.1080.0",
                 "@aws-sdk/client-sts": "3.1080.0",
@@ -103,6 +104,55 @@
                 "npm": ">=10.5.0"
             }
         },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
         "node_modules/@aws-sdk/checksums": {
             "version": "3.1000.17",
             "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.17.tgz",
@@ -164,6 +214,27 @@
                 "@smithy/fetch-http-handler": "^5.6.2",
                 "@smithy/node-http-handler": "^4.9.2",
                 "@smithy/types": "^4.15.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-controlcatalog": {
+            "version": "3.1069.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-controlcatalog/-/client-controlcatalog-3.1069.0.tgz",
+            "integrity": "sha512-iayVGOJF3OUZ2UUHR/FWRBywRwS/Tx3oej96bRLp0xAEfWvS1o6S7O+Qjgv6GQFW9ulVWdLfb3fnnT2mr7Vf7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.21",
+                "@aws-sdk/credential-provider-node": "^3.972.56",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -629,6 +700,18 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.15.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.965.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+            "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+            "license": "Apache-2.0",
+            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3900,6 +3983,18 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@smithy/node-http-handler": {
             "version": "4.9.6",
             "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
@@ -3938,6 +4033,32 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/util-waiter": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dependencies": {
         "@aws-sdk/client-cloudcontrol": "3.1080.0",
         "@aws-sdk/client-cloudformation": "3.1080.0",
+        "@aws-sdk/client-controlcatalog": "3.1069.0",
         "@aws-sdk/client-iam": "3.1080.0",
         "@aws-sdk/client-s3": "3.1080.0",
         "@aws-sdk/client-sts": "3.1080.0",

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -15,9 +15,14 @@ export enum StoreName {
     public_schemas = 'public_schemas',
     sam_schemas = 'sam_schemas',
     private_schemas = 'private_schemas',
+    hook_schemas = 'hook_schemas',
 }
 
-export const PersistedStores: ReadonlyArray<StoreName> = [StoreName.public_schemas, StoreName.sam_schemas];
+export const PersistedStores: ReadonlyArray<StoreName> = [
+    StoreName.public_schemas,
+    StoreName.sam_schemas,
+    StoreName.hook_schemas,
+];
 
 export interface DataStore {
     get<T>(key: string): T | undefined;

--- a/src/hooks/HookCache.ts
+++ b/src/hooks/HookCache.ts
@@ -1,0 +1,132 @@
+interface CacheEntry<T> {
+    value: T;
+    expiresAt: number;
+}
+
+export class TtlCache<T> {
+    private readonly entries = new Map<string, CacheEntry<T>>();
+    private readonly inflight = new Map<string, Promise<T>>();
+
+    constructor(
+        private readonly ttlMs: number,
+        private readonly now: () => number = Date.now,
+    ) {}
+
+    async get(key: string, loader: () => Promise<T>): Promise<T> {
+        const cached = this.entries.get(key);
+        if (cached) {
+            if (cached.expiresAt > this.now()) {
+                return cached.value;
+            }
+            this.entries.delete(key);
+        }
+
+        const existing = this.inflight.get(key);
+        if (existing) {
+            return await existing;
+        }
+
+        const load = loader()
+            .then((value) => {
+                if (this.inflight.get(key) === load) {
+                    this.prune();
+                    this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
+                }
+                return value;
+            })
+            .finally(() => {
+                if (this.inflight.get(key) === load) {
+                    this.inflight.delete(key);
+                }
+            });
+
+        this.inflight.set(key, load);
+        return await load;
+    }
+
+    peek(key: string): T | undefined {
+        const cached = this.entries.get(key);
+        if (cached) {
+            if (cached.expiresAt > this.now()) {
+                return cached.value;
+            }
+            this.entries.delete(key);
+        }
+        return undefined;
+    }
+
+    set(key: string, value: T): void {
+        this.prune();
+        this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
+    }
+
+    invalidate(key: string): void {
+        this.entries.delete(key);
+        this.inflight.delete(key);
+    }
+
+    clear(): void {
+        this.entries.clear();
+        this.inflight.clear();
+    }
+
+    private prune(): void {
+        const now = this.now();
+        for (const [key, entry] of this.entries) {
+            if (entry.expiresAt <= now) {
+                this.entries.delete(key);
+            }
+        }
+    }
+
+    get size(): number {
+        let count = 0;
+        for (const entry of this.entries.values()) {
+            if (entry.expiresAt > this.now()) {
+                count++;
+            }
+        }
+        return count;
+    }
+}
+
+const DEFAULT_TTL_MS = 60_000;
+
+export class HookCache {
+    private readonly configs: TtlCache<string>;
+    private readonly rules: TtlCache<string>;
+
+    constructor(ttlMs: number = DEFAULT_TTL_MS, now: () => number = Date.now) {
+        this.configs = new TtlCache<string>(ttlMs, now);
+        this.rules = new TtlCache<string>(ttlMs, now);
+    }
+
+    async getConfiguration(typeName: string, loader: () => Promise<string>): Promise<string> {
+        return await this.configs.get(typeName, loader);
+    }
+
+    async getRuleContent(s3Uri: string, loader: () => Promise<string>): Promise<string> {
+        return await this.rules.get(s3Uri, loader);
+    }
+
+    peekConfiguration(typeName: string): string | undefined {
+        return this.configs.peek(typeName);
+    }
+
+    peekRuleContent(s3Uri: string): string | undefined {
+        return this.rules.peek(s3Uri);
+    }
+
+    invalidateHook(typeName: string): void {
+        this.configs.invalidate(typeName);
+    }
+
+    invalidateRule(s3Uri: string): void {
+        this.rules.invalidate(s3Uri);
+    }
+
+    invalidateAll(): void {
+        this.configs.clear();
+        this.rules.clear();
+    }
+}

--- a/src/hooks/HookSchemaStore.ts
+++ b/src/hooks/HookSchemaStore.ts
@@ -1,0 +1,57 @@
+import { DataStore, DataStoreFactoryProvider, Persistence, StoreName } from '../datastore/DataStore';
+import type { DescribeHookResult } from './HooksRequestType';
+
+export type HookSchemaRecord = {
+    version: string;
+    typeName: string;
+    schema: DescribeHookResult;
+    firstCreatedMs: number;
+    lastModifiedMs: number;
+};
+
+const HookSchemaVersion = 'v1';
+
+export class HookSchemaStore {
+    private readonly store: DataStore;
+
+    constructor(
+        dataStoreFactory: DataStoreFactoryProvider,
+        private readonly now: () => number = Date.now,
+    ) {
+        this.store = dataStoreFactory.get(StoreName.hook_schemas, Persistence.local);
+    }
+
+    get(typeName: string): HookSchemaRecord | undefined {
+        return this.store.get<HookSchemaRecord>(this.key(typeName));
+    }
+
+    async put(typeName: string, schema: DescribeHookResult): Promise<boolean> {
+        const now = this.now();
+        const existing = this.get(typeName);
+        const record: HookSchemaRecord = {
+            version: HookSchemaVersion,
+            typeName,
+            schema,
+            firstCreatedMs: existing?.firstCreatedMs ?? now,
+            lastModifiedMs: now,
+        };
+        return await this.store.put(this.key(typeName), record);
+    }
+
+    async remove(typeName: string): Promise<void> {
+        await this.store.remove(this.key(typeName));
+    }
+
+    async clear(): Promise<void> {
+        await this.store.clear();
+    }
+
+    getAgeMs(typeName: string): number | undefined {
+        const record = this.get(typeName);
+        return record === undefined ? undefined : this.now() - record.lastModifiedMs;
+    }
+
+    private key(typeName: string): string {
+        return `hook:${typeName}`;
+    }
+}

--- a/src/hooks/HooksRequestType.ts
+++ b/src/hooks/HooksRequestType.ts
@@ -1,0 +1,400 @@
+import { RequestType } from 'vscode-languageserver';
+
+export type ListHooksParams = {
+    loadMore?: boolean;
+};
+
+export type HookSummary = {
+    typeName: string;
+    typeArn: string;
+    defaultVersionId?: string;
+    description?: string;
+    lastUpdated?: string;
+};
+
+export type ListHooksResult = {
+    hooks: HookSummary[];
+    nextToken?: string;
+};
+
+export const ListHooksRequest = new RequestType<ListHooksParams, ListHooksResult, void>('aws/cfn/hooks/list');
+
+export type DetailedHook = HookSummary & {
+    configured: boolean;
+    configuration?: string;
+    failureMode?: string;
+    invocationStatus?: string;
+    targetOperations?: string[];
+    ruleUri?: string;
+};
+
+export type ListHooksDetailedResult = {
+    hooks: DetailedHook[];
+    nextToken?: string;
+};
+
+export const ListHooksDetailedRequest = new RequestType<ListHooksParams, ListHooksDetailedResult, void>(
+    'aws/cfn/hooks/listDetailed',
+);
+
+export type ListPublicHooksParams = {
+    typeNamePrefix?: string;
+};
+
+export type PublicHookSummary = {
+    typeName: string;
+    publisherId: string;
+    description?: string;
+};
+
+export type ListPublicHooksResult = {
+    hooks: PublicHookSummary[];
+};
+
+export const ListPublicHooksRequest = new RequestType<ListPublicHooksParams, ListPublicHooksResult, void>(
+    'aws/cfn/hooks/listPublic',
+);
+
+export type DescribeHookParams = {
+    typeName?: string;
+    arn?: string;
+};
+
+export type HookTargetInfo = {
+    targetName: string;
+    invocationPoint: string;
+    failureMode: string;
+};
+
+export type DescribeHookResult = {
+    typeName: string;
+    arn: string;
+    description?: string;
+    schema?: string;
+    configurationSchema?: string;
+    visibility: string;
+    defaultVersionId?: string;
+    lastUpdated?: string;
+    targets?: HookTargetInfo[];
+};
+
+export const DescribeHookRequest = new RequestType<DescribeHookParams, DescribeHookResult, void>(
+    'aws/cfn/hooks/describe',
+);
+
+export type ListHookResultsParams = {
+    typeArn?: string;
+    status?: string;
+    targetId?: string;
+    targetType?: string;
+    nextToken?: string;
+};
+
+export type HookResultSummary = {
+    hookResultId: string;
+    hookTypeArn: string;
+    hookTypeName: string;
+    invocationPoint: string;
+    hookStatus: string;
+    failureMode: string;
+    targetId?: string;
+    targetType?: string;
+    timestamp?: string;
+};
+
+export type ListHookResultsResult = {
+    hookResults: HookResultSummary[];
+    nextToken?: string;
+};
+
+export const ListHookResultsRequest = new RequestType<ListHookResultsParams, ListHookResultsResult, void>(
+    'aws/cfn/hooks/results/list',
+);
+
+export type GetHookResultParams = {
+    hookResultId: string;
+};
+
+export type HookAnnotation = {
+    severity: string;
+    statusMessage: string;
+    remediationLink?: string;
+};
+
+export type HookTarget = {
+    targetType: string;
+    targetName: string;
+    targetId?: string;
+    action?: string;
+};
+
+export type GetHookResultResult = {
+    hookResultId: string;
+    hookTypeName: string;
+    hookStatus: string;
+    failureMode: string;
+    invocationPoint: string;
+    annotations?: HookAnnotation[];
+    target?: HookTarget;
+    timestamp?: string;
+};
+
+export const GetHookResultRequest = new RequestType<GetHookResultParams, GetHookResultResult, void>(
+    'aws/cfn/hooks/result/get',
+);
+
+export type ConfigureHookParams = {
+    typeName: string;
+    failureMode: string;
+};
+
+export type ConfigureHookResult = {
+    configurationArn?: string;
+};
+
+export const ConfigureHookRequest = new RequestType<ConfigureHookParams, ConfigureHookResult, void>(
+    'aws/cfn/hooks/configure',
+);
+
+export type SetInvocationStatusParams = {
+    typeName: string;
+    invocationStatus: 'ENABLED' | 'DISABLED';
+};
+
+export type SetInvocationStatusResult = {
+    configurationArn?: string;
+    invocationStatus: 'ENABLED' | 'DISABLED';
+};
+
+export const SetInvocationStatusRequest = new RequestType<SetInvocationStatusParams, SetInvocationStatusResult, void>(
+    'aws/cfn/hooks/setInvocationStatus',
+);
+
+export type CreateGuardHookParams = {
+    /** JSON string of the AWS::CloudFormation::GuardHook DesiredState. */
+    desiredState: string;
+};
+
+export type CreateGuardHookResult = {
+    operationStatus?: string;
+    identifier?: string;
+    errorCode?: string;
+    statusMessage?: string;
+};
+
+export const CreateGuardHookRequest = new RequestType<CreateGuardHookParams, CreateGuardHookResult, void>(
+    'aws/cfn/hooks/createGuardHook',
+);
+
+export type ListIamRolesParams = Record<string, never>;
+
+export type IamRoleSummary = {
+    roleName: string;
+    arn: string;
+};
+
+export type ListIamRolesResult = {
+    roles: IamRoleSummary[];
+};
+
+export const ListIamRolesRequest = new RequestType<ListIamRolesParams, ListIamRolesResult, void>(
+    'aws/cfn/hooks/listIamRoles',
+);
+
+export type ListS3BucketsParams = Record<string, never>;
+
+export type ListS3BucketsResult = {
+    buckets: string[];
+};
+
+export const ListS3BucketsRequest = new RequestType<ListS3BucketsParams, ListS3BucketsResult, void>(
+    'aws/cfn/hooks/listS3Buckets',
+);
+
+export type ListS3ObjectsParams = {
+    bucketName: string;
+    prefix?: string;
+};
+
+export type ListS3ObjectsResult = {
+    keys: string[];
+};
+
+export const ListS3ObjectsRequest = new RequestType<ListS3ObjectsParams, ListS3ObjectsResult, void>(
+    'aws/cfn/hooks/listS3Objects',
+);
+
+export type ListProactiveControlsParams = Record<string, never>;
+
+export type ProactiveControlSummary = {
+    controlId: string;
+    name: string;
+    resource?: string;
+};
+
+export type ListProactiveControlsResult = {
+    controls: ProactiveControlSummary[];
+};
+
+export const ListProactiveControlsRequest = new RequestType<
+    ListProactiveControlsParams,
+    ListProactiveControlsResult,
+    void
+>('aws/cfn/hooks/listProactiveControls');
+
+export type CreateS3BucketParams = {
+    bucketName: string;
+};
+
+export type CreateS3BucketResult = {
+    bucketName: string;
+};
+
+export const CreateS3BucketRequest = new RequestType<CreateS3BucketParams, CreateS3BucketResult, void>(
+    'aws/cfn/hooks/createS3Bucket',
+);
+
+export type CreateHookExecutionRoleParams = {
+    roleName: string;
+    ruleBucket?: string;
+};
+
+export type CreateHookExecutionRoleResult = {
+    roleName: string;
+    arn: string;
+};
+
+export const CreateHookExecutionRoleRequest = new RequestType<
+    CreateHookExecutionRoleParams,
+    CreateHookExecutionRoleResult,
+    void
+>('aws/cfn/hooks/createExecutionRole');
+
+export type DeactivateHookParams = {
+    typeName?: string;
+    arn?: string;
+};
+
+export type DeactivateHookResult = Record<string, never>;
+
+export const DeactivateHookRequest = new RequestType<DeactivateHookParams, DeactivateHookResult, void>(
+    'aws/cfn/hooks/deactivate',
+);
+
+export type ActivateHookParams = {
+    typeName: string;
+    publisherId?: string;
+    typeNameAlias?: string;
+    executionRoleArn?: string;
+};
+
+export type ActivateHookResult = {
+    arn?: string;
+};
+
+export const ActivateHookRequest = new RequestType<ActivateHookParams, ActivateHookResult, void>(
+    'aws/cfn/hooks/activate',
+);
+
+export type SetHookConfigurationParams = {
+    typeName: string;
+    configuration: string;
+};
+
+export type SetHookConfigurationResult = {
+    configurationArn?: string;
+};
+
+export const SetHookConfigurationRequest = new RequestType<
+    SetHookConfigurationParams,
+    SetHookConfigurationResult,
+    void
+>('aws/cfn/hooks/setConfiguration');
+
+export type GetHookConfigurationParams = {
+    typeName: string;
+};
+
+export type GetHookConfigurationResult = {
+    configuration: string;
+};
+
+export const GetHookConfigurationRequest = new RequestType<
+    GetHookConfigurationParams,
+    GetHookConfigurationResult,
+    void
+>('aws/cfn/hooks/getConfiguration');
+
+export type GetRuleContentParams = {
+    s3Uri: string;
+};
+
+export type GetRuleContentResult = {
+    content: string;
+};
+
+export const GetRuleContentRequest = new RequestType<GetRuleContentParams, GetRuleContentResult, void>(
+    'aws/cfn/hooks/getRuleContent',
+);
+
+export type ValidateRuleParams = {
+    ruleContent: string;
+    sampleTemplate?: string;
+};
+
+export type RuleViolation = {
+    ruleName: string;
+    message: string;
+    line: number;
+    column: number;
+};
+
+export type ValidateRuleResult = {
+    valid: boolean;
+    parseErrors: string[];
+    violations: RuleViolation[];
+};
+
+export const ValidateRuleRequest = new RequestType<ValidateRuleParams, ValidateRuleResult, void>(
+    'aws/cfn/hooks/validateRule',
+);
+
+export type UploadRuleParams = {
+    ruleContent: string;
+    s3Uri: string;
+};
+
+export type UploadRuleResult = {
+    s3Uri: string;
+};
+
+export const UploadRuleRequest = new RequestType<UploadRuleParams, UploadRuleResult, void>('aws/cfn/hooks/uploadRule');
+
+export type PreviewGuardHooksParams = {
+    templateContent: string;
+};
+
+export type GuardHookPreviewViolation = {
+    ruleName: string;
+    message: string;
+    line: number;
+    column: number;
+    path?: string;
+};
+
+export type GuardHookPreviewEntry = {
+    typeName: string;
+    ruleUri: string;
+    failureMode?: string;
+    valid: boolean;
+    violations: GuardHookPreviewViolation[];
+    error?: string;
+};
+
+export type PreviewGuardHooksResult = {
+    hooks: GuardHookPreviewEntry[];
+};
+
+export const PreviewGuardHooksRequest = new RequestType<PreviewGuardHooksParams, PreviewGuardHooksResult, void>(
+    'aws/cfn/hooks/previewGuard',
+);

--- a/src/services/AwsClient.ts
+++ b/src/services/AwsClient.ts
@@ -1,5 +1,7 @@
 import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { ControlCatalogClient } from '@aws-sdk/client-controlcatalog';
+import { IAMClient } from '@aws-sdk/client-iam';
 import { S3Client } from '@aws-sdk/client-s3';
 import { STSClient } from '@aws-sdk/client-sts';
 import { AwsCredentials } from '../auth/AwsCredentials';
@@ -35,6 +37,14 @@ export class AwsClient {
 
     public getStsClient() {
         return new STSClient(this.iamClientConfig());
+    }
+
+    public getIamClient() {
+        return new IAMClient(this.iamClientConfig());
+    }
+
+    public getControlCatalogClient() {
+        return new ControlCatalogClient(this.iamClientConfig());
     }
 
     public getRegion(): string {

--- a/src/services/CcapiService.ts
+++ b/src/services/CcapiService.ts
@@ -1,9 +1,12 @@
 import {
     CloudControlClient,
+    CreateResourceCommand,
     GetResourceCommand,
     GetResourceInput,
+    GetResourceRequestStatusCommand,
     ListResourcesCommand,
     ListResourcesOutput,
+    ProgressEvent,
 } from '@aws-sdk/client-cloudcontrol';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Measure } from '../telemetry/TelemetryDecorator';
@@ -58,6 +61,51 @@ export class CcapiService {
                 Identifier: identifier,
             };
             return await client.send(new GetResourceCommand(getResourceInput));
+        });
+    }
+
+    /**
+     * Create a resource via the Cloud Control API and poll until the operation reaches a
+     * terminal state. CloudControl create is asynchronous: CreateResource returns a
+     * RequestToken and an initial ProgressEvent, which we poll via
+     * GetResourceRequestStatus until SUCCESS/FAILED (or a timeout).
+     */
+    @Measure({ name: 'createResource', captureErrorType: true })
+    public async createResource(
+        typeName: string,
+        desiredState: string,
+        options?: { pollIntervalMs?: number; timeoutMs?: number },
+    ): Promise<ProgressEvent> {
+        const pollIntervalMs = options?.pollIntervalMs ?? 2000;
+        const timeoutMs = options?.timeoutMs ?? 120_000;
+        return await this.withClient(async (client) => {
+            const create = await client.send(
+                new CreateResourceCommand({ TypeName: typeName, DesiredState: desiredState }),
+            );
+            let progress: ProgressEvent | undefined = create.ProgressEvent;
+            const token = progress?.RequestToken;
+
+            const deadline = Date.now() + timeoutMs;
+            while (
+                token &&
+                progress &&
+                (progress.OperationStatus === 'IN_PROGRESS' || progress.OperationStatus === 'PENDING') &&
+                Date.now() < deadline
+            ) {
+                await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+                const status = await client.send(new GetResourceRequestStatusCommand({ RequestToken: token }));
+                progress = status.ProgressEvent;
+            }
+
+            if (!progress) {
+                throw new Error('CloudControl CreateResource returned no progress event');
+            }
+            if (progress.OperationStatus === 'IN_PROGRESS' || progress.OperationStatus === 'PENDING') {
+                throw new Error(
+                    `CloudControl CreateResource for ${typeName} did not complete within ${timeoutMs}ms (last status: ${progress.OperationStatus}).`,
+                );
+            }
+            return progress;
         });
     }
 }

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -10,6 +10,8 @@ import {
     type CreateChangeSetCommandOutput,
     DescribeChangeSetCommand,
     type DescribeChangeSetCommandInput,
+    DescribeChangeSetHooksCommand,
+    type DescribeChangeSetHooksCommandOutput,
     ExecuteChangeSetCommand,
     type ExecuteChangeSetCommandOutput,
     DeleteChangeSetCommand,
@@ -58,6 +60,18 @@ import {
     type Tag,
     OnStackFailure,
     ChangeSetType,
+    DeactivateTypeCommand,
+    SetTypeConfigurationCommand,
+    type SetTypeConfigurationCommandOutput,
+    ListHookResultsCommand,
+    type ListHookResultsCommandOutput,
+    type ListHookResultsTargetType,
+    GetHookResultCommand,
+    type GetHookResultCommandOutput,
+    BatchDescribeTypeConfigurationsCommand,
+    ActivateTypeCommand,
+    type ActivateTypeCommandOutput,
+    ThirdPartyType,
 } from '@aws-sdk/client-cloudformation';
 import type { WaiterConfiguration, WaiterResult } from '@smithy/util-waiter';
 import { ISettingsSubscriber, SettingsConfigurable, SettingsSubscription } from '../settings/ISettingsSubscriber';
@@ -199,6 +213,32 @@ export class CfnService implements SettingsConfigurable, Closeable {
             } while (nextToken);
 
             result.Changes = changes;
+            result.NextToken = undefined;
+            return result;
+        });
+    }
+
+    @Count({ name: 'describeChangeSetHooks' })
+    public async describeChangeSetHooks(params: {
+        ChangeSetName: string;
+        StackName?: string;
+    }): Promise<DescribeChangeSetHooksCommandOutput> {
+        return await this.withClient(async (client) => {
+            let nextToken: string | undefined;
+            let result: DescribeChangeSetHooksCommandOutput | undefined;
+            const hooks: NonNullable<DescribeChangeSetHooksCommandOutput['Hooks']> = [];
+
+            do {
+                const response = await client.send(
+                    new DescribeChangeSetHooksCommand({ ...params, NextToken: nextToken }),
+                );
+                hooks.push(...(response.Hooks ?? []));
+                result ??= response;
+                nextToken = response.NextToken;
+            } while (nextToken);
+
+            result ??= {} as DescribeChangeSetHooksCommandOutput;
+            result.Hooks = hooks;
             result.NextToken = undefined;
             return result;
         });
@@ -462,6 +502,144 @@ export class CfnService implements SettingsConfigurable, Closeable {
     close(): void {
         this.settingsSubscription?.unsubscribe();
         this.settingsSubscription = undefined;
+    }
+
+    @Count({ name: 'listHooks', captureErrorAttributes: true })
+    public async listHooks(nextToken?: string): Promise<{ hooks: TypeSummary[]; nextToken?: string }> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new ListTypesCommand({
+                    Type: RegistryType.HOOK,
+                    Visibility: Visibility.PRIVATE,
+                    MaxResults: 100,
+                    NextToken: nextToken,
+                }),
+            );
+            return {
+                hooks: response.TypeSummaries ?? [],
+                nextToken: response.NextToken,
+            };
+        });
+    }
+
+    @Count({ name: 'listPublicHooks', captureErrorAttributes: true })
+    public async listPublicHooks(filters?: { typeNamePrefix?: string }): Promise<{ hooks: TypeSummary[] }> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new ListTypesCommand({
+                    Type: RegistryType.HOOK,
+                    Visibility: Visibility.PUBLIC,
+                    MaxResults: 100,
+                    Filters: filters?.typeNamePrefix ? { TypeNamePrefix: filters.typeNamePrefix } : undefined,
+                }),
+            );
+            return { hooks: response.TypeSummaries ?? [] };
+        });
+    }
+
+    @Count({ name: 'describeHook', captureErrorAttributes: true })
+    public async describeHook(params: { typeName?: string; arn?: string }): Promise<DescribeTypeOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new DescribeTypeCommand({
+                    Type: RegistryType.HOOK,
+                    TypeName: params.typeName,
+                    Arn: params.arn,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'getHookConfiguration', captureErrorAttributes: true })
+    public async getHookConfiguration(typeName: string): Promise<string> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new BatchDescribeTypeConfigurationsCommand({
+                    TypeConfigurationIdentifiers: [{ Type: RegistryType.HOOK, TypeName: typeName }],
+                }),
+            );
+            return response.TypeConfigurations?.[0]?.Configuration ?? '{}';
+        });
+    }
+
+    @Count({ name: 'setHookConfiguration', captureErrorAttributes: true })
+    public async setHookConfiguration(params: {
+        typeName: string;
+        configuration: string;
+    }): Promise<SetTypeConfigurationCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new SetTypeConfigurationCommand({
+                    Type: RegistryType.HOOK,
+                    TypeName: params.typeName,
+                    Configuration: params.configuration,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'listHookResults', captureErrorAttributes: true })
+    public async listHookResults(params: {
+        typeArn?: string;
+        status?: string;
+        targetId?: string;
+        targetType?: string;
+        nextToken?: string;
+    }): Promise<ListHookResultsCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new ListHookResultsCommand({
+                    TypeArn: params.typeArn,
+                    TargetId: params.targetId,
+                    TargetType: params.targetType as ListHookResultsTargetType,
+                    NextToken: params.nextToken,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'getHookResult', captureErrorAttributes: true })
+    public async getHookResult(hookResultId: string): Promise<GetHookResultCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new GetHookResultCommand({
+                    HookResultId: hookResultId,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'deactivateHook', captureErrorAttributes: true })
+    public async deactivateHook(params: { typeName?: string; arn?: string }): Promise<void> {
+        await this.withClient((client) =>
+            client.send(
+                new DeactivateTypeCommand({
+                    Type: params.typeName ? ThirdPartyType.HOOK : undefined,
+                    TypeName: params.typeName,
+                    Arn: params.arn,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'activateHook', captureErrorAttributes: true })
+    public async activateHook(params: {
+        typeName: string;
+        publisherId?: string;
+        typeNameAlias?: string;
+        executionRoleArn?: string;
+    }): Promise<ActivateTypeCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new ActivateTypeCommand({
+                    Type: ThirdPartyType.HOOK,
+                    TypeName: params.typeName,
+                    PublisherId: params.publisherId,
+                    TypeNameAlias: params.typeNameAlias,
+                    ExecutionRoleArn: params.executionRoleArn,
+                }),
+            ),
+        );
     }
 }
 

--- a/src/services/ControlCatalogService.ts
+++ b/src/services/ControlCatalogService.ts
@@ -1,0 +1,55 @@
+import { ControlCatalogClient, ListControlsCommand } from '@aws-sdk/client-controlcatalog';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { Measure } from '../telemetry/TelemetryDecorator';
+import { markIfClientError } from '../utils/errors/FaultSuppression';
+import { AwsClient } from './AwsClient';
+
+const log = LoggerFactory.getLogger('ControlCatalogService');
+
+export interface ProactiveControl {
+    controlId: string;
+    name: string;
+    resource?: string;
+}
+
+export class ControlCatalogService {
+    constructor(private readonly awsClient: AwsClient) {}
+
+    private async withClient<T>(request: (client: ControlCatalogClient) => Promise<T>): Promise<T> {
+        try {
+            const client = this.awsClient.getControlCatalogClient();
+            return await request(client);
+        } catch (error) {
+            log.error(error, 'Control Catalog API call failed');
+            markIfClientError(error);
+            throw error;
+        }
+    }
+
+    @Measure({ name: 'listProactiveControls', captureErrorType: true })
+    public async listProactiveControls(maxControls = 2000): Promise<ProactiveControl[]> {
+        return await this.withClient(async (client) => {
+            const controls: ProactiveControl[] = [];
+            let nextToken: string | undefined;
+            do {
+                const response = await client.send(new ListControlsCommand({ NextToken: nextToken }));
+                for (const control of response.Controls ?? []) {
+                    if (control.Behavior !== 'PROACTIVE') {
+                        continue;
+                    }
+                    const controlId = (control.Aliases ?? []).find((alias) => alias.startsWith('CT.'));
+                    if (!controlId) {
+                        continue;
+                    }
+                    controls.push({
+                        controlId,
+                        name: control.Name ?? controlId,
+                        resource: control.GovernedResources?.[0],
+                    });
+                }
+                nextToken = response.NextToken;
+            } while (nextToken && controls.length < maxControls);
+            return controls.toSorted((a, b) => a.controlId.localeCompare(b.controlId));
+        });
+    }
+}

--- a/src/services/IamService.ts
+++ b/src/services/IamService.ts
@@ -1,0 +1,123 @@
+import { IAMClient, ListRolesCommand, CreateRoleCommand, PutRolePolicyCommand } from '@aws-sdk/client-iam';
+import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { Measure } from '../telemetry/TelemetryDecorator';
+import { markIfClientError } from '../utils/errors/FaultSuppression';
+import { AwsClient } from './AwsClient';
+
+const log = LoggerFactory.getLogger('IamService');
+
+export interface IamRole {
+    roleName: string;
+    arn: string;
+}
+
+export class IamService {
+    constructor(private readonly awsClient: AwsClient) {}
+
+    private async withClient<T>(request: (client: IAMClient) => Promise<T>): Promise<T> {
+        try {
+            const client = this.awsClient.getIamClient();
+            return await request(client);
+        } catch (error) {
+            log.error(error, 'IAM API call failed');
+            markIfClientError(error);
+            throw error;
+        }
+    }
+
+    /**
+     * List IAM roles in the account, paginating up to `maxRoles` (default 1000).
+     * Returns role name + ARN for populating a role picker.
+     */
+    @Measure({ name: 'listRoles', captureErrorType: true })
+    public async listRoles(maxRoles = 1000): Promise<IamRole[]> {
+        return await this.withClient(async (client) => {
+            const roles: IamRole[] = [];
+            let marker: string | undefined;
+            do {
+                const response = await client.send(new ListRolesCommand({ Marker: marker, MaxItems: 100 }));
+                for (const role of response.Roles ?? []) {
+                    if (role.RoleName && role.Arn) {
+                        roles.push({ roleName: role.RoleName, arn: role.Arn });
+                    }
+                }
+                marker = response.IsTruncated ? response.Marker : undefined;
+            } while (marker && roles.length < maxRoles);
+            return roles;
+        });
+    }
+
+    /**
+     * Create an IAM role a Guard Hook can assume: trusts hooks.cloudformation.amazonaws.com
+     * scoped to this account (aws:SourceAccount) and, when a rule bucket is given, attaches an
+     * inline policy granting read on just that bucket. Returns the new role's name and ARN.
+     */
+    @Measure({ name: 'createHookExecutionRole', captureErrorType: true })
+    public async createHookExecutionRole(roleName: string, ruleBucket?: string): Promise<IamRole> {
+        if (ruleBucket !== undefined && !/^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/.test(ruleBucket)) {
+            throw new Error(`Invalid S3 bucket name: ${ruleBucket}`);
+        }
+        const accountId = await this.getCallerAccountId();
+        const trustPolicy = {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Principal: { Service: 'hooks.cloudformation.amazonaws.com' },
+                    Action: 'sts:AssumeRole',
+                    Condition: { StringEquals: { 'aws:SourceAccount': accountId } },
+                },
+            ],
+        };
+
+        return await this.withClient(async (client) => {
+            const created = await client.send(
+                new CreateRoleCommand({
+                    RoleName: roleName,
+                    AssumeRolePolicyDocument: JSON.stringify(trustPolicy),
+                    Description: 'Execution role for a CloudFormation Guard Hook (created by the AWS Toolkit).',
+                }),
+            );
+            if (ruleBucket) {
+                const s3ReadPolicy = {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Action: ['s3:GetObject', 's3:GetObjectVersion', 's3:ListBucket'],
+                            Resource: [`arn:aws:s3:::${ruleBucket}`, `arn:aws:s3:::${ruleBucket}/*`],
+                        },
+                    ],
+                };
+                await client.send(
+                    new PutRolePolicyCommand({
+                        RoleName: roleName,
+                        PolicyName: 'GuardHookS3ReadAccess',
+                        PolicyDocument: JSON.stringify(s3ReadPolicy),
+                    }),
+                );
+            }
+            const arn = created.Role?.Arn;
+            if (!arn) {
+                throw new Error(`CreateRole returned no ARN for role ${roleName}`);
+            }
+            return { roleName, arn };
+        });
+    }
+
+    private async getCallerAccountId(): Promise<string> {
+        const sts = this.awsClient.getStsClient();
+        try {
+            const identity = await sts.send(new GetCallerIdentityCommand({}));
+            if (!identity.Account) {
+                throw new Error('STS GetCallerIdentity did not return an account ID');
+            }
+            return identity.Account;
+        } catch (error) {
+            log.error(error, 'Failed to resolve caller account ID via STS');
+            markIfClientError(error);
+            throw error;
+        }
+    }
+}

--- a/src/services/S3Service.ts
+++ b/src/services/S3Service.ts
@@ -4,7 +4,11 @@ import { ResourceNotFoundException } from '@aws-sdk/client-cloudcontrol';
 import {
     S3Client,
     PutObjectCommand,
+    GetObjectCommand,
     ListBucketsCommand,
+    ListObjectsV2Command,
+    CreateBucketCommand,
+    BucketLocationConstraint,
     HeadObjectCommand,
     HeadBucketCommand,
 } from '@aws-sdk/client-s3';
@@ -56,6 +60,74 @@ export class S3Service {
         });
     }
 
+    /**
+     * List all bucket names in the account (across regions), paginating up to `maxBuckets`.
+     * Used to populate a bucket picker.
+     */
+    @Measure({ name: 'listAllBucketNames' })
+    async listAllBucketNames(maxBuckets = 1000): Promise<string[]> {
+        const region = this.awsClient.getRegion();
+        return await this.withClient(async (client) => {
+            const names: string[] = [];
+            let continuationToken: string | undefined;
+            do {
+                const response = await client.send(
+                    new ListBucketsCommand({ BucketRegion: region, ContinuationToken: continuationToken }),
+                );
+                for (const bucket of response.Buckets ?? []) {
+                    if (bucket.Name) {
+                        names.push(bucket.Name);
+                    }
+                }
+                continuationToken = response.ContinuationToken;
+            } while (continuationToken && names.length < maxBuckets);
+            return names;
+        });
+    }
+
+    @Measure({ name: 'listObjects' })
+    async listObjects(bucketName: string, prefix?: string, maxKeys = 1000): Promise<string[]> {
+        return await this.withClient(async (client) => {
+            const keys: string[] = [];
+            let continuationToken: string | undefined;
+            do {
+                const response = await client.send(
+                    new ListObjectsV2Command({
+                        Bucket: bucketName,
+                        Prefix: prefix,
+                        ContinuationToken: continuationToken,
+                    }),
+                );
+                for (const object of response.Contents ?? []) {
+                    if (object.Key !== undefined) {
+                        keys.push(object.Key);
+                    }
+                }
+                continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+            } while (continuationToken && keys.length < maxKeys);
+            return keys.slice(0, maxKeys);
+        });
+    }
+
+    /**
+     * Create a bucket in the client's region. us-east-1 must NOT send a LocationConstraint
+     * (it's the default and specifying it errors); every other region must.
+     */
+    @Measure({ name: 'createBucket' })
+    async createBucket(bucketName: string): Promise<void> {
+        const region = this.awsClient.getRegion();
+        await this.withClient(async (client) => {
+            await client.send(
+                new CreateBucketCommand({
+                    Bucket: bucketName,
+                    ...(region && region !== 'us-east-1'
+                        ? { CreateBucketConfiguration: { LocationConstraint: region as BucketLocationConstraint } }
+                        : {}),
+                }),
+            );
+        });
+    }
+
     @Measure({ name: 'putObject' })
     async putObjectContent(content: string | Buffer, bucketName: string, key: string) {
         return await this.withClient(async (client) => {
@@ -66,6 +138,19 @@ export class S3Service {
                     Body: content,
                 }),
             );
+        });
+    }
+
+    @Measure({ name: 'getObject' })
+    async getObjectContent(bucketName: string, key: string): Promise<string> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new GetObjectCommand({
+                    Bucket: bucketName,
+                    Key: key,
+                }),
+            );
+            return (await response.Body?.transformToString()) ?? '';
         });
     }
 

--- a/tst/unit/hooks/CfnService.hooks.test.ts
+++ b/tst/unit/hooks/CfnService.hooks.test.ts
@@ -1,0 +1,190 @@
+import {
+    CloudFormationClient,
+    CloudFormationServiceException,
+    ListTypesCommand,
+    DescribeTypeCommand,
+    DeactivateTypeCommand,
+    SetTypeConfigurationCommand,
+    RegistryType,
+    Visibility,
+} from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { CfnService } from '../../../src/services/CfnService';
+
+const cloudFormationMock = mockClient(CloudFormationClient);
+const mockGetCloudFormationClient = vi.fn();
+
+const mockClientComponent = {
+    getCloudFormationClient: mockGetCloudFormationClient,
+} as unknown as AwsClient;
+
+describe('CfnService - Hooks', () => {
+    let service: CfnService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cloudFormationMock.reset();
+        mockGetCloudFormationClient.mockReturnValue(new CloudFormationClient({}));
+        service = new CfnService(mockClientComponent);
+    });
+
+    describe('listHooks()', () => {
+        it('should call ListTypesCommand with HOOK type and PRIVATE visibility', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: [
+                    {
+                        TypeName: 'Private::Guard::S3Check',
+                        TypeArn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+                    },
+                ],
+                NextToken: undefined,
+            });
+
+            const result = await service.listHooks();
+
+            expect(result.hooks).toHaveLength(1);
+            expect(result.hooks[0].TypeName).toBe('Private::Guard::S3Check');
+            expect(result.nextToken).toBeUndefined();
+
+            const call = cloudFormationMock.commandCalls(ListTypesCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                Visibility: Visibility.PRIVATE,
+                MaxResults: 100,
+            });
+        });
+
+        it('should pass nextToken for pagination', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: [],
+                NextToken: 'next-page',
+            });
+
+            const result = await service.listHooks('token-123');
+
+            expect(result.nextToken).toBe('next-page');
+            const call = cloudFormationMock.commandCalls(ListTypesCommand)[0];
+            expect(call.args[0].input.NextToken).toBe('token-123');
+        });
+
+        it('should return empty array when no hooks found', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: undefined,
+            });
+
+            const result = await service.listHooks();
+            expect(result.hooks).toEqual([]);
+        });
+
+        it('should throw on API error', async () => {
+            const error = new CloudFormationServiceException({
+                message: 'Service error',
+                $metadata: { httpStatusCode: 500 },
+                name: 'CloudFormationServiceException',
+                $fault: 'server',
+            });
+            cloudFormationMock.on(ListTypesCommand).rejects(error);
+
+            await expect(service.listHooks()).rejects.toThrow(error);
+        });
+    });
+
+    describe('describeHook()', () => {
+        it('should call DescribeTypeCommand with typeName', async () => {
+            cloudFormationMock.on(DescribeTypeCommand).resolves({
+                TypeName: 'Private::Guard::S3Check',
+                Arn: 'arn:aws:...',
+                Description: 'Checks S3 encryption',
+                Schema: '{}',
+                Visibility: 'PRIVATE',
+            });
+
+            const result = await service.describeHook({ typeName: 'Private::Guard::S3Check' });
+
+            expect(result.TypeName).toBe('Private::Guard::S3Check');
+            const call = cloudFormationMock.commandCalls(DescribeTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+            });
+        });
+
+        it('should call DescribeTypeCommand with arn', async () => {
+            cloudFormationMock.on(DescribeTypeCommand).resolves({
+                TypeName: 'Private::Guard::S3Check',
+                Arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+
+            const result = await service.describeHook({
+                arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+
+            expect(result.TypeName).toBe('Private::Guard::S3Check');
+            const call = cloudFormationMock.commandCalls(DescribeTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                Arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+        });
+
+        it('should throw on API error', async () => {
+            const error = new CloudFormationServiceException({
+                message: 'Type not found',
+                $metadata: { httpStatusCode: 404 },
+                name: 'TypeNotFoundException',
+                $fault: 'client',
+            });
+            cloudFormationMock.on(DescribeTypeCommand).rejects(error);
+
+            await expect(service.describeHook({ typeName: 'NonExistent' })).rejects.toThrow(error);
+        });
+    });
+
+    describe('setHookConfiguration()', () => {
+        it('should call SetTypeConfigurationCommand with correct params', async () => {
+            cloudFormationMock.on(SetTypeConfigurationCommand).resolves({
+                ConfigurationArn: 'arn:aws:cloudformation:us-east-1:123:type-configuration/hook/Private-Guard-S3Check',
+            });
+
+            const result = await service.setHookConfiguration({
+                typeName: 'Private::Guard::S3Check',
+                configuration: '{"CloudFormationConfiguration":{"HookConfiguration":{"FailureMode":"WARN"}}}',
+            });
+
+            expect(result.ConfigurationArn).toBeDefined();
+            const call = cloudFormationMock.commandCalls(SetTypeConfigurationCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+                Configuration: '{"CloudFormationConfiguration":{"HookConfiguration":{"FailureMode":"WARN"}}}',
+            });
+        });
+    });
+
+    describe('deactivateHook()', () => {
+        it('should call DeactivateTypeCommand with typeName', async () => {
+            cloudFormationMock.on(DeactivateTypeCommand).resolves({});
+
+            await service.deactivateHook({ typeName: 'Private::Guard::S3Check' });
+
+            const call = cloudFormationMock.commandCalls(DeactivateTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+            });
+        });
+
+        it('should call DeactivateTypeCommand with arn', async () => {
+            cloudFormationMock.on(DeactivateTypeCommand).resolves({});
+
+            await service.deactivateHook({ arn: 'arn:aws:...' });
+
+            const call = cloudFormationMock.commandCalls(DeactivateTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Arn: 'arn:aws:...',
+            });
+        });
+    });
+});

--- a/tst/unit/hooks/ControlCatalogService.test.ts
+++ b/tst/unit/hooks/ControlCatalogService.test.ts
@@ -1,0 +1,85 @@
+import { ControlCatalogClient, ListControlsCommand } from '@aws-sdk/client-controlcatalog';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { ControlCatalogService } from '../../../src/services/ControlCatalogService';
+
+const controlCatalogMock = mockClient(ControlCatalogClient);
+const mockGetControlCatalogClient = vi.fn();
+
+const mockClientComponent = {
+    getControlCatalogClient: mockGetControlCatalogClient,
+} as unknown as AwsClient;
+
+describe('ControlCatalogService', () => {
+    let service: ControlCatalogService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        controlCatalogMock.reset();
+        mockGetControlCatalogClient.mockReturnValue(new ControlCatalogClient({}));
+        service = new ControlCatalogService(mockClientComponent);
+    });
+
+    it('returns only PROACTIVE controls that have a CT. alias, mapped and sorted', async () => {
+        controlCatalogMock.on(ListControlsCommand).resolves({
+            Controls: [
+                {
+                    Behavior: 'PROACTIVE',
+                    Name: 'Require encryption',
+                    Aliases: ['CT.S3.PR.2', 'OTHER'],
+                    GovernedResources: ['AWS::S3::Bucket'],
+                },
+                { Behavior: 'DETECTIVE', Name: 'Detective control', Aliases: ['CT.S3.DR.1'] },
+                { Behavior: 'PROACTIVE', Name: 'No CT alias', Aliases: ['SH.S3.1'] },
+                {
+                    Behavior: 'PROACTIVE',
+                    Name: 'Require versioning',
+                    Aliases: ['CT.S3.PR.1'],
+                    GovernedResources: ['AWS::S3::Bucket'],
+                },
+            ] as never,
+        });
+
+        const result = await service.listProactiveControls();
+
+        expect(result).toEqual([
+            { controlId: 'CT.S3.PR.1', name: 'Require versioning', resource: 'AWS::S3::Bucket' },
+            { controlId: 'CT.S3.PR.2', name: 'Require encryption', resource: 'AWS::S3::Bucket' },
+        ]);
+    });
+
+    it('paginates across NextToken', async () => {
+        controlCatalogMock
+            .on(ListControlsCommand, { NextToken: undefined })
+            .resolves({
+                Controls: [{ Behavior: 'PROACTIVE', Name: 'A', Aliases: ['CT.A.1'] }] as never,
+                NextToken: 'page2',
+            })
+            .on(ListControlsCommand, { NextToken: 'page2' })
+            .resolves({
+                Controls: [{ Behavior: 'PROACTIVE', Name: 'B', Aliases: ['CT.B.1'] }] as never,
+            });
+
+        const result = await service.listProactiveControls();
+
+        expect(result.map((c) => c.controlId)).toEqual(['CT.A.1', 'CT.B.1']);
+        expect(controlCatalogMock.commandCalls(ListControlsCommand)).toHaveLength(2);
+    });
+
+    it('falls back to the control id when Name is missing', async () => {
+        controlCatalogMock.on(ListControlsCommand).resolves({
+            Controls: [{ Behavior: 'PROACTIVE', Aliases: ['CT.X.1'] }] as never,
+        });
+
+        const result = await service.listProactiveControls();
+
+        expect(result).toEqual([{ controlId: 'CT.X.1', name: 'CT.X.1', resource: undefined }]);
+    });
+
+    it('propagates API errors', async () => {
+        controlCatalogMock.on(ListControlsCommand).rejects(new Error('boom'));
+
+        await expect(service.listProactiveControls()).rejects.toThrow('boom');
+    });
+});

--- a/tst/unit/hooks/HookCache.test.ts
+++ b/tst/unit/hooks/HookCache.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HookCache, TtlCache } from '../../../src/hooks/HookCache';
+
+describe('TtlCache', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('loads and caches a value within the TTL', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValue('v1');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads after the TTL expires', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValueOnce('v1').mockResolvedValueOnce('v2');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        clock += 101;
+        expect(await cache.get('k', loader)).toBe('v2');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('reloads when the clock reaches expiresAt (exclusive upper bound)', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValueOnce('v1').mockResolvedValueOnce('v2');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        clock += 99;
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(loader).toHaveBeenCalledTimes(1);
+        clock += 1;
+        expect(await cache.get('k', loader)).toBe('v2');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates concurrent loads for the same key', async () => {
+        const cache = new TtlCache<string>(100, now);
+        let resolveLoad!: (v: string) => void;
+        const loader = vi.fn().mockReturnValue(new Promise<string>((resolve) => (resolveLoad = resolve)));
+
+        const a = cache.get('k', loader);
+        const b = cache.get('k', loader);
+        resolveLoad('shared');
+
+        expect(await a).toBe('shared');
+        expect(await b).toBe('shared');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a failed load and retries next time', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce('ok');
+
+        await expect(cache.get('k', loader)).rejects.toThrow('boom');
+        expect(await cache.get('k', loader)).toBe('ok');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('peek returns unexpired values only', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('k', () => Promise.resolve('v1'));
+
+        expect(cache.peek('k')).toBe('v1');
+        clock += 101;
+        expect(cache.peek('k')).toBeUndefined();
+        expect(cache.peek('missing')).toBeUndefined();
+    });
+
+    it('set stores a value with a fresh TTL', () => {
+        const cache = new TtlCache<string>(100, now);
+        cache.set('k', 'v1');
+        expect(cache.peek('k')).toBe('v1');
+    });
+
+    it('invalidate removes a single key', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValue('v1');
+        await cache.get('k', loader);
+        cache.invalidate('k');
+        await cache.get('k', loader);
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidate during an in-flight load does not cache the resolved value', async () => {
+        const cache = new TtlCache<string>(100, now);
+        let resolveLoad!: (v: string) => void;
+        const loader = vi.fn().mockReturnValue(new Promise<string>((resolve) => (resolveLoad = resolve)));
+
+        const pending = cache.get('k', loader);
+        cache.invalidate('k');
+        resolveLoad('stale');
+        await pending;
+
+        expect(cache.peek('k')).toBeUndefined();
+    });
+
+    it('clear removes all keys', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('a', () => Promise.resolve('1'));
+        await cache.get('b', () => Promise.resolve('2'));
+        cache.clear();
+        expect(cache.size).toBe(0);
+    });
+
+    it('size counts only unexpired entries', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('a', () => Promise.resolve('1'));
+        expect(cache.size).toBe(1);
+        clock += 101;
+        expect(cache.size).toBe(0);
+    });
+});
+
+describe('HookCache', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('caches hook configuration by type name', async () => {
+        const cache = new HookCache(100, now);
+        const loader = vi.fn().mockResolvedValue('{"cfg":1}');
+
+        expect(await cache.getConfiguration('Private::Guard::A', loader)).toBe('{"cfg":1}');
+        expect(await cache.getConfiguration('Private::Guard::A', loader)).toBe('{"cfg":1}');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches rule content by S3 URI independently of config', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule R {}');
+
+        await cache.getConfiguration('T', cfgLoader);
+        expect(await cache.getRuleContent('s3://b/r.guard', ruleLoader)).toBe('rule R {}');
+        expect(await cache.getRuleContent('s3://b/r.guard', ruleLoader)).toBe('rule R {}');
+        expect(ruleLoader).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateHook forces a config reload but keeps rules', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateHook('T');
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+
+        expect(cfgLoader).toHaveBeenCalledTimes(2);
+        expect(ruleLoader).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateRule forces a rule reload', async () => {
+        const cache = new HookCache(100, now);
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateRule('s3://b/r');
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        expect(ruleLoader).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidateAll clears both configs and rules', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateAll();
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        expect(cfgLoader).toHaveBeenCalledTimes(2);
+        expect(ruleLoader).toHaveBeenCalledTimes(2);
+    });
+
+    it('peek helpers return cached values without loading', async () => {
+        const cache = new HookCache(100, now);
+        await cache.getConfiguration('T', () => Promise.resolve('cfg'));
+        expect(cache.peekConfiguration('T')).toBe('cfg');
+        expect(cache.peekRuleContent('s3://none')).toBeUndefined();
+    });
+});
+
+describe('TtlCache pruning', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('evicts expired entries on write so the map does not retain stale keys', () => {
+        const cache = new TtlCache<string>(100, now);
+        cache.set('a', 'va');
+        cache.set('b', 'vb');
+        expect(cache.size).toBe(2);
+
+        clock += 200;
+        cache.set('c', 'vc');
+
+        expect(cache.size).toBe(1);
+        expect(cache.peek('a')).toBeUndefined();
+        expect(cache.peek('b')).toBeUndefined();
+        expect(cache.peek('c')).toBe('vc');
+    });
+});

--- a/tst/unit/hooks/IamService.test.ts
+++ b/tst/unit/hooks/IamService.test.ts
@@ -1,0 +1,104 @@
+import { IAMClient, ListRolesCommand, CreateRoleCommand, PutRolePolicyCommand } from '@aws-sdk/client-iam';
+import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { IamService } from '../../../src/services/IamService';
+
+const iamMock = mockClient(IAMClient);
+const stsMock = mockClient(STSClient);
+const mockGetIamClient = vi.fn();
+const mockGetStsClient = vi.fn();
+
+const mockClientComponent = {
+    getIamClient: mockGetIamClient,
+    getStsClient: mockGetStsClient,
+} as unknown as AwsClient;
+
+describe('IamService', () => {
+    let service: IamService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        iamMock.reset();
+        stsMock.reset();
+        mockGetIamClient.mockReturnValue(new IAMClient({}));
+        mockGetStsClient.mockReturnValue(new STSClient({}));
+        stsMock.on(GetCallerIdentityCommand).resolves({ Account: '123' });
+        service = new IamService(mockClientComponent);
+    });
+
+    describe('listRoles()', () => {
+        it('paginates and maps role name + arn, skipping incomplete roles', async () => {
+            iamMock
+                .on(ListRolesCommand, { Marker: undefined })
+                .resolves({
+                    Roles: [{ RoleName: 'roleA', Arn: 'arn:aws:iam::123:role/roleA' }, { RoleName: 'noArn' }] as never,
+                    IsTruncated: true,
+                    Marker: 'm2',
+                })
+                .on(ListRolesCommand, { Marker: 'm2' })
+                .resolves({
+                    Roles: [{ RoleName: 'roleB', Arn: 'arn:aws:iam::123:role/roleB' }] as never,
+                    IsTruncated: false,
+                });
+
+            const roles = await service.listRoles();
+
+            expect(roles).toEqual([
+                { roleName: 'roleA', arn: 'arn:aws:iam::123:role/roleA' },
+                { roleName: 'roleB', arn: 'arn:aws:iam::123:role/roleB' },
+            ]);
+        });
+    });
+
+    describe('createHookExecutionRole()', () => {
+        it('creates a role with an account-scoped trust policy and no inline policy when no bucket given', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: { Arn: 'arn:aws:iam::123:role/hookRole' } as never });
+
+            const result = await service.createHookExecutionRole('hookRole');
+
+            expect(result).toEqual({ roleName: 'hookRole', arn: 'arn:aws:iam::123:role/hookRole' });
+            expect(iamMock.commandCalls(PutRolePolicyCommand)).toHaveLength(0);
+            const trust = JSON.parse(
+                iamMock.commandCalls(CreateRoleCommand)[0].args[0].input.AssumeRolePolicyDocument as string,
+            );
+            expect(trust.Statement[0].Condition.StringEquals['aws:SourceAccount']).toBe('123');
+            expect(trust.Statement[0].Principal.Service).toBe('hooks.cloudformation.amazonaws.com');
+        });
+
+        it('attaches an inline S3 read policy scoped to the given bucket', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: { Arn: 'arn:aws:iam::123:role/hookRole' } as never });
+            iamMock.on(PutRolePolicyCommand).resolves({});
+
+            await service.createHookExecutionRole('hookRole', 'my-rule-bucket');
+
+            const policyCall = iamMock.commandCalls(PutRolePolicyCommand)[0];
+            const policy = JSON.parse(policyCall.args[0].input.PolicyDocument as string);
+            expect(policy.Statement[0].Resource).toEqual([
+                'arn:aws:s3:::my-rule-bucket',
+                'arn:aws:s3:::my-rule-bucket/*',
+            ]);
+        });
+
+        it('rejects an invalid bucket name before making any AWS calls', async () => {
+            await expect(service.createHookExecutionRole('hookRole', 'Invalid_Bucket!')).rejects.toThrow(
+                /Invalid S3 bucket name/,
+            );
+            expect(iamMock.commandCalls(CreateRoleCommand)).toHaveLength(0);
+            expect(stsMock.commandCalls(GetCallerIdentityCommand)).toHaveLength(0);
+        });
+
+        it('throws when CreateRole returns no ARN', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: {} as never });
+
+            await expect(service.createHookExecutionRole('hookRole')).rejects.toThrow(/no ARN/);
+        });
+
+        it('propagates STS failures when resolving the account id', async () => {
+            stsMock.on(GetCallerIdentityCommand).rejects(new Error('sts-down'));
+
+            await expect(service.createHookExecutionRole('hookRole')).rejects.toThrow('sts-down');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

**PR 2 of 7** for the CloudFormation **Hooks** feature — the AWS **service layer**: client wrappers and hook-related SDK calls that the higher layers depend on.

> **Stacking note:** This depends on **#646** (PR 1: cache infra). It is opened against `main`, so until #646 merges the diff below includes PR 1's commit as well. Once #646 merges, this PR's diff automatically collapses to just the service-layer slice. **Please review/merge in order.** The net-new commit here is `feat(hooks): add ControlCatalog/IAM services and hook APIs on AWS clients`.

## What's included

- **`src/services/ControlCatalogService.ts`** (new) — wraps the Control Tower Control Catalog client; `listProactiveControls()` paginates `ListControls`, keeps only `PROACTIVE` controls exposing a `CT.*` alias, returns them sorted by control id.
- **`src/services/IamService.ts`** (new) — IAM client wrapper. `listRoles()` paginates for a role picker; `createHookExecutionRole()` creates a role trusting `hooks.cloudformation.amazonaws.com` scoped to the caller account (`aws:SourceAccount`) and, when a rule bucket is supplied, attaches an inline policy granting read on just that bucket.
- **`src/services/AwsClient.ts`** — adds hook-related client accessors (e.g. `getIamClient`, `getControlCatalogClient`).
- **`src/services/CcapiService.ts`, `S3Service.ts`, `CfnService.ts`** — add hook-related APIs (Cloud Control resource create; S3 bucket/object list + create + read; CFN hook describe/list/activate/deactivate/configuration/results).
- **`package.json` / `package-lock.json`** — add `@aws-sdk/client-controlcatalog`.

Consumers (`HooksManager`, handlers) arrive in later stacked PRs, so some methods here have no in-repo caller yet.

## Review feedback addressed
- Added missing error handling to `IamService.getCallerAccountId()` (try/catch + `markIfClientError`), matching `S3Service.getCallerAccountId()`.
- `deactivateHook` now uses `ThirdPartyType.HOOK` (consistent with `activateHook`).
- `createHookExecutionRole` validates the `ruleBucket` name against S3 naming rules before interpolating it into an IAM policy ARN.

## Note on the SDK version
`@aws-sdk/client-controlcatalog` is pinned at `3.1069.0` rather than `3.1080.0` (the version of the other `@aws-sdk/client-*` packages) because **`3.1080.0` is not published** for `client-controlcatalog` — `3.1069.0` is the latest available and is API-compatible with the rest of the SDK.

## Testing
- `tst/unit/hooks/IamService.test.ts` (new) — `listRoles` pagination/mapping, role creation with/without a rule bucket, invalid-bucket rejection (no AWS calls made), missing-ARN error, STS-failure propagation.
- `tst/unit/hooks/ControlCatalogService.test.ts` (new) — proactive-only filtering, `CT.*`-alias requirement, mapping/sorting, `NextToken` pagination, name fallback, API-error propagation.
- `tst/unit/hooks/CfnService.hooks.test.ts` — CFN hook methods happy-path, pagination, error cases.
- Build (`tsc -b`) and lint pass.
