### PR TITLE
feat(hooks): local Guard hook preview (4/7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@aws-sdk/client-cloudcontrol": "3.1080.0",
                 "@aws-sdk/client-cloudformation": "3.1080.0",
+                "@aws-sdk/client-controlcatalog": "3.1069.0",
                 "@aws-sdk/client-iam": "3.1080.0",
                 "@aws-sdk/client-s3": "3.1080.0",
                 "@aws-sdk/client-sts": "3.1080.0",
@@ -103,6 +104,55 @@
                 "npm": ">=10.5.0"
             }
         },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
         "node_modules/@aws-sdk/checksums": {
             "version": "3.1000.17",
             "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.17.tgz",
@@ -164,6 +214,27 @@
                 "@smithy/fetch-http-handler": "^5.6.2",
                 "@smithy/node-http-handler": "^4.9.2",
                 "@smithy/types": "^4.15.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-controlcatalog": {
+            "version": "3.1069.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-controlcatalog/-/client-controlcatalog-3.1069.0.tgz",
+            "integrity": "sha512-iayVGOJF3OUZ2UUHR/FWRBywRwS/Tx3oej96bRLp0xAEfWvS1o6S7O+Qjgv6GQFW9ulVWdLfb3fnnT2mr7Vf7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.21",
+                "@aws-sdk/credential-provider-node": "^3.972.56",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -629,6 +700,18 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.15.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.965.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+            "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+            "license": "Apache-2.0",
+            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3900,6 +3983,18 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@smithy/node-http-handler": {
             "version": "4.9.6",
             "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
@@ -3938,6 +4033,32 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/util-waiter": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dependencies": {
         "@aws-sdk/client-cloudcontrol": "3.1080.0",
         "@aws-sdk/client-cloudformation": "3.1080.0",
+        "@aws-sdk/client-controlcatalog": "3.1069.0",
         "@aws-sdk/client-iam": "3.1080.0",
         "@aws-sdk/client-s3": "3.1080.0",
         "@aws-sdk/client-sts": "3.1080.0",

--- a/src/datastore/DataStore.ts
+++ b/src/datastore/DataStore.ts
@@ -15,9 +15,14 @@ export enum StoreName {
     public_schemas = 'public_schemas',
     sam_schemas = 'sam_schemas',
     private_schemas = 'private_schemas',
+    hook_schemas = 'hook_schemas',
 }
 
-export const PersistedStores: ReadonlyArray<StoreName> = [StoreName.public_schemas, StoreName.sam_schemas];
+export const PersistedStores: ReadonlyArray<StoreName> = [
+    StoreName.public_schemas,
+    StoreName.sam_schemas,
+    StoreName.hook_schemas,
+];
 
 export interface DataStore {
     get<T>(key: string): T | undefined;

--- a/src/hooks/GuardHookPreview.ts
+++ b/src/hooks/GuardHookPreview.ts
@@ -1,0 +1,67 @@
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { GuardRule, GuardViolation } from '../services/guard/GuardEngine';
+import { extractErrorMessage } from '../utils/errors/ErrorUtils';
+import { DetailedHook, GuardHookPreviewEntry, PreviewGuardHooksResult } from './HooksRequestType';
+
+export interface GuardHookPreviewDeps {
+    listHooksDetailed: () => Promise<DetailedHook[]>;
+    fetchRuleContent: (ruleUri: string) => Promise<string>;
+    validateTemplate: (content: string, rules: GuardRule[], severity: DiagnosticSeverity) => GuardViolation[];
+}
+
+export function isPreviewableGuardHook(hook: DetailedHook): boolean {
+    return Boolean(hook.configured && hook.invocationStatus === 'ENABLED' && hook.ruleUri);
+}
+
+export async function previewGuardHooks(
+    deps: GuardHookPreviewDeps,
+    templateContent: string,
+): Promise<PreviewGuardHooksResult> {
+    const detailed = await deps.listHooksDetailed();
+    const applicable = detailed.filter((hook) => isPreviewableGuardHook(hook));
+    const hooks = await Promise.all(applicable.map((hook) => previewSingleHook(deps, templateContent, hook)));
+    return { hooks };
+}
+
+async function previewSingleHook(
+    deps: GuardHookPreviewDeps,
+    templateContent: string,
+    hook: DetailedHook,
+): Promise<GuardHookPreviewEntry> {
+    const ruleUri = hook.ruleUri as string;
+    const severity = hook.failureMode === 'WARN' ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error;
+    try {
+        const content = await deps.fetchRuleContent(ruleUri);
+        const rule: GuardRule = {
+            name: hook.typeName,
+            description: hook.typeName,
+            severity,
+            content,
+            tags: [],
+            pack: hook.typeName,
+        };
+        const violations = deps.validateTemplate(templateContent, [rule], severity);
+        return {
+            typeName: hook.typeName,
+            ruleUri,
+            failureMode: hook.failureMode,
+            valid: violations.length === 0,
+            violations: violations.map((violation) => ({
+                ruleName: violation.ruleName,
+                message: violation.message,
+                line: violation.location.line,
+                column: violation.location.column,
+                path: violation.location.path,
+            })),
+        };
+    } catch (error) {
+        return {
+            typeName: hook.typeName,
+            ruleUri,
+            failureMode: hook.failureMode,
+            valid: false,
+            violations: [],
+            error: extractErrorMessage(error),
+        };
+    }
+}

--- a/src/hooks/HookCache.ts
+++ b/src/hooks/HookCache.ts
@@ -1,0 +1,132 @@
+interface CacheEntry<T> {
+    value: T;
+    expiresAt: number;
+}
+
+export class TtlCache<T> {
+    private readonly entries = new Map<string, CacheEntry<T>>();
+    private readonly inflight = new Map<string, Promise<T>>();
+
+    constructor(
+        private readonly ttlMs: number,
+        private readonly now: () => number = Date.now,
+    ) {}
+
+    async get(key: string, loader: () => Promise<T>): Promise<T> {
+        const cached = this.entries.get(key);
+        if (cached) {
+            if (cached.expiresAt > this.now()) {
+                return cached.value;
+            }
+            this.entries.delete(key);
+        }
+
+        const existing = this.inflight.get(key);
+        if (existing) {
+            return await existing;
+        }
+
+        const load = loader()
+            .then((value) => {
+                if (this.inflight.get(key) === load) {
+                    this.prune();
+                    this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
+                }
+                return value;
+            })
+            .finally(() => {
+                if (this.inflight.get(key) === load) {
+                    this.inflight.delete(key);
+                }
+            });
+
+        this.inflight.set(key, load);
+        return await load;
+    }
+
+    peek(key: string): T | undefined {
+        const cached = this.entries.get(key);
+        if (cached) {
+            if (cached.expiresAt > this.now()) {
+                return cached.value;
+            }
+            this.entries.delete(key);
+        }
+        return undefined;
+    }
+
+    set(key: string, value: T): void {
+        this.prune();
+        this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
+    }
+
+    invalidate(key: string): void {
+        this.entries.delete(key);
+        this.inflight.delete(key);
+    }
+
+    clear(): void {
+        this.entries.clear();
+        this.inflight.clear();
+    }
+
+    private prune(): void {
+        const now = this.now();
+        for (const [key, entry] of this.entries) {
+            if (entry.expiresAt <= now) {
+                this.entries.delete(key);
+            }
+        }
+    }
+
+    get size(): number {
+        let count = 0;
+        for (const entry of this.entries.values()) {
+            if (entry.expiresAt > this.now()) {
+                count++;
+            }
+        }
+        return count;
+    }
+}
+
+const DEFAULT_TTL_MS = 60_000;
+
+export class HookCache {
+    private readonly configs: TtlCache<string>;
+    private readonly rules: TtlCache<string>;
+
+    constructor(ttlMs: number = DEFAULT_TTL_MS, now: () => number = Date.now) {
+        this.configs = new TtlCache<string>(ttlMs, now);
+        this.rules = new TtlCache<string>(ttlMs, now);
+    }
+
+    async getConfiguration(typeName: string, loader: () => Promise<string>): Promise<string> {
+        return await this.configs.get(typeName, loader);
+    }
+
+    async getRuleContent(s3Uri: string, loader: () => Promise<string>): Promise<string> {
+        return await this.rules.get(s3Uri, loader);
+    }
+
+    peekConfiguration(typeName: string): string | undefined {
+        return this.configs.peek(typeName);
+    }
+
+    peekRuleContent(s3Uri: string): string | undefined {
+        return this.rules.peek(s3Uri);
+    }
+
+    invalidateHook(typeName: string): void {
+        this.configs.invalidate(typeName);
+    }
+
+    invalidateRule(s3Uri: string): void {
+        this.rules.invalidate(s3Uri);
+    }
+
+    invalidateAll(): void {
+        this.configs.clear();
+        this.rules.clear();
+    }
+}

--- a/src/hooks/HookSchemaStore.ts
+++ b/src/hooks/HookSchemaStore.ts
@@ -1,0 +1,57 @@
+import { DataStore, DataStoreFactoryProvider, Persistence, StoreName } from '../datastore/DataStore';
+import type { DescribeHookResult } from './HooksRequestType';
+
+export type HookSchemaRecord = {
+    version: string;
+    typeName: string;
+    schema: DescribeHookResult;
+    firstCreatedMs: number;
+    lastModifiedMs: number;
+};
+
+const HookSchemaVersion = 'v1';
+
+export class HookSchemaStore {
+    private readonly store: DataStore;
+
+    constructor(
+        dataStoreFactory: DataStoreFactoryProvider,
+        private readonly now: () => number = Date.now,
+    ) {
+        this.store = dataStoreFactory.get(StoreName.hook_schemas, Persistence.local);
+    }
+
+    get(typeName: string): HookSchemaRecord | undefined {
+        return this.store.get<HookSchemaRecord>(this.key(typeName));
+    }
+
+    async put(typeName: string, schema: DescribeHookResult): Promise<boolean> {
+        const now = this.now();
+        const existing = this.get(typeName);
+        const record: HookSchemaRecord = {
+            version: HookSchemaVersion,
+            typeName,
+            schema,
+            firstCreatedMs: existing?.firstCreatedMs ?? now,
+            lastModifiedMs: now,
+        };
+        return await this.store.put(this.key(typeName), record);
+    }
+
+    async remove(typeName: string): Promise<void> {
+        await this.store.remove(this.key(typeName));
+    }
+
+    async clear(): Promise<void> {
+        await this.store.clear();
+    }
+
+    getAgeMs(typeName: string): number | undefined {
+        const record = this.get(typeName);
+        return record === undefined ? undefined : this.now() - record.lastModifiedMs;
+    }
+
+    private key(typeName: string): string {
+        return `hook:${typeName}`;
+    }
+}

--- a/src/hooks/HooksManager.ts
+++ b/src/hooks/HooksManager.ts
@@ -1,0 +1,201 @@
+import type { TypeSummary } from '@aws-sdk/client-cloudformation';
+import type { CfnService } from '../services/CfnService';
+import { HookCache } from './HookCache';
+import type { HookSchemaStore } from './HookSchemaStore';
+import type {
+    HookSummary,
+    DescribeHookResult,
+    DescribeHookParams,
+    ListHooksResult,
+    ListHooksDetailedResult,
+    DetailedHook,
+} from './HooksRequestType';
+
+const StaleDaysThreshold = 7;
+const MsPerDay = 24 * 60 * 60 * 1000;
+const DetailedFetchConcurrency = 10;
+
+export type ParsedHookConfiguration = {
+    configured: boolean;
+    failureMode?: string;
+    invocationStatus?: string;
+    targetOperations?: string[];
+    ruleUri?: string;
+};
+
+export function parseHookConfiguration(rawConfiguration: string): ParsedHookConfiguration {
+    let hookConfiguration: Record<string, unknown> | undefined;
+    try {
+        const parsed = JSON.parse(rawConfiguration) as Record<string, unknown>;
+        const wrapper = parsed.CloudFormationConfiguration as Record<string, unknown> | undefined;
+        hookConfiguration = wrapper?.HookConfiguration as Record<string, unknown> | undefined;
+    } catch {
+        hookConfiguration = undefined;
+    }
+
+    if (!hookConfiguration || Object.keys(hookConfiguration).length === 0) {
+        return { configured: false };
+    }
+
+    const targetOperations = Array.isArray(hookConfiguration.TargetOperations)
+        ? (hookConfiguration.TargetOperations as string[])
+        : undefined;
+
+    return {
+        configured: true,
+        failureMode: typeof hookConfiguration.FailureMode === 'string' ? hookConfiguration.FailureMode : undefined,
+        invocationStatus:
+            typeof hookConfiguration.HookInvocationStatus === 'string'
+                ? hookConfiguration.HookInvocationStatus
+                : undefined,
+        targetOperations,
+        ruleUri: extractRuleUri(hookConfiguration),
+    };
+}
+
+function extractRuleUri(hookConfiguration: Record<string, unknown>): string | undefined {
+    const properties = hookConfiguration.Properties as Record<string, unknown> | undefined;
+    const ruleLocation = properties?.ruleLocation;
+    if (typeof ruleLocation === 'string') {
+        return ruleLocation;
+    }
+    if (ruleLocation && typeof ruleLocation === 'object') {
+        const uri = (ruleLocation as Record<string, unknown>).uri;
+        if (typeof uri === 'string') {
+            return uri;
+        }
+    }
+    return undefined;
+}
+
+export class HooksManager {
+    private readonly hooksCache: Map<string, HookSummary> = new Map();
+    private readonly hookDetailsCache: Map<string, DescribeHookResult> = new Map();
+    private nextToken?: string;
+
+    constructor(
+        private readonly cfnService: CfnService,
+        private readonly schemaStore?: HookSchemaStore,
+        private readonly staleDaysThreshold: number = StaleDaysThreshold,
+        private readonly hookCache: HookCache = new HookCache(),
+    ) {}
+
+    public async listHooksDetailed(loadMore?: boolean): Promise<ListHooksDetailedResult> {
+        const listed = await this.listHooks(loadMore);
+        const detailed: DetailedHook[] = [];
+        for (let i = 0; i < listed.hooks.length; i += DetailedFetchConcurrency) {
+            const batch = listed.hooks.slice(i, i + DetailedFetchConcurrency);
+            const resolved = await Promise.all(
+                batch.map(async (hook) => {
+                    let parsed: ParsedHookConfiguration = { configured: false };
+                    let configuration: string | undefined;
+                    try {
+                        configuration = await this.hookCache.getConfiguration(hook.typeName, () =>
+                            this.cfnService.getHookConfiguration(hook.typeName),
+                        );
+                        parsed = parseHookConfiguration(configuration);
+                    } catch {
+                        parsed = { configured: false };
+                    }
+                    return {
+                        ...hook,
+                        configuration,
+                        configured: parsed.configured,
+                        failureMode: parsed.failureMode,
+                        invocationStatus: parsed.invocationStatus,
+                        targetOperations: parsed.targetOperations,
+                        ruleUri: parsed.ruleUri,
+                    };
+                }),
+            );
+            detailed.push(...resolved);
+        }
+        return { hooks: detailed, nextToken: listed.nextToken };
+    }
+
+    public async getCachedRuleContent(ruleUri: string, loader: () => Promise<string>): Promise<string> {
+        return await this.hookCache.getRuleContent(ruleUri, loader);
+    }
+
+    public async listHooks(loadMore?: boolean): Promise<ListHooksResult> {
+        if (!loadMore) {
+            this.hooksCache.clear();
+            this.nextToken = undefined;
+        }
+
+        const response = await this.cfnService.listHooks(loadMore ? this.nextToken : undefined);
+
+        for (const hook of response.hooks) {
+            if (hook.TypeName && !this.hooksCache.has(hook.TypeName)) {
+                this.hooksCache.set(hook.TypeName, this.mapTypeSummaryToHookSummary(hook));
+            }
+        }
+
+        this.nextToken = response.nextToken;
+
+        return {
+            hooks: [...this.hooksCache.values()],
+            nextToken: this.nextToken,
+        };
+    }
+
+    public async describeHook(params: DescribeHookParams): Promise<DescribeHookResult> {
+        const cacheKey = params.typeName ?? params.arn;
+        if (!cacheKey) {
+            throw new Error('describeHook requires either typeName or arn');
+        }
+
+        const memCached = this.hookDetailsCache.get(cacheKey);
+        if (memCached) {
+            return memCached;
+        }
+
+        if (params.typeName && this.schemaStore) {
+            const persisted = this.schemaStore.get(params.typeName);
+            if (persisted && !this.isStale(persisted.lastModifiedMs)) {
+                this.hookDetailsCache.set(cacheKey, persisted.schema);
+                return persisted.schema;
+            }
+        }
+
+        const response = await this.cfnService.describeHook(params);
+        const result: DescribeHookResult = {
+            typeName: response.TypeName ?? '',
+            arn: response.Arn ?? '',
+            description: response.Description,
+            schema: response.Schema,
+            configurationSchema: response.ConfigurationSchema,
+            visibility: response.Visibility ?? 'PRIVATE',
+            defaultVersionId: response.DefaultVersionId,
+            lastUpdated: response.LastUpdated?.toISOString(),
+        };
+
+        this.hookDetailsCache.set(cacheKey, result);
+        if (params.typeName && this.schemaStore) {
+            await this.schemaStore.put(params.typeName, result);
+        }
+        return result;
+    }
+
+    public clearCache(): void {
+        this.hooksCache.clear();
+        this.hookDetailsCache.clear();
+        this.hookCache.invalidateAll();
+        this.nextToken = undefined;
+    }
+
+    private isStale(lastModifiedMs: number): boolean {
+        const ageMs = Date.now() - lastModifiedMs;
+        return ageMs >= this.staleDaysThreshold * MsPerDay;
+    }
+
+    private mapTypeSummaryToHookSummary(summary: TypeSummary): HookSummary {
+        return {
+            typeName: summary.TypeName ?? '',
+            typeArn: summary.TypeArn ?? '',
+            defaultVersionId: summary.DefaultVersionId,
+            description: summary.Description,
+            lastUpdated: summary.LastUpdated?.toISOString(),
+        };
+    }
+}

--- a/src/hooks/HooksParser.ts
+++ b/src/hooks/HooksParser.ts
@@ -1,0 +1,258 @@
+import { z } from 'zod';
+import { NonEmptyZodString } from '../utils/ZodModel';
+import type {
+    ListHooksParams,
+    DescribeHookParams,
+    ListHookResultsParams,
+    GetHookResultParams,
+    ConfigureHookParams,
+    SetInvocationStatusParams,
+    CreateGuardHookParams,
+    CreateHookExecutionRoleParams,
+    CreateS3BucketParams,
+    DeactivateHookParams,
+    ActivateHookParams,
+    SetHookConfigurationParams,
+    GetHookConfigurationParams,
+    GetRuleContentParams,
+    ValidateRuleParams,
+    UploadRuleParams,
+    PreviewGuardHooksParams,
+} from './HooksRequestType';
+
+const ListHooksParamsSchema = z
+    .object({
+        loadMore: z.boolean().optional(),
+    })
+    .strict();
+
+const DescribeHookParamsSchema = z
+    .object({
+        typeName: NonEmptyZodString.optional(),
+        arn: NonEmptyZodString.optional(),
+    })
+    .strict()
+    .refine((data) => data.typeName ?? data.arn, {
+        message: 'At least one of typeName or arn is required',
+    });
+
+const TargetTypeEnum = z.enum(['CHANGE_SET', 'STACK', 'RESOURCE', 'CLOUD_CONTROL']);
+
+const ListHookResultsParamsSchema = z
+    .object({
+        typeArn: z.string().optional(),
+        status: z.string().optional(),
+        targetId: z.string().optional(),
+        targetType: TargetTypeEnum.optional(),
+        nextToken: z.string().optional(),
+    })
+    .strict();
+
+const GetHookResultParamsSchema = z
+    .object({
+        hookResultId: NonEmptyZodString,
+    })
+    .strict();
+
+const ConfigureHookParamsSchema = z
+    .object({
+        typeName: NonEmptyZodString,
+        failureMode: z.enum(['FAIL', 'WARN']),
+    })
+    .strict();
+
+const DeactivateHookParamsSchema = z
+    .object({
+        typeName: NonEmptyZodString.optional(),
+        arn: NonEmptyZodString.optional(),
+    })
+    .strict()
+    .refine((data) => data.typeName ?? data.arn, {
+        message: 'At least one of typeName or arn is required',
+    });
+
+export function parseListHooksParams(input: unknown): ListHooksParams {
+    return ListHooksParamsSchema.parse(input);
+}
+
+export function parseDescribeHookParams(input: unknown): DescribeHookParams {
+    return DescribeHookParamsSchema.parse(input);
+}
+
+export function parseListHookResultsParams(input: unknown): ListHookResultsParams {
+    return ListHookResultsParamsSchema.parse(input);
+}
+
+export function parseGetHookResultParams(input: unknown): GetHookResultParams {
+    return GetHookResultParamsSchema.parse(input);
+}
+
+export function parseConfigureHookParams(input: unknown): ConfigureHookParams {
+    return ConfigureHookParamsSchema.parse(input);
+}
+
+const SetInvocationStatusParamsSchema = z
+    .object({
+        typeName: NonEmptyZodString,
+        invocationStatus: z.enum(['ENABLED', 'DISABLED']),
+    })
+    .strict();
+
+export function parseSetInvocationStatusParams(input: unknown): SetInvocationStatusParams {
+    return SetInvocationStatusParamsSchema.parse(input);
+}
+
+const REQUIRED_GUARD_HOOK_KEYS = [
+    'Alias',
+    'ExecutionRole',
+    'FailureMode',
+    'HookStatus',
+    'RuleLocation',
+    'TargetOperations',
+];
+
+const CreateGuardHookParamsSchema = z
+    .object({
+        desiredState: NonEmptyZodString,
+    })
+    .strict()
+    .superRefine((data, ctx) => {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(data.desiredState);
+        } catch {
+            ctx.addIssue({ code: 'custom', message: 'desiredState must be valid JSON' });
+            return;
+        }
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+            ctx.addIssue({ code: 'custom', message: 'desiredState must be a JSON object' });
+            return;
+        }
+        const obj = parsed as Record<string, unknown>;
+        for (const key of REQUIRED_GUARD_HOOK_KEYS) {
+            if (obj[key] === undefined) {
+                ctx.addIssue({ code: 'custom', message: `desiredState is missing required key: ${key}` });
+            }
+        }
+    });
+
+export function parseCreateGuardHookParams(input: unknown): CreateGuardHookParams {
+    return CreateGuardHookParamsSchema.parse(input);
+}
+
+const CreateHookExecutionRoleParamsSchema = z
+    .object({
+        roleName: NonEmptyZodString.regex(
+            /^[A-Za-z0-9+=,.@_-]{1,64}$/,
+            'Role name may contain letters, numbers, and +=,.@_- (max 64 chars)',
+        ),
+        ruleBucket: NonEmptyZodString.optional(),
+    })
+    .strict();
+
+export function parseCreateHookExecutionRoleParams(input: unknown): CreateHookExecutionRoleParams {
+    return CreateHookExecutionRoleParamsSchema.parse(input);
+}
+
+const CreateS3BucketParamsSchema = z
+    .object({
+        bucketName: NonEmptyZodString.regex(
+            /^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/,
+            'Bucket names must be 3-63 chars, lowercase letters, numbers, dots, or hyphens, starting and ending alphanumeric',
+        )
+            .refine((name) => !/\.\.|\.-|-\./.test(name), {
+                message: 'Bucket names cannot contain consecutive dots or a dot adjacent to a hyphen',
+            })
+            .refine(
+                (name) => {
+                    const parts = name.split('.');
+                    return !(parts.length === 4 && parts.every((part) => /^\d+$/.test(part)));
+                },
+                { message: 'Bucket names cannot be formatted as an IP address' },
+            ),
+    })
+    .strict();
+
+export function parseCreateS3BucketParams(input: unknown): CreateS3BucketParams {
+    return CreateS3BucketParamsSchema.parse(input);
+}
+
+export function parseDeactivateHookParams(input: unknown): DeactivateHookParams {
+    return DeactivateHookParamsSchema.parse(input);
+}
+
+const ActivateHookParamsSchema = z
+    .object({
+        typeName: NonEmptyZodString,
+        publisherId: NonEmptyZodString.optional(),
+        typeNameAlias: NonEmptyZodString.optional(),
+        executionRoleArn: NonEmptyZodString.optional(),
+    })
+    .strict();
+
+const SetHookConfigurationParamsSchema = z
+    .object({
+        typeName: NonEmptyZodString,
+        configuration: NonEmptyZodString,
+    })
+    .strict();
+
+export function parseActivateHookParams(input: unknown): ActivateHookParams {
+    return ActivateHookParamsSchema.parse(input);
+}
+
+export function parseSetHookConfigurationParams(input: unknown): SetHookConfigurationParams {
+    return SetHookConfigurationParamsSchema.parse(input);
+}
+
+const GetHookConfigurationParamsSchema = z
+    .object({
+        typeName: NonEmptyZodString,
+    })
+    .strict();
+
+const GetRuleContentParamsSchema = z
+    .object({
+        s3Uri: NonEmptyZodString,
+    })
+    .strict();
+
+export function parseGetHookConfigurationParams(input: unknown): GetHookConfigurationParams {
+    return GetHookConfigurationParamsSchema.parse(input);
+}
+
+export function parseGetRuleContentParams(input: unknown): GetRuleContentParams {
+    return GetRuleContentParamsSchema.parse(input);
+}
+
+const ValidateRuleParamsSchema = z
+    .object({
+        ruleContent: NonEmptyZodString,
+        sampleTemplate: z.string().optional(),
+    })
+    .strict();
+
+const UploadRuleParamsSchema = z
+    .object({
+        ruleContent: NonEmptyZodString,
+        s3Uri: NonEmptyZodString,
+    })
+    .strict();
+
+export function parseValidateRuleParams(input: unknown): ValidateRuleParams {
+    return ValidateRuleParamsSchema.parse(input);
+}
+
+export function parseUploadRuleParams(input: unknown): UploadRuleParams {
+    return UploadRuleParamsSchema.parse(input);
+}
+
+const PreviewGuardHooksParamsSchema = z
+    .object({
+        templateContent: NonEmptyZodString,
+    })
+    .strict();
+
+export function parsePreviewGuardHooksParams(input: unknown): PreviewGuardHooksParams {
+    return PreviewGuardHooksParamsSchema.parse(input);
+}

--- a/src/hooks/HooksRequestType.ts
+++ b/src/hooks/HooksRequestType.ts
@@ -1,0 +1,400 @@
+import { RequestType } from 'vscode-languageserver';
+
+export type ListHooksParams = {
+    loadMore?: boolean;
+};
+
+export type HookSummary = {
+    typeName: string;
+    typeArn: string;
+    defaultVersionId?: string;
+    description?: string;
+    lastUpdated?: string;
+};
+
+export type ListHooksResult = {
+    hooks: HookSummary[];
+    nextToken?: string;
+};
+
+export const ListHooksRequest = new RequestType<ListHooksParams, ListHooksResult, void>('aws/cfn/hooks/list');
+
+export type DetailedHook = HookSummary & {
+    configured: boolean;
+    configuration?: string;
+    failureMode?: string;
+    invocationStatus?: string;
+    targetOperations?: string[];
+    ruleUri?: string;
+};
+
+export type ListHooksDetailedResult = {
+    hooks: DetailedHook[];
+    nextToken?: string;
+};
+
+export const ListHooksDetailedRequest = new RequestType<ListHooksParams, ListHooksDetailedResult, void>(
+    'aws/cfn/hooks/listDetailed',
+);
+
+export type ListPublicHooksParams = {
+    typeNamePrefix?: string;
+};
+
+export type PublicHookSummary = {
+    typeName: string;
+    publisherId: string;
+    description?: string;
+};
+
+export type ListPublicHooksResult = {
+    hooks: PublicHookSummary[];
+};
+
+export const ListPublicHooksRequest = new RequestType<ListPublicHooksParams, ListPublicHooksResult, void>(
+    'aws/cfn/hooks/listPublic',
+);
+
+export type DescribeHookParams = {
+    typeName?: string;
+    arn?: string;
+};
+
+export type HookTargetInfo = {
+    targetName: string;
+    invocationPoint: string;
+    failureMode: string;
+};
+
+export type DescribeHookResult = {
+    typeName: string;
+    arn: string;
+    description?: string;
+    schema?: string;
+    configurationSchema?: string;
+    visibility: string;
+    defaultVersionId?: string;
+    lastUpdated?: string;
+    targets?: HookTargetInfo[];
+};
+
+export const DescribeHookRequest = new RequestType<DescribeHookParams, DescribeHookResult, void>(
+    'aws/cfn/hooks/describe',
+);
+
+export type ListHookResultsParams = {
+    typeArn?: string;
+    status?: string;
+    targetId?: string;
+    targetType?: string;
+    nextToken?: string;
+};
+
+export type HookResultSummary = {
+    hookResultId: string;
+    hookTypeArn: string;
+    hookTypeName: string;
+    invocationPoint: string;
+    hookStatus: string;
+    failureMode: string;
+    targetId?: string;
+    targetType?: string;
+    timestamp?: string;
+};
+
+export type ListHookResultsResult = {
+    hookResults: HookResultSummary[];
+    nextToken?: string;
+};
+
+export const ListHookResultsRequest = new RequestType<ListHookResultsParams, ListHookResultsResult, void>(
+    'aws/cfn/hooks/results/list',
+);
+
+export type GetHookResultParams = {
+    hookResultId: string;
+};
+
+export type HookAnnotation = {
+    severity: string;
+    statusMessage: string;
+    remediationLink?: string;
+};
+
+export type HookTarget = {
+    targetType: string;
+    targetName: string;
+    targetId?: string;
+    action?: string;
+};
+
+export type GetHookResultResult = {
+    hookResultId: string;
+    hookTypeName: string;
+    hookStatus: string;
+    failureMode: string;
+    invocationPoint: string;
+    annotations?: HookAnnotation[];
+    target?: HookTarget;
+    timestamp?: string;
+};
+
+export const GetHookResultRequest = new RequestType<GetHookResultParams, GetHookResultResult, void>(
+    'aws/cfn/hooks/result/get',
+);
+
+export type ConfigureHookParams = {
+    typeName: string;
+    failureMode: string;
+};
+
+export type ConfigureHookResult = {
+    configurationArn?: string;
+};
+
+export const ConfigureHookRequest = new RequestType<ConfigureHookParams, ConfigureHookResult, void>(
+    'aws/cfn/hooks/configure',
+);
+
+export type SetInvocationStatusParams = {
+    typeName: string;
+    invocationStatus: 'ENABLED' | 'DISABLED';
+};
+
+export type SetInvocationStatusResult = {
+    configurationArn?: string;
+    invocationStatus: 'ENABLED' | 'DISABLED';
+};
+
+export const SetInvocationStatusRequest = new RequestType<SetInvocationStatusParams, SetInvocationStatusResult, void>(
+    'aws/cfn/hooks/setInvocationStatus',
+);
+
+export type CreateGuardHookParams = {
+    /** JSON string of the AWS::CloudFormation::GuardHook DesiredState. */
+    desiredState: string;
+};
+
+export type CreateGuardHookResult = {
+    operationStatus?: string;
+    identifier?: string;
+    errorCode?: string;
+    statusMessage?: string;
+};
+
+export const CreateGuardHookRequest = new RequestType<CreateGuardHookParams, CreateGuardHookResult, void>(
+    'aws/cfn/hooks/createGuardHook',
+);
+
+export type ListIamRolesParams = Record<string, never>;
+
+export type IamRoleSummary = {
+    roleName: string;
+    arn: string;
+};
+
+export type ListIamRolesResult = {
+    roles: IamRoleSummary[];
+};
+
+export const ListIamRolesRequest = new RequestType<ListIamRolesParams, ListIamRolesResult, void>(
+    'aws/cfn/hooks/listIamRoles',
+);
+
+export type ListS3BucketsParams = Record<string, never>;
+
+export type ListS3BucketsResult = {
+    buckets: string[];
+};
+
+export const ListS3BucketsRequest = new RequestType<ListS3BucketsParams, ListS3BucketsResult, void>(
+    'aws/cfn/hooks/listS3Buckets',
+);
+
+export type ListS3ObjectsParams = {
+    bucketName: string;
+    prefix?: string;
+};
+
+export type ListS3ObjectsResult = {
+    keys: string[];
+};
+
+export const ListS3ObjectsRequest = new RequestType<ListS3ObjectsParams, ListS3ObjectsResult, void>(
+    'aws/cfn/hooks/listS3Objects',
+);
+
+export type ListProactiveControlsParams = Record<string, never>;
+
+export type ProactiveControlSummary = {
+    controlId: string;
+    name: string;
+    resource?: string;
+};
+
+export type ListProactiveControlsResult = {
+    controls: ProactiveControlSummary[];
+};
+
+export const ListProactiveControlsRequest = new RequestType<
+    ListProactiveControlsParams,
+    ListProactiveControlsResult,
+    void
+>('aws/cfn/hooks/listProactiveControls');
+
+export type CreateS3BucketParams = {
+    bucketName: string;
+};
+
+export type CreateS3BucketResult = {
+    bucketName: string;
+};
+
+export const CreateS3BucketRequest = new RequestType<CreateS3BucketParams, CreateS3BucketResult, void>(
+    'aws/cfn/hooks/createS3Bucket',
+);
+
+export type CreateHookExecutionRoleParams = {
+    roleName: string;
+    ruleBucket?: string;
+};
+
+export type CreateHookExecutionRoleResult = {
+    roleName: string;
+    arn: string;
+};
+
+export const CreateHookExecutionRoleRequest = new RequestType<
+    CreateHookExecutionRoleParams,
+    CreateHookExecutionRoleResult,
+    void
+>('aws/cfn/hooks/createExecutionRole');
+
+export type DeactivateHookParams = {
+    typeName?: string;
+    arn?: string;
+};
+
+export type DeactivateHookResult = Record<string, never>;
+
+export const DeactivateHookRequest = new RequestType<DeactivateHookParams, DeactivateHookResult, void>(
+    'aws/cfn/hooks/deactivate',
+);
+
+export type ActivateHookParams = {
+    typeName: string;
+    publisherId?: string;
+    typeNameAlias?: string;
+    executionRoleArn?: string;
+};
+
+export type ActivateHookResult = {
+    arn?: string;
+};
+
+export const ActivateHookRequest = new RequestType<ActivateHookParams, ActivateHookResult, void>(
+    'aws/cfn/hooks/activate',
+);
+
+export type SetHookConfigurationParams = {
+    typeName: string;
+    configuration: string;
+};
+
+export type SetHookConfigurationResult = {
+    configurationArn?: string;
+};
+
+export const SetHookConfigurationRequest = new RequestType<
+    SetHookConfigurationParams,
+    SetHookConfigurationResult,
+    void
+>('aws/cfn/hooks/setConfiguration');
+
+export type GetHookConfigurationParams = {
+    typeName: string;
+};
+
+export type GetHookConfigurationResult = {
+    configuration: string;
+};
+
+export const GetHookConfigurationRequest = new RequestType<
+    GetHookConfigurationParams,
+    GetHookConfigurationResult,
+    void
+>('aws/cfn/hooks/getConfiguration');
+
+export type GetRuleContentParams = {
+    s3Uri: string;
+};
+
+export type GetRuleContentResult = {
+    content: string;
+};
+
+export const GetRuleContentRequest = new RequestType<GetRuleContentParams, GetRuleContentResult, void>(
+    'aws/cfn/hooks/getRuleContent',
+);
+
+export type ValidateRuleParams = {
+    ruleContent: string;
+    sampleTemplate?: string;
+};
+
+export type RuleViolation = {
+    ruleName: string;
+    message: string;
+    line: number;
+    column: number;
+};
+
+export type ValidateRuleResult = {
+    valid: boolean;
+    parseErrors: string[];
+    violations: RuleViolation[];
+};
+
+export const ValidateRuleRequest = new RequestType<ValidateRuleParams, ValidateRuleResult, void>(
+    'aws/cfn/hooks/validateRule',
+);
+
+export type UploadRuleParams = {
+    ruleContent: string;
+    s3Uri: string;
+};
+
+export type UploadRuleResult = {
+    s3Uri: string;
+};
+
+export const UploadRuleRequest = new RequestType<UploadRuleParams, UploadRuleResult, void>('aws/cfn/hooks/uploadRule');
+
+export type PreviewGuardHooksParams = {
+    templateContent: string;
+};
+
+export type GuardHookPreviewViolation = {
+    ruleName: string;
+    message: string;
+    line: number;
+    column: number;
+    path?: string;
+};
+
+export type GuardHookPreviewEntry = {
+    typeName: string;
+    ruleUri: string;
+    failureMode?: string;
+    valid: boolean;
+    violations: GuardHookPreviewViolation[];
+    error?: string;
+};
+
+export type PreviewGuardHooksResult = {
+    hooks: GuardHookPreviewEntry[];
+};
+
+export const PreviewGuardHooksRequest = new RequestType<PreviewGuardHooksParams, PreviewGuardHooksResult, void>(
+    'aws/cfn/hooks/previewGuard',
+);

--- a/src/services/AwsClient.ts
+++ b/src/services/AwsClient.ts
@@ -1,5 +1,7 @@
 import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { ControlCatalogClient } from '@aws-sdk/client-controlcatalog';
+import { IAMClient } from '@aws-sdk/client-iam';
 import { S3Client } from '@aws-sdk/client-s3';
 import { STSClient } from '@aws-sdk/client-sts';
 import { AwsCredentials } from '../auth/AwsCredentials';
@@ -35,6 +37,14 @@ export class AwsClient {
 
     public getStsClient() {
         return new STSClient(this.iamClientConfig());
+    }
+
+    public getIamClient() {
+        return new IAMClient(this.iamClientConfig());
+    }
+
+    public getControlCatalogClient() {
+        return new ControlCatalogClient(this.iamClientConfig());
     }
 
     public getRegion(): string {

--- a/src/services/CcapiService.ts
+++ b/src/services/CcapiService.ts
@@ -1,9 +1,12 @@
 import {
     CloudControlClient,
+    CreateResourceCommand,
     GetResourceCommand,
     GetResourceInput,
+    GetResourceRequestStatusCommand,
     ListResourcesCommand,
     ListResourcesOutput,
+    ProgressEvent,
 } from '@aws-sdk/client-cloudcontrol';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Measure } from '../telemetry/TelemetryDecorator';
@@ -58,6 +61,51 @@ export class CcapiService {
                 Identifier: identifier,
             };
             return await client.send(new GetResourceCommand(getResourceInput));
+        });
+    }
+
+    /**
+     * Create a resource via the Cloud Control API and poll until the operation reaches a
+     * terminal state. CloudControl create is asynchronous: CreateResource returns a
+     * RequestToken and an initial ProgressEvent, which we poll via
+     * GetResourceRequestStatus until SUCCESS/FAILED (or a timeout).
+     */
+    @Measure({ name: 'createResource', captureErrorType: true })
+    public async createResource(
+        typeName: string,
+        desiredState: string,
+        options?: { pollIntervalMs?: number; timeoutMs?: number },
+    ): Promise<ProgressEvent> {
+        const pollIntervalMs = options?.pollIntervalMs ?? 2000;
+        const timeoutMs = options?.timeoutMs ?? 120_000;
+        return await this.withClient(async (client) => {
+            const create = await client.send(
+                new CreateResourceCommand({ TypeName: typeName, DesiredState: desiredState }),
+            );
+            let progress: ProgressEvent | undefined = create.ProgressEvent;
+            const token = progress?.RequestToken;
+
+            const deadline = Date.now() + timeoutMs;
+            while (
+                token &&
+                progress &&
+                (progress.OperationStatus === 'IN_PROGRESS' || progress.OperationStatus === 'PENDING') &&
+                Date.now() < deadline
+            ) {
+                await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+                const status = await client.send(new GetResourceRequestStatusCommand({ RequestToken: token }));
+                progress = status.ProgressEvent;
+            }
+
+            if (!progress) {
+                throw new Error('CloudControl CreateResource returned no progress event');
+            }
+            if (progress.OperationStatus === 'IN_PROGRESS' || progress.OperationStatus === 'PENDING') {
+                throw new Error(
+                    `CloudControl CreateResource for ${typeName} did not complete within ${timeoutMs}ms (last status: ${progress.OperationStatus}).`,
+                );
+            }
+            return progress;
         });
     }
 }

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -10,6 +10,8 @@ import {
     type CreateChangeSetCommandOutput,
     DescribeChangeSetCommand,
     type DescribeChangeSetCommandInput,
+    DescribeChangeSetHooksCommand,
+    type DescribeChangeSetHooksCommandOutput,
     ExecuteChangeSetCommand,
     type ExecuteChangeSetCommandOutput,
     DeleteChangeSetCommand,
@@ -58,6 +60,18 @@ import {
     type Tag,
     OnStackFailure,
     ChangeSetType,
+    DeactivateTypeCommand,
+    SetTypeConfigurationCommand,
+    type SetTypeConfigurationCommandOutput,
+    ListHookResultsCommand,
+    type ListHookResultsCommandOutput,
+    type ListHookResultsTargetType,
+    GetHookResultCommand,
+    type GetHookResultCommandOutput,
+    BatchDescribeTypeConfigurationsCommand,
+    ActivateTypeCommand,
+    type ActivateTypeCommandOutput,
+    ThirdPartyType,
 } from '@aws-sdk/client-cloudformation';
 import type { WaiterConfiguration, WaiterResult } from '@smithy/util-waiter';
 import { ISettingsSubscriber, SettingsConfigurable, SettingsSubscription } from '../settings/ISettingsSubscriber';
@@ -199,6 +213,32 @@ export class CfnService implements SettingsConfigurable, Closeable {
             } while (nextToken);
 
             result.Changes = changes;
+            result.NextToken = undefined;
+            return result;
+        });
+    }
+
+    @Count({ name: 'describeChangeSetHooks' })
+    public async describeChangeSetHooks(params: {
+        ChangeSetName: string;
+        StackName?: string;
+    }): Promise<DescribeChangeSetHooksCommandOutput> {
+        return await this.withClient(async (client) => {
+            let nextToken: string | undefined;
+            let result: DescribeChangeSetHooksCommandOutput | undefined;
+            const hooks: NonNullable<DescribeChangeSetHooksCommandOutput['Hooks']> = [];
+
+            do {
+                const response = await client.send(
+                    new DescribeChangeSetHooksCommand({ ...params, NextToken: nextToken }),
+                );
+                hooks.push(...(response.Hooks ?? []));
+                result ??= response;
+                nextToken = response.NextToken;
+            } while (nextToken);
+
+            result ??= {} as DescribeChangeSetHooksCommandOutput;
+            result.Hooks = hooks;
             result.NextToken = undefined;
             return result;
         });
@@ -462,6 +502,144 @@ export class CfnService implements SettingsConfigurable, Closeable {
     close(): void {
         this.settingsSubscription?.unsubscribe();
         this.settingsSubscription = undefined;
+    }
+
+    @Count({ name: 'listHooks', captureErrorAttributes: true })
+    public async listHooks(nextToken?: string): Promise<{ hooks: TypeSummary[]; nextToken?: string }> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new ListTypesCommand({
+                    Type: RegistryType.HOOK,
+                    Visibility: Visibility.PRIVATE,
+                    MaxResults: 100,
+                    NextToken: nextToken,
+                }),
+            );
+            return {
+                hooks: response.TypeSummaries ?? [],
+                nextToken: response.NextToken,
+            };
+        });
+    }
+
+    @Count({ name: 'listPublicHooks', captureErrorAttributes: true })
+    public async listPublicHooks(filters?: { typeNamePrefix?: string }): Promise<{ hooks: TypeSummary[] }> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new ListTypesCommand({
+                    Type: RegistryType.HOOK,
+                    Visibility: Visibility.PUBLIC,
+                    MaxResults: 100,
+                    Filters: filters?.typeNamePrefix ? { TypeNamePrefix: filters.typeNamePrefix } : undefined,
+                }),
+            );
+            return { hooks: response.TypeSummaries ?? [] };
+        });
+    }
+
+    @Count({ name: 'describeHook', captureErrorAttributes: true })
+    public async describeHook(params: { typeName?: string; arn?: string }): Promise<DescribeTypeOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new DescribeTypeCommand({
+                    Type: RegistryType.HOOK,
+                    TypeName: params.typeName,
+                    Arn: params.arn,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'getHookConfiguration', captureErrorAttributes: true })
+    public async getHookConfiguration(typeName: string): Promise<string> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new BatchDescribeTypeConfigurationsCommand({
+                    TypeConfigurationIdentifiers: [{ Type: RegistryType.HOOK, TypeName: typeName }],
+                }),
+            );
+            return response.TypeConfigurations?.[0]?.Configuration ?? '{}';
+        });
+    }
+
+    @Count({ name: 'setHookConfiguration', captureErrorAttributes: true })
+    public async setHookConfiguration(params: {
+        typeName: string;
+        configuration: string;
+    }): Promise<SetTypeConfigurationCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new SetTypeConfigurationCommand({
+                    Type: RegistryType.HOOK,
+                    TypeName: params.typeName,
+                    Configuration: params.configuration,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'listHookResults', captureErrorAttributes: true })
+    public async listHookResults(params: {
+        typeArn?: string;
+        status?: string;
+        targetId?: string;
+        targetType?: string;
+        nextToken?: string;
+    }): Promise<ListHookResultsCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new ListHookResultsCommand({
+                    TypeArn: params.typeArn,
+                    TargetId: params.targetId,
+                    TargetType: params.targetType as ListHookResultsTargetType,
+                    NextToken: params.nextToken,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'getHookResult', captureErrorAttributes: true })
+    public async getHookResult(hookResultId: string): Promise<GetHookResultCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new GetHookResultCommand({
+                    HookResultId: hookResultId,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'deactivateHook', captureErrorAttributes: true })
+    public async deactivateHook(params: { typeName?: string; arn?: string }): Promise<void> {
+        await this.withClient((client) =>
+            client.send(
+                new DeactivateTypeCommand({
+                    Type: params.typeName ? ThirdPartyType.HOOK : undefined,
+                    TypeName: params.typeName,
+                    Arn: params.arn,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'activateHook', captureErrorAttributes: true })
+    public async activateHook(params: {
+        typeName: string;
+        publisherId?: string;
+        typeNameAlias?: string;
+        executionRoleArn?: string;
+    }): Promise<ActivateTypeCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new ActivateTypeCommand({
+                    Type: ThirdPartyType.HOOK,
+                    TypeName: params.typeName,
+                    PublisherId: params.publisherId,
+                    TypeNameAlias: params.typeNameAlias,
+                    ExecutionRoleArn: params.executionRoleArn,
+                }),
+            ),
+        );
     }
 }
 

--- a/src/services/ControlCatalogService.ts
+++ b/src/services/ControlCatalogService.ts
@@ -1,0 +1,55 @@
+import { ControlCatalogClient, ListControlsCommand } from '@aws-sdk/client-controlcatalog';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { Measure } from '../telemetry/TelemetryDecorator';
+import { markIfClientError } from '../utils/errors/FaultSuppression';
+import { AwsClient } from './AwsClient';
+
+const log = LoggerFactory.getLogger('ControlCatalogService');
+
+export interface ProactiveControl {
+    controlId: string;
+    name: string;
+    resource?: string;
+}
+
+export class ControlCatalogService {
+    constructor(private readonly awsClient: AwsClient) {}
+
+    private async withClient<T>(request: (client: ControlCatalogClient) => Promise<T>): Promise<T> {
+        try {
+            const client = this.awsClient.getControlCatalogClient();
+            return await request(client);
+        } catch (error) {
+            log.error(error, 'Control Catalog API call failed');
+            markIfClientError(error);
+            throw error;
+        }
+    }
+
+    @Measure({ name: 'listProactiveControls', captureErrorType: true })
+    public async listProactiveControls(maxControls = 2000): Promise<ProactiveControl[]> {
+        return await this.withClient(async (client) => {
+            const controls: ProactiveControl[] = [];
+            let nextToken: string | undefined;
+            do {
+                const response = await client.send(new ListControlsCommand({ NextToken: nextToken }));
+                for (const control of response.Controls ?? []) {
+                    if (control.Behavior !== 'PROACTIVE') {
+                        continue;
+                    }
+                    const controlId = (control.Aliases ?? []).find((alias) => alias.startsWith('CT.'));
+                    if (!controlId) {
+                        continue;
+                    }
+                    controls.push({
+                        controlId,
+                        name: control.Name ?? controlId,
+                        resource: control.GovernedResources?.[0],
+                    });
+                }
+                nextToken = response.NextToken;
+            } while (nextToken && controls.length < maxControls);
+            return controls.toSorted((a, b) => a.controlId.localeCompare(b.controlId));
+        });
+    }
+}

--- a/src/services/IamService.ts
+++ b/src/services/IamService.ts
@@ -1,0 +1,123 @@
+import { IAMClient, ListRolesCommand, CreateRoleCommand, PutRolePolicyCommand } from '@aws-sdk/client-iam';
+import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { Measure } from '../telemetry/TelemetryDecorator';
+import { markIfClientError } from '../utils/errors/FaultSuppression';
+import { AwsClient } from './AwsClient';
+
+const log = LoggerFactory.getLogger('IamService');
+
+export interface IamRole {
+    roleName: string;
+    arn: string;
+}
+
+export class IamService {
+    constructor(private readonly awsClient: AwsClient) {}
+
+    private async withClient<T>(request: (client: IAMClient) => Promise<T>): Promise<T> {
+        try {
+            const client = this.awsClient.getIamClient();
+            return await request(client);
+        } catch (error) {
+            log.error(error, 'IAM API call failed');
+            markIfClientError(error);
+            throw error;
+        }
+    }
+
+    /**
+     * List IAM roles in the account, paginating up to `maxRoles` (default 1000).
+     * Returns role name + ARN for populating a role picker.
+     */
+    @Measure({ name: 'listRoles', captureErrorType: true })
+    public async listRoles(maxRoles = 1000): Promise<IamRole[]> {
+        return await this.withClient(async (client) => {
+            const roles: IamRole[] = [];
+            let marker: string | undefined;
+            do {
+                const response = await client.send(new ListRolesCommand({ Marker: marker, MaxItems: 100 }));
+                for (const role of response.Roles ?? []) {
+                    if (role.RoleName && role.Arn) {
+                        roles.push({ roleName: role.RoleName, arn: role.Arn });
+                    }
+                }
+                marker = response.IsTruncated ? response.Marker : undefined;
+            } while (marker && roles.length < maxRoles);
+            return roles;
+        });
+    }
+
+    /**
+     * Create an IAM role a Guard Hook can assume: trusts hooks.cloudformation.amazonaws.com
+     * scoped to this account (aws:SourceAccount) and, when a rule bucket is given, attaches an
+     * inline policy granting read on just that bucket. Returns the new role's name and ARN.
+     */
+    @Measure({ name: 'createHookExecutionRole', captureErrorType: true })
+    public async createHookExecutionRole(roleName: string, ruleBucket?: string): Promise<IamRole> {
+        if (ruleBucket !== undefined && !/^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/.test(ruleBucket)) {
+            throw new Error(`Invalid S3 bucket name: ${ruleBucket}`);
+        }
+        const accountId = await this.getCallerAccountId();
+        const trustPolicy = {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Principal: { Service: 'hooks.cloudformation.amazonaws.com' },
+                    Action: 'sts:AssumeRole',
+                    Condition: { StringEquals: { 'aws:SourceAccount': accountId } },
+                },
+            ],
+        };
+
+        return await this.withClient(async (client) => {
+            const created = await client.send(
+                new CreateRoleCommand({
+                    RoleName: roleName,
+                    AssumeRolePolicyDocument: JSON.stringify(trustPolicy),
+                    Description: 'Execution role for a CloudFormation Guard Hook (created by the AWS Toolkit).',
+                }),
+            );
+            if (ruleBucket) {
+                const s3ReadPolicy = {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Action: ['s3:GetObject', 's3:GetObjectVersion', 's3:ListBucket'],
+                            Resource: [`arn:aws:s3:::${ruleBucket}`, `arn:aws:s3:::${ruleBucket}/*`],
+                        },
+                    ],
+                };
+                await client.send(
+                    new PutRolePolicyCommand({
+                        RoleName: roleName,
+                        PolicyName: 'GuardHookS3ReadAccess',
+                        PolicyDocument: JSON.stringify(s3ReadPolicy),
+                    }),
+                );
+            }
+            const arn = created.Role?.Arn;
+            if (!arn) {
+                throw new Error(`CreateRole returned no ARN for role ${roleName}`);
+            }
+            return { roleName, arn };
+        });
+    }
+
+    private async getCallerAccountId(): Promise<string> {
+        const sts = this.awsClient.getStsClient();
+        try {
+            const identity = await sts.send(new GetCallerIdentityCommand({}));
+            if (!identity.Account) {
+                throw new Error('STS GetCallerIdentity did not return an account ID');
+            }
+            return identity.Account;
+        } catch (error) {
+            log.error(error, 'Failed to resolve caller account ID via STS');
+            markIfClientError(error);
+            throw error;
+        }
+    }
+}

--- a/src/services/S3Service.ts
+++ b/src/services/S3Service.ts
@@ -4,7 +4,11 @@ import { ResourceNotFoundException } from '@aws-sdk/client-cloudcontrol';
 import {
     S3Client,
     PutObjectCommand,
+    GetObjectCommand,
     ListBucketsCommand,
+    ListObjectsV2Command,
+    CreateBucketCommand,
+    BucketLocationConstraint,
     HeadObjectCommand,
     HeadBucketCommand,
 } from '@aws-sdk/client-s3';
@@ -56,6 +60,74 @@ export class S3Service {
         });
     }
 
+    /**
+     * List all bucket names in the account (across regions), paginating up to `maxBuckets`.
+     * Used to populate a bucket picker.
+     */
+    @Measure({ name: 'listAllBucketNames' })
+    async listAllBucketNames(maxBuckets = 1000): Promise<string[]> {
+        const region = this.awsClient.getRegion();
+        return await this.withClient(async (client) => {
+            const names: string[] = [];
+            let continuationToken: string | undefined;
+            do {
+                const response = await client.send(
+                    new ListBucketsCommand({ BucketRegion: region, ContinuationToken: continuationToken }),
+                );
+                for (const bucket of response.Buckets ?? []) {
+                    if (bucket.Name) {
+                        names.push(bucket.Name);
+                    }
+                }
+                continuationToken = response.ContinuationToken;
+            } while (continuationToken && names.length < maxBuckets);
+            return names;
+        });
+    }
+
+    @Measure({ name: 'listObjects' })
+    async listObjects(bucketName: string, prefix?: string, maxKeys = 1000): Promise<string[]> {
+        return await this.withClient(async (client) => {
+            const keys: string[] = [];
+            let continuationToken: string | undefined;
+            do {
+                const response = await client.send(
+                    new ListObjectsV2Command({
+                        Bucket: bucketName,
+                        Prefix: prefix,
+                        ContinuationToken: continuationToken,
+                    }),
+                );
+                for (const object of response.Contents ?? []) {
+                    if (object.Key !== undefined) {
+                        keys.push(object.Key);
+                    }
+                }
+                continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+            } while (continuationToken && keys.length < maxKeys);
+            return keys.slice(0, maxKeys);
+        });
+    }
+
+    /**
+     * Create a bucket in the client's region. us-east-1 must NOT send a LocationConstraint
+     * (it's the default and specifying it errors); every other region must.
+     */
+    @Measure({ name: 'createBucket' })
+    async createBucket(bucketName: string): Promise<void> {
+        const region = this.awsClient.getRegion();
+        await this.withClient(async (client) => {
+            await client.send(
+                new CreateBucketCommand({
+                    Bucket: bucketName,
+                    ...(region && region !== 'us-east-1'
+                        ? { CreateBucketConfiguration: { LocationConstraint: region as BucketLocationConstraint } }
+                        : {}),
+                }),
+            );
+        });
+    }
+
     @Measure({ name: 'putObject' })
     async putObjectContent(content: string | Buffer, bucketName: string, key: string) {
         return await this.withClient(async (client) => {
@@ -66,6 +138,19 @@ export class S3Service {
                     Body: content,
                 }),
             );
+        });
+    }
+
+    @Measure({ name: 'getObject' })
+    async getObjectContent(bucketName: string, key: string): Promise<string> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new GetObjectCommand({
+                    Bucket: bucketName,
+                    Key: key,
+                }),
+            );
+            return (await response.Body?.transformToString()) ?? '';
         });
     }
 

--- a/src/services/guard/GuardEngine.ts
+++ b/src/services/guard/GuardEngine.ts
@@ -65,6 +65,122 @@ export class GuardEngine {
         }
     }
 
+    /**
+     * Validate a single Guard rule for syntax/compilation and, optionally, evaluate it
+     * against a sample template. A parse/compile failure is reported as invalid; a rule
+     * that builds successfully is valid, and any violations against the sample template
+     * are returned for informational preview.
+     */
+    validateRule(
+        ruleContent: string,
+        sampleData?: string,
+    ): { valid: boolean; parseErrors: string[]; violations: GuardViolation[] } {
+        const rule: GuardRule = {
+            name: 'candidate-rule',
+            description: 'Candidate Guard rule',
+            severity: DiagnosticSeverity.Error,
+            content: ruleContent,
+            tags: ['candidate'],
+            pack: 'candidate',
+        };
+        const data = sampleData && sampleData.trim().length > 0 ? sampleData : '{"Resources":{}}';
+
+        // cfn-guard's WASM binding silently swallows parse/compile errors (it returns an
+        // empty result set for malformed, empty, or garbage rules — indistinguishable from
+        // a clean pass). Run a lightweight syntactic pre-check so obviously-invalid rules
+        // are rejected instead of being uploaded as-is.
+        const syntaxError = this.syntacticPreCheck(ruleContent);
+        if (syntaxError) {
+            return { valid: false, parseErrors: [syntaxError], violations: [] };
+        }
+
+        try {
+            const violations = this.validateTemplate(data, [rule], DiagnosticSeverity.Error);
+            return { valid: true, parseErrors: [], violations };
+        } catch (error) {
+            return { valid: false, parseErrors: [extractErrorMessage(error)], violations: [] };
+        }
+    }
+
+    /**
+     * Best-effort syntactic validation of a Guard rule. cfn-guard's WASM entry point does
+     * not surface parse errors, so this catches the common failure modes: empty content,
+     * and unbalanced/mismatched brackets (e.g. a rule block missing its closing brace).
+     * String contents are ignored so brackets inside quotes don't trip the check.
+     */
+    private syntacticPreCheck(ruleContent: string): string | undefined {
+        const closers: Record<string, string> = { '}': '{', ')': '(', ']': '[' };
+        const stack: string[] = [];
+        let inString: string | undefined;
+        let inRegex = false;
+        let hasContent = false;
+        for (let i = 0; i < ruleContent.length; i++) {
+            const char = ruleContent[i];
+            if (inString) {
+                if (char === '\\') {
+                    i++;
+                    continue;
+                }
+                if (char === inString) {
+                    inString = undefined;
+                }
+                continue;
+            }
+            if (inRegex) {
+                if (char === '\\') {
+                    i++;
+                    continue;
+                }
+                if (char === '/' || char === '\n') {
+                    inRegex = false;
+                }
+                continue;
+            }
+            if (char === '#') {
+                while (i < ruleContent.length && ruleContent[i] !== '\n') {
+                    i++;
+                }
+                continue;
+            }
+            if (char.trim().length > 0) {
+                hasContent = true;
+            }
+            switch (char) {
+                case '"':
+                case "'": {
+                    inString = char;
+                    break;
+                }
+                case '/': {
+                    inRegex = true;
+                    break;
+                }
+                case '{':
+                case '(':
+                case '[': {
+                    stack.push(char);
+                    break;
+                }
+                case '}':
+                case ')':
+                case ']': {
+                    if (stack.pop() !== closers[char]) {
+                        return `Mismatched '${char}' in the Guard rule. Check your rule blocks and brackets.`;
+                    }
+                    break;
+                }
+                // No default
+            }
+        }
+        if (!hasContent) {
+            return 'The Guard rule is empty. Define at least one `rule <name> { ... }` block.';
+        }
+        if (stack.length > 0) {
+            return `Unclosed '${stack[stack.length - 1]}' in the Guard rule — a block is missing its closing bracket.`;
+        }
+        return undefined;
+    }
+
     private convertSarifToViolations(
         sarifResult: string,
         rules: GuardRule[],

--- a/tst/unit/hooks/CfnService.hooks.test.ts
+++ b/tst/unit/hooks/CfnService.hooks.test.ts
@@ -1,0 +1,190 @@
+import {
+    CloudFormationClient,
+    CloudFormationServiceException,
+    ListTypesCommand,
+    DescribeTypeCommand,
+    DeactivateTypeCommand,
+    SetTypeConfigurationCommand,
+    RegistryType,
+    Visibility,
+} from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { CfnService } from '../../../src/services/CfnService';
+
+const cloudFormationMock = mockClient(CloudFormationClient);
+const mockGetCloudFormationClient = vi.fn();
+
+const mockClientComponent = {
+    getCloudFormationClient: mockGetCloudFormationClient,
+} as unknown as AwsClient;
+
+describe('CfnService - Hooks', () => {
+    let service: CfnService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cloudFormationMock.reset();
+        mockGetCloudFormationClient.mockReturnValue(new CloudFormationClient({}));
+        service = new CfnService(mockClientComponent);
+    });
+
+    describe('listHooks()', () => {
+        it('should call ListTypesCommand with HOOK type and PRIVATE visibility', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: [
+                    {
+                        TypeName: 'Private::Guard::S3Check',
+                        TypeArn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+                    },
+                ],
+                NextToken: undefined,
+            });
+
+            const result = await service.listHooks();
+
+            expect(result.hooks).toHaveLength(1);
+            expect(result.hooks[0].TypeName).toBe('Private::Guard::S3Check');
+            expect(result.nextToken).toBeUndefined();
+
+            const call = cloudFormationMock.commandCalls(ListTypesCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                Visibility: Visibility.PRIVATE,
+                MaxResults: 100,
+            });
+        });
+
+        it('should pass nextToken for pagination', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: [],
+                NextToken: 'next-page',
+            });
+
+            const result = await service.listHooks('token-123');
+
+            expect(result.nextToken).toBe('next-page');
+            const call = cloudFormationMock.commandCalls(ListTypesCommand)[0];
+            expect(call.args[0].input.NextToken).toBe('token-123');
+        });
+
+        it('should return empty array when no hooks found', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: undefined,
+            });
+
+            const result = await service.listHooks();
+            expect(result.hooks).toEqual([]);
+        });
+
+        it('should throw on API error', async () => {
+            const error = new CloudFormationServiceException({
+                message: 'Service error',
+                $metadata: { httpStatusCode: 500 },
+                name: 'CloudFormationServiceException',
+                $fault: 'server',
+            });
+            cloudFormationMock.on(ListTypesCommand).rejects(error);
+
+            await expect(service.listHooks()).rejects.toThrow(error);
+        });
+    });
+
+    describe('describeHook()', () => {
+        it('should call DescribeTypeCommand with typeName', async () => {
+            cloudFormationMock.on(DescribeTypeCommand).resolves({
+                TypeName: 'Private::Guard::S3Check',
+                Arn: 'arn:aws:...',
+                Description: 'Checks S3 encryption',
+                Schema: '{}',
+                Visibility: 'PRIVATE',
+            });
+
+            const result = await service.describeHook({ typeName: 'Private::Guard::S3Check' });
+
+            expect(result.TypeName).toBe('Private::Guard::S3Check');
+            const call = cloudFormationMock.commandCalls(DescribeTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+            });
+        });
+
+        it('should call DescribeTypeCommand with arn', async () => {
+            cloudFormationMock.on(DescribeTypeCommand).resolves({
+                TypeName: 'Private::Guard::S3Check',
+                Arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+
+            const result = await service.describeHook({
+                arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+
+            expect(result.TypeName).toBe('Private::Guard::S3Check');
+            const call = cloudFormationMock.commandCalls(DescribeTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                Arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+        });
+
+        it('should throw on API error', async () => {
+            const error = new CloudFormationServiceException({
+                message: 'Type not found',
+                $metadata: { httpStatusCode: 404 },
+                name: 'TypeNotFoundException',
+                $fault: 'client',
+            });
+            cloudFormationMock.on(DescribeTypeCommand).rejects(error);
+
+            await expect(service.describeHook({ typeName: 'NonExistent' })).rejects.toThrow(error);
+        });
+    });
+
+    describe('setHookConfiguration()', () => {
+        it('should call SetTypeConfigurationCommand with correct params', async () => {
+            cloudFormationMock.on(SetTypeConfigurationCommand).resolves({
+                ConfigurationArn: 'arn:aws:cloudformation:us-east-1:123:type-configuration/hook/Private-Guard-S3Check',
+            });
+
+            const result = await service.setHookConfiguration({
+                typeName: 'Private::Guard::S3Check',
+                configuration: '{"CloudFormationConfiguration":{"HookConfiguration":{"FailureMode":"WARN"}}}',
+            });
+
+            expect(result.ConfigurationArn).toBeDefined();
+            const call = cloudFormationMock.commandCalls(SetTypeConfigurationCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+                Configuration: '{"CloudFormationConfiguration":{"HookConfiguration":{"FailureMode":"WARN"}}}',
+            });
+        });
+    });
+
+    describe('deactivateHook()', () => {
+        it('should call DeactivateTypeCommand with typeName', async () => {
+            cloudFormationMock.on(DeactivateTypeCommand).resolves({});
+
+            await service.deactivateHook({ typeName: 'Private::Guard::S3Check' });
+
+            const call = cloudFormationMock.commandCalls(DeactivateTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+            });
+        });
+
+        it('should call DeactivateTypeCommand with arn', async () => {
+            cloudFormationMock.on(DeactivateTypeCommand).resolves({});
+
+            await service.deactivateHook({ arn: 'arn:aws:...' });
+
+            const call = cloudFormationMock.commandCalls(DeactivateTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Arn: 'arn:aws:...',
+            });
+        });
+    });
+});

--- a/tst/unit/hooks/ControlCatalogService.test.ts
+++ b/tst/unit/hooks/ControlCatalogService.test.ts
@@ -1,0 +1,85 @@
+import { ControlCatalogClient, ListControlsCommand } from '@aws-sdk/client-controlcatalog';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { ControlCatalogService } from '../../../src/services/ControlCatalogService';
+
+const controlCatalogMock = mockClient(ControlCatalogClient);
+const mockGetControlCatalogClient = vi.fn();
+
+const mockClientComponent = {
+    getControlCatalogClient: mockGetControlCatalogClient,
+} as unknown as AwsClient;
+
+describe('ControlCatalogService', () => {
+    let service: ControlCatalogService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        controlCatalogMock.reset();
+        mockGetControlCatalogClient.mockReturnValue(new ControlCatalogClient({}));
+        service = new ControlCatalogService(mockClientComponent);
+    });
+
+    it('returns only PROACTIVE controls that have a CT. alias, mapped and sorted', async () => {
+        controlCatalogMock.on(ListControlsCommand).resolves({
+            Controls: [
+                {
+                    Behavior: 'PROACTIVE',
+                    Name: 'Require encryption',
+                    Aliases: ['CT.S3.PR.2', 'OTHER'],
+                    GovernedResources: ['AWS::S3::Bucket'],
+                },
+                { Behavior: 'DETECTIVE', Name: 'Detective control', Aliases: ['CT.S3.DR.1'] },
+                { Behavior: 'PROACTIVE', Name: 'No CT alias', Aliases: ['SH.S3.1'] },
+                {
+                    Behavior: 'PROACTIVE',
+                    Name: 'Require versioning',
+                    Aliases: ['CT.S3.PR.1'],
+                    GovernedResources: ['AWS::S3::Bucket'],
+                },
+            ] as never,
+        });
+
+        const result = await service.listProactiveControls();
+
+        expect(result).toEqual([
+            { controlId: 'CT.S3.PR.1', name: 'Require versioning', resource: 'AWS::S3::Bucket' },
+            { controlId: 'CT.S3.PR.2', name: 'Require encryption', resource: 'AWS::S3::Bucket' },
+        ]);
+    });
+
+    it('paginates across NextToken', async () => {
+        controlCatalogMock
+            .on(ListControlsCommand, { NextToken: undefined })
+            .resolves({
+                Controls: [{ Behavior: 'PROACTIVE', Name: 'A', Aliases: ['CT.A.1'] }] as never,
+                NextToken: 'page2',
+            })
+            .on(ListControlsCommand, { NextToken: 'page2' })
+            .resolves({
+                Controls: [{ Behavior: 'PROACTIVE', Name: 'B', Aliases: ['CT.B.1'] }] as never,
+            });
+
+        const result = await service.listProactiveControls();
+
+        expect(result.map((c) => c.controlId)).toEqual(['CT.A.1', 'CT.B.1']);
+        expect(controlCatalogMock.commandCalls(ListControlsCommand)).toHaveLength(2);
+    });
+
+    it('falls back to the control id when Name is missing', async () => {
+        controlCatalogMock.on(ListControlsCommand).resolves({
+            Controls: [{ Behavior: 'PROACTIVE', Aliases: ['CT.X.1'] }] as never,
+        });
+
+        const result = await service.listProactiveControls();
+
+        expect(result).toEqual([{ controlId: 'CT.X.1', name: 'CT.X.1', resource: undefined }]);
+    });
+
+    it('propagates API errors', async () => {
+        controlCatalogMock.on(ListControlsCommand).rejects(new Error('boom'));
+
+        await expect(service.listProactiveControls()).rejects.toThrow('boom');
+    });
+});

--- a/tst/unit/hooks/GuardHookPreview.test.ts
+++ b/tst/unit/hooks/GuardHookPreview.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DiagnosticSeverity } from 'vscode-languageserver';
+import { previewGuardHooks, isPreviewableGuardHook } from '../../../src/hooks/GuardHookPreview';
+import { DetailedHook } from '../../../src/hooks/HooksRequestType';
+
+function hook(overrides: Partial<DetailedHook> = {}): DetailedHook {
+    return {
+        typeName: 'Private::Guard::S3',
+        typeArn: 'arn:hook',
+        configured: true,
+        invocationStatus: 'ENABLED',
+        ruleUri: 's3://bucket/rule.guard',
+        ...overrides,
+    };
+}
+
+describe('isPreviewableGuardHook', () => {
+    it('is true only for configured, ENABLED hooks with a rule uri', () => {
+        expect(isPreviewableGuardHook(hook())).toBe(true);
+        expect(isPreviewableGuardHook(hook({ invocationStatus: 'DISABLED' }))).toBe(false);
+        expect(isPreviewableGuardHook(hook({ configured: false }))).toBe(false);
+        expect(isPreviewableGuardHook(hook({ ruleUri: undefined }))).toBe(false);
+    });
+});
+
+describe('previewGuardHooks', () => {
+    it('runs each previewable hook rule against the template and reports pass/fail', async () => {
+        const validateTemplate = vi
+            .fn()
+            .mockReturnValueOnce([])
+            .mockReturnValueOnce([
+                {
+                    ruleName: 'encryption',
+                    message: 'must encrypt',
+                    severity: DiagnosticSeverity.Error,
+                    location: { line: 3, column: 5, path: 'Resources/Bucket' },
+                },
+            ]);
+        const fetchRuleContent = vi.fn().mockResolvedValue('rule r { ... }');
+        const deps = {
+            listHooksDetailed: () =>
+                Promise.resolve([
+                    hook({ typeName: 'Private::Guard::A', ruleUri: 's3://b/a.guard' }),
+                    hook({ typeName: 'Private::Guard::B', ruleUri: 's3://b/b.guard', failureMode: 'FAIL' }),
+                    hook({ typeName: 'Private::Guard::Disabled', invocationStatus: 'DISABLED' }),
+                ]),
+            fetchRuleContent,
+            validateTemplate,
+        };
+
+        const result = await previewGuardHooks(deps, '{"Resources":{}}');
+
+        expect(result.hooks).toHaveLength(2);
+        expect(fetchRuleContent).toHaveBeenCalledTimes(2);
+        expect(result.hooks[0]).toEqual({
+            typeName: 'Private::Guard::A',
+            ruleUri: 's3://b/a.guard',
+            failureMode: undefined,
+            valid: true,
+            violations: [],
+        });
+        expect(result.hooks[1].valid).toBe(false);
+        expect(result.hooks[1].violations).toEqual([
+            { ruleName: 'encryption', message: 'must encrypt', line: 3, column: 5, path: 'Resources/Bucket' },
+        ]);
+    });
+
+    it('uses Warning severity for WARN-mode hooks', async () => {
+        const validateTemplate = vi.fn().mockReturnValue([]);
+        const deps = {
+            listHooksDetailed: () => Promise.resolve([hook({ failureMode: 'WARN' })]),
+            fetchRuleContent: () => Promise.resolve('rule r { ... }'),
+            validateTemplate,
+        };
+        await previewGuardHooks(deps, '{}');
+        expect(validateTemplate).toHaveBeenCalledWith('{}', expect.any(Array), DiagnosticSeverity.Warning);
+    });
+
+    it('captures an error per hook without failing the whole preview', async () => {
+        const deps = {
+            listHooksDetailed: () => Promise.resolve([hook()]),
+            fetchRuleContent: () => Promise.reject(new Error('S3 access denied')),
+            validateTemplate: vi.fn(),
+        };
+        const result = await previewGuardHooks(deps, '{}');
+        expect(result.hooks[0].valid).toBe(false);
+        expect(result.hooks[0].error).toContain('S3 access denied');
+        expect(deps.validateTemplate).not.toHaveBeenCalled();
+    });
+
+    it('returns no entries when there are no previewable hooks', async () => {
+        const result = await previewGuardHooks(
+            {
+                listHooksDetailed: () => Promise.resolve([hook({ configured: false })]),
+                fetchRuleContent: vi.fn(),
+                validateTemplate: vi.fn(),
+            },
+            '{}',
+        );
+        expect(result.hooks).toEqual([]);
+    });
+});

--- a/tst/unit/hooks/HookCache.test.ts
+++ b/tst/unit/hooks/HookCache.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HookCache, TtlCache } from '../../../src/hooks/HookCache';
+
+describe('TtlCache', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('loads and caches a value within the TTL', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValue('v1');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads after the TTL expires', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValueOnce('v1').mockResolvedValueOnce('v2');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        clock += 101;
+        expect(await cache.get('k', loader)).toBe('v2');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('reloads when the clock reaches expiresAt (exclusive upper bound)', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValueOnce('v1').mockResolvedValueOnce('v2');
+
+        expect(await cache.get('k', loader)).toBe('v1');
+        clock += 99;
+        expect(await cache.get('k', loader)).toBe('v1');
+        expect(loader).toHaveBeenCalledTimes(1);
+        clock += 1;
+        expect(await cache.get('k', loader)).toBe('v2');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('deduplicates concurrent loads for the same key', async () => {
+        const cache = new TtlCache<string>(100, now);
+        let resolveLoad!: (v: string) => void;
+        const loader = vi.fn().mockReturnValue(new Promise<string>((resolve) => (resolveLoad = resolve)));
+
+        const a = cache.get('k', loader);
+        const b = cache.get('k', loader);
+        resolveLoad('shared');
+
+        expect(await a).toBe('shared');
+        expect(await b).toBe('shared');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a failed load and retries next time', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce('ok');
+
+        await expect(cache.get('k', loader)).rejects.toThrow('boom');
+        expect(await cache.get('k', loader)).toBe('ok');
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('peek returns unexpired values only', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('k', () => Promise.resolve('v1'));
+
+        expect(cache.peek('k')).toBe('v1');
+        clock += 101;
+        expect(cache.peek('k')).toBeUndefined();
+        expect(cache.peek('missing')).toBeUndefined();
+    });
+
+    it('set stores a value with a fresh TTL', () => {
+        const cache = new TtlCache<string>(100, now);
+        cache.set('k', 'v1');
+        expect(cache.peek('k')).toBe('v1');
+    });
+
+    it('invalidate removes a single key', async () => {
+        const cache = new TtlCache<string>(100, now);
+        const loader = vi.fn().mockResolvedValue('v1');
+        await cache.get('k', loader);
+        cache.invalidate('k');
+        await cache.get('k', loader);
+        expect(loader).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidate during an in-flight load does not cache the resolved value', async () => {
+        const cache = new TtlCache<string>(100, now);
+        let resolveLoad!: (v: string) => void;
+        const loader = vi.fn().mockReturnValue(new Promise<string>((resolve) => (resolveLoad = resolve)));
+
+        const pending = cache.get('k', loader);
+        cache.invalidate('k');
+        resolveLoad('stale');
+        await pending;
+
+        expect(cache.peek('k')).toBeUndefined();
+    });
+
+    it('clear removes all keys', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('a', () => Promise.resolve('1'));
+        await cache.get('b', () => Promise.resolve('2'));
+        cache.clear();
+        expect(cache.size).toBe(0);
+    });
+
+    it('size counts only unexpired entries', async () => {
+        const cache = new TtlCache<string>(100, now);
+        await cache.get('a', () => Promise.resolve('1'));
+        expect(cache.size).toBe(1);
+        clock += 101;
+        expect(cache.size).toBe(0);
+    });
+});
+
+describe('HookCache', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('caches hook configuration by type name', async () => {
+        const cache = new HookCache(100, now);
+        const loader = vi.fn().mockResolvedValue('{"cfg":1}');
+
+        expect(await cache.getConfiguration('Private::Guard::A', loader)).toBe('{"cfg":1}');
+        expect(await cache.getConfiguration('Private::Guard::A', loader)).toBe('{"cfg":1}');
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches rule content by S3 URI independently of config', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule R {}');
+
+        await cache.getConfiguration('T', cfgLoader);
+        expect(await cache.getRuleContent('s3://b/r.guard', ruleLoader)).toBe('rule R {}');
+        expect(await cache.getRuleContent('s3://b/r.guard', ruleLoader)).toBe('rule R {}');
+        expect(ruleLoader).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateHook forces a config reload but keeps rules', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateHook('T');
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+
+        expect(cfgLoader).toHaveBeenCalledTimes(2);
+        expect(ruleLoader).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidateRule forces a rule reload', async () => {
+        const cache = new HookCache(100, now);
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateRule('s3://b/r');
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        expect(ruleLoader).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidateAll clears both configs and rules', async () => {
+        const cache = new HookCache(100, now);
+        const cfgLoader = vi.fn().mockResolvedValue('cfg');
+        const ruleLoader = vi.fn().mockResolvedValue('rule');
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        cache.invalidateAll();
+        await cache.getConfiguration('T', cfgLoader);
+        await cache.getRuleContent('s3://b/r', ruleLoader);
+        expect(cfgLoader).toHaveBeenCalledTimes(2);
+        expect(ruleLoader).toHaveBeenCalledTimes(2);
+    });
+
+    it('peek helpers return cached values without loading', async () => {
+        const cache = new HookCache(100, now);
+        await cache.getConfiguration('T', () => Promise.resolve('cfg'));
+        expect(cache.peekConfiguration('T')).toBe('cfg');
+        expect(cache.peekRuleContent('s3://none')).toBeUndefined();
+    });
+});
+
+describe('TtlCache pruning', () => {
+    let clock: number;
+    const now = () => clock;
+
+    beforeEach(() => {
+        clock = 1000;
+    });
+
+    it('evicts expired entries on write so the map does not retain stale keys', () => {
+        const cache = new TtlCache<string>(100, now);
+        cache.set('a', 'va');
+        cache.set('b', 'vb');
+        expect(cache.size).toBe(2);
+
+        clock += 200;
+        cache.set('c', 'vc');
+
+        expect(cache.size).toBe(1);
+        expect(cache.peek('a')).toBeUndefined();
+        expect(cache.peek('b')).toBeUndefined();
+        expect(cache.peek('c')).toBe('vc');
+    });
+});

--- a/tst/unit/hooks/HooksManager.test.ts
+++ b/tst/unit/hooks/HooksManager.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { HooksManager, parseHookConfiguration } from '../../../src/hooks/HooksManager';
+import { CfnService } from '../../../src/services/CfnService';
+
+describe('HooksManager', () => {
+    let manager: HooksManager;
+    let mockCfnService: { listHooks: ReturnType<typeof vi.fn>; describeHook: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        mockCfnService = {
+            listHooks: vi.fn(),
+            describeHook: vi.fn(),
+        };
+        manager = new HooksManager(mockCfnService as unknown as CfnService);
+    });
+
+    describe('listHooks()', () => {
+        it('should fetch hooks from CfnService on initial call', async () => {
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Private::Guard::S3Check', TypeArn: 'arn:aws:...' }],
+                nextToken: undefined,
+            });
+
+            const result = await manager.listHooks();
+
+            expect(result.hooks).toHaveLength(1);
+            expect(result.hooks[0].typeName).toBe('Private::Guard::S3Check');
+            expect(mockCfnService.listHooks).toHaveBeenCalledOnce();
+        });
+
+        it('should clear cache and refetch when loadMore is false', async () => {
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: 'token-1',
+            });
+
+            await manager.listHooks();
+
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook2', TypeArn: 'arn:2' }],
+                nextToken: undefined,
+            });
+
+            const result = await manager.listHooks(false);
+
+            expect(result.hooks).toHaveLength(1);
+            expect(result.hooks[0].typeName).toBe('Hook2');
+        });
+
+        it('should append to cache when loadMore is true', async () => {
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: 'token-1',
+            });
+
+            await manager.listHooks();
+
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook2', TypeArn: 'arn:2' }],
+                nextToken: undefined,
+            });
+
+            const result = await manager.listHooks(true);
+
+            expect(result.hooks).toHaveLength(2);
+            expect(result.hooks[0].typeName).toBe('Hook1');
+            expect(result.hooks[1].typeName).toBe('Hook2');
+        });
+
+        it('should pass nextToken when loading more', async () => {
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: 'page-2-token',
+            });
+
+            await manager.listHooks();
+
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook2', TypeArn: 'arn:2' }],
+                nextToken: undefined,
+            });
+
+            await manager.listHooks(true);
+
+            expect(mockCfnService.listHooks).toHaveBeenLastCalledWith('page-2-token');
+        });
+
+        it('should deduplicate hooks by TypeName', async () => {
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [
+                    { TypeName: 'Hook1', TypeArn: 'arn:1' },
+                    { TypeName: 'Hook1', TypeArn: 'arn:1-duplicate' },
+                ],
+                nextToken: undefined,
+            });
+
+            const result = await manager.listHooks();
+            expect(result.hooks).toHaveLength(1);
+        });
+
+        it('should return nextToken from response', async () => {
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: 'has-more',
+            });
+
+            const result = await manager.listHooks();
+            expect(result.nextToken).toBe('has-more');
+        });
+    });
+
+    describe('describeHook()', () => {
+        it('should fetch hook details from CfnService', async () => {
+            mockCfnService.describeHook.mockResolvedValue({
+                TypeName: 'Private::Guard::S3Check',
+                Arn: 'arn:aws:...',
+                Description: 'Checks S3 encryption',
+                Visibility: 'PRIVATE',
+            });
+
+            const result = await manager.describeHook({ typeName: 'Private::Guard::S3Check' });
+
+            expect(result.typeName).toBe('Private::Guard::S3Check');
+            expect(result.description).toBe('Checks S3 encryption');
+        });
+
+        it('should cache describe results and not call service again', async () => {
+            mockCfnService.describeHook.mockResolvedValue({
+                TypeName: 'Private::Guard::S3Check',
+                Arn: 'arn:aws:...',
+                Visibility: 'PRIVATE',
+            });
+
+            await manager.describeHook({ typeName: 'Private::Guard::S3Check' });
+            await manager.describeHook({ typeName: 'Private::Guard::S3Check' });
+
+            expect(mockCfnService.describeHook).toHaveBeenCalledOnce();
+        });
+
+        it('should fetch separately for different hooks', async () => {
+            mockCfnService.describeHook.mockResolvedValue({
+                TypeName: 'Hook1',
+                Arn: 'arn:1',
+                Visibility: 'PRIVATE',
+            });
+
+            await manager.describeHook({ typeName: 'Hook1' });
+            await manager.describeHook({ typeName: 'Hook2' });
+
+            expect(mockCfnService.describeHook).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('describeHook() with persistent schema store', () => {
+        let schemaStore: { get: ReturnType<typeof vi.fn>; put: ReturnType<typeof vi.fn> };
+
+        beforeEach(() => {
+            schemaStore = {
+                get: vi.fn(),
+                put: vi.fn().mockResolvedValue(undefined),
+            };
+            manager = new HooksManager(
+                mockCfnService as unknown as CfnService,
+                schemaStore as unknown as import('../../../src/hooks/HookSchemaStore').HookSchemaStore,
+            );
+        });
+
+        it('should return persisted schema if not stale (skips service call)', async () => {
+            schemaStore.get.mockReturnValue({
+                version: 'v1',
+                typeName: 'Hook1',
+                schema: { typeName: 'Hook1', arn: 'arn:1', visibility: 'PRIVATE' },
+                firstCreatedMs: Date.now(),
+                lastModifiedMs: Date.now(),
+            });
+
+            const result = await manager.describeHook({ typeName: 'Hook1' });
+
+            expect(result.typeName).toBe('Hook1');
+            expect(mockCfnService.describeHook).not.toHaveBeenCalled();
+        });
+
+        it('should refetch and update store when persisted record is stale', async () => {
+            const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+            schemaStore.get.mockReturnValue({
+                version: 'v1',
+                typeName: 'Hook1',
+                schema: { typeName: 'Hook1', arn: 'arn:old', visibility: 'PRIVATE' },
+                firstCreatedMs: eightDaysAgo,
+                lastModifiedMs: eightDaysAgo,
+            });
+            mockCfnService.describeHook.mockResolvedValue({
+                TypeName: 'Hook1',
+                Arn: 'arn:new',
+                Visibility: 'PRIVATE',
+            });
+
+            const result = await manager.describeHook({ typeName: 'Hook1' });
+
+            expect(result.arn).toBe('arn:new');
+            expect(mockCfnService.describeHook).toHaveBeenCalledOnce();
+            expect(schemaStore.put).toHaveBeenCalledOnce();
+        });
+
+        it('should fetch and persist when no record exists', async () => {
+            schemaStore.get.mockReturnValue(undefined);
+            mockCfnService.describeHook.mockResolvedValue({
+                TypeName: 'Hook1',
+                Arn: 'arn:1',
+                Visibility: 'PRIVATE',
+            });
+
+            await manager.describeHook({ typeName: 'Hook1' });
+
+            expect(mockCfnService.describeHook).toHaveBeenCalledOnce();
+            expect(schemaStore.put).toHaveBeenCalledWith(
+                'Hook1',
+                expect.objectContaining({ typeName: 'Hook1', arn: 'arn:1' }),
+            );
+        });
+    });
+
+    describe('clearCache()', () => {
+        it('should clear hooks cache so next call refetches', async () => {
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: undefined,
+            });
+
+            await manager.listHooks();
+            manager.clearCache();
+
+            mockCfnService.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook2', TypeArn: 'arn:2' }],
+                nextToken: undefined,
+            });
+
+            const result = await manager.listHooks();
+            expect(result.hooks[0].typeName).toBe('Hook2');
+            expect(mockCfnService.listHooks).toHaveBeenCalledTimes(2);
+        });
+
+        it('should clear describe cache so next call refetches', async () => {
+            mockCfnService.describeHook.mockResolvedValue({
+                TypeName: 'Hook1',
+                Arn: 'arn:1',
+                Visibility: 'PRIVATE',
+            });
+
+            await manager.describeHook({ typeName: 'Hook1' });
+            manager.clearCache();
+            await manager.describeHook({ typeName: 'Hook1' });
+
+            expect(mockCfnService.describeHook).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('parseHookConfiguration()', () => {
+        it('returns configured=false for empty config', () => {
+            expect(parseHookConfiguration('{}').configured).toBe(false);
+            expect(parseHookConfiguration('{"CloudFormationConfiguration":{"HookConfiguration":{}}}').configured).toBe(
+                false,
+            );
+        });
+
+        it('returns configured=false for invalid JSON', () => {
+            expect(parseHookConfiguration('not json').configured).toBe(false);
+        });
+
+        it('extracts failure mode, status, and target operations', () => {
+            const raw = JSON.stringify({
+                CloudFormationConfiguration: {
+                    HookConfiguration: {
+                        FailureMode: 'FAIL',
+                        HookInvocationStatus: 'ENABLED',
+                        TargetOperations: ['RESOURCE', 'STACK'],
+                    },
+                },
+            });
+            const parsed = parseHookConfiguration(raw);
+            expect(parsed.configured).toBe(true);
+            expect(parsed.failureMode).toBe('FAIL');
+            expect(parsed.invocationStatus).toBe('ENABLED');
+            expect(parsed.targetOperations).toEqual(['RESOURCE', 'STACK']);
+        });
+
+        it('extracts ruleLocation as an object', () => {
+            const raw = JSON.stringify({
+                CloudFormationConfiguration: {
+                    HookConfiguration: { Properties: { ruleLocation: { uri: 's3://b/r.guard' } } },
+                },
+            });
+            expect(parseHookConfiguration(raw).ruleUri).toBe('s3://b/r.guard');
+        });
+
+        it('extracts ruleLocation as a bare string', () => {
+            const raw = JSON.stringify({
+                CloudFormationConfiguration: {
+                    HookConfiguration: { Properties: { ruleLocation: 's3://b/r.guard' } },
+                },
+            });
+            expect(parseHookConfiguration(raw).ruleUri).toBe('s3://b/r.guard');
+        });
+    });
+
+    describe('listHooksDetailed()', () => {
+        let detailedManager: HooksManager;
+        let detailedMock: {
+            listHooks: ReturnType<typeof vi.fn>;
+            describeHook: ReturnType<typeof vi.fn>;
+            getHookConfiguration: ReturnType<typeof vi.fn>;
+        };
+
+        beforeEach(() => {
+            detailedMock = {
+                listHooks: vi.fn(),
+                describeHook: vi.fn(),
+                getHookConfiguration: vi.fn(),
+            };
+            detailedManager = new HooksManager(detailedMock as unknown as CfnService);
+        });
+
+        it('merges configuration into each listed hook', async () => {
+            detailedMock.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Private::Guard::A', TypeArn: 'arn:a' }],
+                nextToken: undefined,
+            });
+            detailedMock.getHookConfiguration.mockResolvedValue(
+                JSON.stringify({
+                    CloudFormationConfiguration: {
+                        HookConfiguration: {
+                            FailureMode: 'WARN',
+                            HookInvocationStatus: 'ENABLED',
+                            TargetOperations: ['RESOURCE'],
+                            Properties: { ruleLocation: { uri: 's3://b/a.guard' } },
+                        },
+                    },
+                }),
+            );
+
+            const result = await detailedManager.listHooksDetailed();
+
+            expect(result.hooks).toHaveLength(1);
+            expect(result.hooks[0]).toMatchObject({
+                typeName: 'Private::Guard::A',
+                configured: true,
+                failureMode: 'WARN',
+                invocationStatus: 'ENABLED',
+                targetOperations: ['RESOURCE'],
+                ruleUri: 's3://b/a.guard',
+            });
+        });
+
+        it('marks a hook unconfigured when config is empty', async () => {
+            detailedMock.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: undefined,
+            });
+            detailedMock.getHookConfiguration.mockResolvedValue('{}');
+
+            const result = await detailedManager.listHooksDetailed();
+            expect(result.hooks[0].configured).toBe(false);
+        });
+
+        it('degrades gracefully when configuration fetch fails', async () => {
+            detailedMock.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: undefined,
+            });
+            detailedMock.getHookConfiguration.mockRejectedValue(new Error('access denied'));
+
+            const result = await detailedManager.listHooksDetailed();
+            expect(result.hooks[0].configured).toBe(false);
+            expect(result.hooks[0].failureMode).toBeUndefined();
+        });
+
+        it('caches configuration across repeated detailed listings', async () => {
+            detailedMock.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: undefined,
+            });
+            detailedMock.getHookConfiguration.mockResolvedValue('{}');
+
+            await detailedManager.listHooksDetailed();
+            await detailedManager.listHooksDetailed();
+
+            expect(detailedMock.getHookConfiguration).toHaveBeenCalledTimes(1);
+        });
+
+        it('refetches configuration after clearCache', async () => {
+            detailedMock.listHooks.mockResolvedValue({
+                hooks: [{ TypeName: 'Hook1', TypeArn: 'arn:1' }],
+                nextToken: undefined,
+            });
+            detailedMock.getHookConfiguration.mockResolvedValue('{}');
+
+            await detailedManager.listHooksDetailed();
+            detailedManager.clearCache();
+            await detailedManager.listHooksDetailed();
+
+            expect(detailedMock.getHookConfiguration).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/tst/unit/hooks/HooksParser.test.ts
+++ b/tst/unit/hooks/HooksParser.test.ts
@@ -1,0 +1,381 @@
+import { describe, it, expect } from 'vitest';
+import {
+    parseListHooksParams,
+    parseDescribeHookParams,
+    parseListHookResultsParams,
+    parseGetHookResultParams,
+    parseConfigureHookParams,
+    parseDeactivateHookParams,
+    parseActivateHookParams,
+    parseSetHookConfigurationParams,
+    parseSetInvocationStatusParams,
+    parseCreateGuardHookParams,
+    parseCreateHookExecutionRoleParams,
+    parseCreateS3BucketParams,
+    parseGetHookConfigurationParams,
+    parseGetRuleContentParams,
+    parseValidateRuleParams,
+    parseUploadRuleParams,
+    parsePreviewGuardHooksParams,
+} from '../../../src/hooks/HooksParser';
+
+describe('HooksParser', () => {
+    describe('parseListHooksParams', () => {
+        it('should accept empty params', () => {
+            expect(parseListHooksParams({})).toEqual({});
+        });
+
+        it('should accept loadMore as true', () => {
+            expect(parseListHooksParams({ loadMore: true })).toEqual({ loadMore: true });
+        });
+
+        it('should accept loadMore as false', () => {
+            expect(parseListHooksParams({ loadMore: false })).toEqual({ loadMore: false });
+        });
+
+        it('should reject unknown properties', () => {
+            expect(() => parseListHooksParams({ loadMore: true, unknown: 'value' })).toThrow();
+        });
+    });
+
+    describe('parseDescribeHookParams', () => {
+        it('should accept typeName only', () => {
+            const result = parseDescribeHookParams({ typeName: 'Private::Guard::S3Check' });
+            expect(result).toEqual({ typeName: 'Private::Guard::S3Check' });
+        });
+
+        it('should accept arn only', () => {
+            const result = parseDescribeHookParams({
+                arn: 'arn:aws:cloudformation:us-east-1:123456789:type/hook/Private-Guard-S3Check',
+            });
+            expect(result).toEqual({
+                arn: 'arn:aws:cloudformation:us-east-1:123456789:type/hook/Private-Guard-S3Check',
+            });
+        });
+
+        it('should accept both typeName and arn', () => {
+            const result = parseDescribeHookParams({ typeName: 'Private::Guard::S3Check', arn: 'arn:aws:...' });
+            expect(result).toEqual({ typeName: 'Private::Guard::S3Check', arn: 'arn:aws:...' });
+        });
+
+        it('should reject when neither typeName nor arn is provided', () => {
+            expect(() => parseDescribeHookParams({})).toThrow();
+        });
+
+        it('should reject empty typeName with no arn', () => {
+            expect(() => parseDescribeHookParams({ typeName: '' })).toThrow();
+        });
+
+        it('should reject whitespace-only typeName with no arn', () => {
+            expect(() => parseDescribeHookParams({ typeName: ' '.repeat(3) })).toThrow();
+        });
+    });
+
+    describe('parseListHookResultsParams', () => {
+        it('should accept empty params (list all results)', () => {
+            expect(parseListHookResultsParams({})).toEqual({});
+        });
+
+        it('should accept typeArn filter', () => {
+            const result = parseListHookResultsParams({ typeArn: 'arn:aws:...' });
+            expect(result).toEqual({ typeArn: 'arn:aws:...' });
+        });
+
+        it('should accept valid targetType CHANGE_SET', () => {
+            const result = parseListHookResultsParams({ targetType: 'CHANGE_SET' });
+            expect(result).toEqual({ targetType: 'CHANGE_SET' });
+        });
+
+        it('should accept valid targetType STACK', () => {
+            const result = parseListHookResultsParams({ targetType: 'STACK' });
+            expect(result).toEqual({ targetType: 'STACK' });
+        });
+
+        it('should accept valid targetType RESOURCE', () => {
+            const result = parseListHookResultsParams({ targetType: 'RESOURCE' });
+            expect(result).toEqual({ targetType: 'RESOURCE' });
+        });
+
+        it('should accept valid targetType CLOUD_CONTROL', () => {
+            const result = parseListHookResultsParams({ targetType: 'CLOUD_CONTROL' });
+            expect(result).toEqual({ targetType: 'CLOUD_CONTROL' });
+        });
+
+        it('should reject invalid targetType', () => {
+            expect(() => parseListHookResultsParams({ targetType: 'INVALID' })).toThrow();
+        });
+
+        it('should accept nextToken for pagination', () => {
+            const result = parseListHookResultsParams({ nextToken: 'abc123' });
+            expect(result).toEqual({ nextToken: 'abc123' });
+        });
+
+        it('should accept combined filters', () => {
+            const result = parseListHookResultsParams({
+                typeArn: 'arn:aws:...',
+                status: 'HOOK_COMPLETE_FAILED',
+                targetType: 'STACK',
+            });
+            expect(result).toEqual({
+                typeArn: 'arn:aws:...',
+                status: 'HOOK_COMPLETE_FAILED',
+                targetType: 'STACK',
+            });
+        });
+    });
+
+    describe('parseGetHookResultParams', () => {
+        it('should accept valid hookResultId', () => {
+            const result = parseGetHookResultParams({ hookResultId: 'result-123-abc' });
+            expect(result).toEqual({ hookResultId: 'result-123-abc' });
+        });
+
+        it('should reject missing hookResultId', () => {
+            expect(() => parseGetHookResultParams({})).toThrow();
+        });
+
+        it('should reject empty hookResultId', () => {
+            expect(() => parseGetHookResultParams({ hookResultId: '' })).toThrow();
+        });
+
+        it('should reject whitespace-only hookResultId', () => {
+            expect(() => parseGetHookResultParams({ hookResultId: ' '.repeat(3) })).toThrow();
+        });
+    });
+
+    describe('parseConfigureHookParams', () => {
+        it('should accept valid typeName and failureMode', () => {
+            const result = parseConfigureHookParams({
+                typeName: 'Private::Guard::S3Check',
+                failureMode: 'FAIL',
+            });
+            expect(result).toEqual({
+                typeName: 'Private::Guard::S3Check',
+                failureMode: 'FAIL',
+            });
+        });
+
+        it('should accept WARN failureMode', () => {
+            const result = parseConfigureHookParams({
+                typeName: 'Private::Guard::S3Check',
+                failureMode: 'WARN',
+            });
+            expect(result.failureMode).toBe('WARN');
+        });
+
+        it('should reject missing typeName', () => {
+            expect(() => parseConfigureHookParams({ failureMode: 'FAIL' })).toThrow();
+        });
+
+        it('should reject empty typeName', () => {
+            expect(() => parseConfigureHookParams({ typeName: '', failureMode: 'FAIL' })).toThrow();
+        });
+
+        it('should reject missing failureMode', () => {
+            expect(() => parseConfigureHookParams({ typeName: 'Private::Guard::S3Check' })).toThrow();
+        });
+
+        it('should reject invalid failureMode', () => {
+            expect(() =>
+                parseConfigureHookParams({ typeName: 'Private::Guard::S3Check', failureMode: 'INVALID' }),
+            ).toThrow();
+        });
+    });
+
+    describe('parseDeactivateHookParams', () => {
+        it('should accept typeName', () => {
+            const result = parseDeactivateHookParams({ typeName: 'Private::Guard::S3Check' });
+            expect(result).toEqual({ typeName: 'Private::Guard::S3Check' });
+        });
+
+        it('should accept arn', () => {
+            const result = parseDeactivateHookParams({ arn: 'arn:aws:...' });
+            expect(result).toEqual({ arn: 'arn:aws:...' });
+        });
+
+        it('should reject when neither typeName nor arn is provided', () => {
+            expect(() => parseDeactivateHookParams({})).toThrow();
+        });
+
+        it('should reject empty typeName with no arn', () => {
+            expect(() => parseDeactivateHookParams({ typeName: '' })).toThrow();
+        });
+    });
+
+    describe('parseActivateHookParams', () => {
+        it('should accept typeName only', () => {
+            const result = parseActivateHookParams({ typeName: 'AWS::Hooks::GuardHook' });
+            expect(result).toEqual({ typeName: 'AWS::Hooks::GuardHook' });
+        });
+
+        it('should accept all optional fields', () => {
+            const result = parseActivateHookParams({
+                typeName: 'AWS::Hooks::GuardHook',
+                publisherId: 'pub-123',
+                typeNameAlias: 'Private::Guard::MyHook',
+                executionRoleArn: 'arn:aws:iam::123:role/HookRole',
+            });
+            expect(result.publisherId).toBe('pub-123');
+            expect(result.typeNameAlias).toBe('Private::Guard::MyHook');
+            expect(result.executionRoleArn).toBe('arn:aws:iam::123:role/HookRole');
+        });
+
+        it('should reject missing typeName', () => {
+            expect(() => parseActivateHookParams({})).toThrow();
+        });
+
+        it('should reject empty typeName', () => {
+            expect(() => parseActivateHookParams({ typeName: '' })).toThrow();
+        });
+    });
+
+    describe('parseSetHookConfigurationParams', () => {
+        it('should accept typeName and configuration', () => {
+            const result = parseSetHookConfigurationParams({
+                typeName: 'Private::Guard::S3Check',
+                configuration: '{"CloudFormationConfiguration":{}}',
+            });
+            expect(result).toEqual({
+                typeName: 'Private::Guard::S3Check',
+                configuration: '{"CloudFormationConfiguration":{}}',
+            });
+        });
+
+        it('should reject missing typeName', () => {
+            expect(() => parseSetHookConfigurationParams({ configuration: '{}' })).toThrow();
+        });
+
+        it('should reject empty typeName', () => {
+            expect(() => parseSetHookConfigurationParams({ typeName: '', configuration: '{}' })).toThrow();
+        });
+
+        it('should reject missing configuration', () => {
+            expect(() => parseSetHookConfigurationParams({ typeName: 'Hook' })).toThrow();
+        });
+
+        it('should reject empty configuration', () => {
+            expect(() => parseSetHookConfigurationParams({ typeName: 'Hook', configuration: '' })).toThrow();
+        });
+    });
+});
+
+describe('HooksParser - additional parsers', () => {
+    describe('parseSetInvocationStatusParams', () => {
+        it('accepts ENABLED/DISABLED', () => {
+            expect(parseSetInvocationStatusParams({ typeName: 'H', invocationStatus: 'ENABLED' })).toEqual({
+                typeName: 'H',
+                invocationStatus: 'ENABLED',
+            });
+        });
+        it('rejects an invalid status', () => {
+            expect(() => parseSetInvocationStatusParams({ typeName: 'H', invocationStatus: 'ON' })).toThrow();
+        });
+        it('rejects a missing typeName', () => {
+            expect(() => parseSetInvocationStatusParams({ invocationStatus: 'ENABLED' })).toThrow();
+        });
+    });
+
+    describe('parseCreateGuardHookParams', () => {
+        const validState = JSON.stringify({
+            Alias: 'Private::Guard::Demo',
+            ExecutionRole: 'arn:aws:iam::123:role/r',
+            FailureMode: 'FAIL',
+            HookStatus: 'ENABLED',
+            RuleLocation: 's3://b/r.guard',
+            TargetOperations: ['STACK'],
+        });
+        it('accepts a well-formed desiredState', () => {
+            expect(parseCreateGuardHookParams({ desiredState: validState })).toEqual({ desiredState: validState });
+        });
+        it('rejects non-JSON desiredState', () => {
+            expect(() => parseCreateGuardHookParams({ desiredState: 'not json' })).toThrow();
+        });
+        it('rejects a JSON array', () => {
+            expect(() => parseCreateGuardHookParams({ desiredState: '[]' })).toThrow();
+        });
+        it('rejects when a required key is missing', () => {
+            const missing = JSON.stringify({ Alias: 'A', ExecutionRole: 'r', FailureMode: 'FAIL' });
+            expect(() => parseCreateGuardHookParams({ desiredState: missing })).toThrow();
+        });
+    });
+
+    describe('parseCreateHookExecutionRoleParams', () => {
+        it('accepts a valid role name with an optional bucket', () => {
+            expect(parseCreateHookExecutionRoleParams({ roleName: 'my-role_1', ruleBucket: 'b' })).toEqual({
+                roleName: 'my-role_1',
+                ruleBucket: 'b',
+            });
+        });
+        it('rejects a role name with illegal characters', () => {
+            expect(() => parseCreateHookExecutionRoleParams({ roleName: 'bad/name' })).toThrow();
+        });
+    });
+
+    describe('parseCreateS3BucketParams', () => {
+        it('accepts a valid bucket name', () => {
+            expect(parseCreateS3BucketParams({ bucketName: 'my-rule-bucket' })).toEqual({
+                bucketName: 'my-rule-bucket',
+            });
+        });
+        it('rejects uppercase/underscore names', () => {
+            expect(() => parseCreateS3BucketParams({ bucketName: 'My_Bucket' })).toThrow();
+        });
+        it('rejects consecutive dots', () => {
+            expect(() => parseCreateS3BucketParams({ bucketName: 'a..b' })).toThrow();
+        });
+        it('rejects IP-formatted names', () => {
+            expect(() => parseCreateS3BucketParams({ bucketName: '192.168.1.1' })).toThrow();
+        });
+    });
+
+    describe('parseGetHookConfigurationParams', () => {
+        it('accepts a typeName', () => {
+            expect(parseGetHookConfigurationParams({ typeName: 'H' })).toEqual({ typeName: 'H' });
+        });
+        it('rejects empty input', () => {
+            expect(() => parseGetHookConfigurationParams({})).toThrow();
+        });
+    });
+
+    describe('parseGetRuleContentParams', () => {
+        it('accepts an s3Uri', () => {
+            expect(parseGetRuleContentParams({ s3Uri: 's3://b/r.guard' })).toEqual({ s3Uri: 's3://b/r.guard' });
+        });
+        it('rejects an empty s3Uri', () => {
+            expect(() => parseGetRuleContentParams({ s3Uri: '' })).toThrow();
+        });
+    });
+
+    describe('parseValidateRuleParams', () => {
+        it('accepts ruleContent with an optional sampleTemplate', () => {
+            expect(parseValidateRuleParams({ ruleContent: 'rule R {}', sampleTemplate: '{}' })).toEqual({
+                ruleContent: 'rule R {}',
+                sampleTemplate: '{}',
+            });
+        });
+        it('rejects missing ruleContent', () => {
+            expect(() => parseValidateRuleParams({ sampleTemplate: '{}' })).toThrow();
+        });
+    });
+
+    describe('parseUploadRuleParams', () => {
+        it('accepts ruleContent + s3Uri', () => {
+            expect(parseUploadRuleParams({ ruleContent: 'x', s3Uri: 's3://b/r' })).toEqual({
+                ruleContent: 'x',
+                s3Uri: 's3://b/r',
+            });
+        });
+        it('rejects a missing s3Uri', () => {
+            expect(() => parseUploadRuleParams({ ruleContent: 'x' })).toThrow();
+        });
+    });
+
+    describe('parsePreviewGuardHooksParams', () => {
+        it('accepts templateContent', () => {
+            expect(parsePreviewGuardHooksParams({ templateContent: '{}' })).toEqual({ templateContent: '{}' });
+        });
+        it('rejects empty templateContent', () => {
+            expect(() => parsePreviewGuardHooksParams({ templateContent: '' })).toThrow();
+        });
+    });
+});

--- a/tst/unit/hooks/IamService.test.ts
+++ b/tst/unit/hooks/IamService.test.ts
@@ -1,0 +1,104 @@
+import { IAMClient, ListRolesCommand, CreateRoleCommand, PutRolePolicyCommand } from '@aws-sdk/client-iam';
+import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { IamService } from '../../../src/services/IamService';
+
+const iamMock = mockClient(IAMClient);
+const stsMock = mockClient(STSClient);
+const mockGetIamClient = vi.fn();
+const mockGetStsClient = vi.fn();
+
+const mockClientComponent = {
+    getIamClient: mockGetIamClient,
+    getStsClient: mockGetStsClient,
+} as unknown as AwsClient;
+
+describe('IamService', () => {
+    let service: IamService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        iamMock.reset();
+        stsMock.reset();
+        mockGetIamClient.mockReturnValue(new IAMClient({}));
+        mockGetStsClient.mockReturnValue(new STSClient({}));
+        stsMock.on(GetCallerIdentityCommand).resolves({ Account: '123' });
+        service = new IamService(mockClientComponent);
+    });
+
+    describe('listRoles()', () => {
+        it('paginates and maps role name + arn, skipping incomplete roles', async () => {
+            iamMock
+                .on(ListRolesCommand, { Marker: undefined })
+                .resolves({
+                    Roles: [{ RoleName: 'roleA', Arn: 'arn:aws:iam::123:role/roleA' }, { RoleName: 'noArn' }] as never,
+                    IsTruncated: true,
+                    Marker: 'm2',
+                })
+                .on(ListRolesCommand, { Marker: 'm2' })
+                .resolves({
+                    Roles: [{ RoleName: 'roleB', Arn: 'arn:aws:iam::123:role/roleB' }] as never,
+                    IsTruncated: false,
+                });
+
+            const roles = await service.listRoles();
+
+            expect(roles).toEqual([
+                { roleName: 'roleA', arn: 'arn:aws:iam::123:role/roleA' },
+                { roleName: 'roleB', arn: 'arn:aws:iam::123:role/roleB' },
+            ]);
+        });
+    });
+
+    describe('createHookExecutionRole()', () => {
+        it('creates a role with an account-scoped trust policy and no inline policy when no bucket given', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: { Arn: 'arn:aws:iam::123:role/hookRole' } as never });
+
+            const result = await service.createHookExecutionRole('hookRole');
+
+            expect(result).toEqual({ roleName: 'hookRole', arn: 'arn:aws:iam::123:role/hookRole' });
+            expect(iamMock.commandCalls(PutRolePolicyCommand)).toHaveLength(0);
+            const trust = JSON.parse(
+                iamMock.commandCalls(CreateRoleCommand)[0].args[0].input.AssumeRolePolicyDocument as string,
+            );
+            expect(trust.Statement[0].Condition.StringEquals['aws:SourceAccount']).toBe('123');
+            expect(trust.Statement[0].Principal.Service).toBe('hooks.cloudformation.amazonaws.com');
+        });
+
+        it('attaches an inline S3 read policy scoped to the given bucket', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: { Arn: 'arn:aws:iam::123:role/hookRole' } as never });
+            iamMock.on(PutRolePolicyCommand).resolves({});
+
+            await service.createHookExecutionRole('hookRole', 'my-rule-bucket');
+
+            const policyCall = iamMock.commandCalls(PutRolePolicyCommand)[0];
+            const policy = JSON.parse(policyCall.args[0].input.PolicyDocument as string);
+            expect(policy.Statement[0].Resource).toEqual([
+                'arn:aws:s3:::my-rule-bucket',
+                'arn:aws:s3:::my-rule-bucket/*',
+            ]);
+        });
+
+        it('rejects an invalid bucket name before making any AWS calls', async () => {
+            await expect(service.createHookExecutionRole('hookRole', 'Invalid_Bucket!')).rejects.toThrow(
+                /Invalid S3 bucket name/,
+            );
+            expect(iamMock.commandCalls(CreateRoleCommand)).toHaveLength(0);
+            expect(stsMock.commandCalls(GetCallerIdentityCommand)).toHaveLength(0);
+        });
+
+        it('throws when CreateRole returns no ARN', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: {} as never });
+
+            await expect(service.createHookExecutionRole('hookRole')).rejects.toThrow(/no ARN/);
+        });
+
+        it('propagates STS failures when resolving the account id', async () => {
+            stsMock.on(GetCallerIdentityCommand).rejects(new Error('sts-down'));
+
+            await expect(service.createHookExecutionRole('hookRole')).rejects.toThrow('sts-down');
+        });
+    });
+});

--- a/tst/unit/services/guard/GuardEngine.test.ts
+++ b/tst/unit/services/guard/GuardEngine.test.ts
@@ -205,4 +205,60 @@ rule S3_BUCKET_ENCRYPTION when %s3_buckets !empty {
             expect(ruleWithMessage.content).not.toContain('>>');
         });
     });
+
+    describe('validateRule syntactic pre-check', () => {
+        it('rejects a rule with an unclosed brace', () => {
+            const result = guardEngine.validateRule('rule R when Resources !empty {\n  Resources.Foo exists');
+            expect(result.valid).toBe(false);
+            expect(result.parseErrors[0]).toMatch(/Unclosed/i);
+        });
+
+        it('rejects an empty rule', () => {
+            const result = guardEngine.validateRule('   \n  ');
+            expect(result.valid).toBe(false);
+            expect(result.parseErrors[0]).toMatch(/empty/i);
+        });
+
+        it('rejects a comments-only rule (e.g. the untouched starter)', () => {
+            const result = guardEngine.validateRule('# just a comment\n# another line');
+            expect(result.valid).toBe(false);
+            expect(result.parseErrors[0]).toMatch(/empty/i);
+        });
+
+        it('rejects mismatched brackets', () => {
+            const result = guardEngine.validateRule('rule R { Resources.Foo exists )');
+            expect(result.valid).toBe(false);
+            expect(result.parseErrors[0]).toMatch(/Mismatched/i);
+        });
+
+        it('accepts a well-formed rule', () => {
+            const result = guardEngine.validateRule('rule R when Resources !empty {\n  Resources.Foo exists\n}');
+            expect(result.valid).toBe(true);
+            expect(result.parseErrors).toHaveLength(0);
+        });
+
+        it('ignores brackets inside strings', () => {
+            const result = guardEngine.validateRule("rule R when Resources !empty {\n  Resources.Name == 'a}b{c'\n}");
+            expect(result.valid).toBe(true);
+        });
+
+        it('does not treat # inside a string as a comment', () => {
+            const result = guardEngine.validateRule(
+                'rule R when Resources !empty {\n  Resources.Tag == "color#red"\n}',
+            );
+            expect(result.valid).toBe(true);
+        });
+
+        it('handles escaped quotes inside a string', () => {
+            const result = guardEngine.validateRule('rule R when Resources !empty {\n  Resources.Name == "a\\"b"\n}');
+            expect(result.valid).toBe(true);
+        });
+
+        it('ignores brackets inside a regex literal', () => {
+            const result = guardEngine.validateRule(
+                'rule R when Resources !empty {\n  Resources.Arn == /arn:aws[a-z0-9]*/\n}',
+            );
+            expect(result.valid).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

**PR 4 of 7** for the CloudFormation **Hooks** feature — **local Guard hook preview**: evaluate configured Guard hooks against a template locally so a user sees which resources would pass/fail *before* deploying.

> **Stacking note:** Depends on **#646** (PR1), **#647** (PR2), **#648** (PR3). Opened against `main`, so until those merge the diff includes their commits; it collapses to just this slice as they merge. **Review/merge in order.** The net-new commit is `feat(hooks): add local stack-accurate Guard hook preview`.

## What's included

- **`src/hooks/GuardHookPreview.ts`** (new) — `previewGuardHooks()` takes a `GuardHookPreviewDeps` object (callbacks like `listHooksDetailed` and `fetchRuleContent`) rather than importing `HooksManager` directly, keeping the preview logic decoupled and unit-testable. For each applicable, enabled, configured Guard hook it fetches the rule from S3 (cached), runs it through `GuardEngine`, and maps cfn-guard results to per-resource pass/fail with the hook's failure-mode → diagnostic-severity mapping. Per-hook failures (e.g. an S3 access error) are captured individually so one bad hook doesn't abort the whole preview.
- **`src/services/guard/GuardEngine.ts`** (modified) — adds `validateRule()` alongside `validateTemplate()`, plus a best-effort `syntacticPreCheck` (empty-rule + unbalanced-bracket detection).

Handler/LSP wiring that calls this arrives in PR 5.

## Known limitation (not introduced here)
The vendored cfn-guard **WASM binding silently swallows rule parse/compile errors** — a malformed rule returns an empty result set (indistinguishable from a clean pass) and never throws. `syntacticPreCheck` is a best-effort mitigation (catches empty rules and bracket imbalance only). This is a property of the binding, documented here for reviewers.

## Testing
- `tst/unit/hooks/GuardHookPreview.test.ts` (new) — filters non-previewable hooks (disabled/unconfigured/no ruleUri), correct per-resource violation mapping, severity mapping (WARN→Warning, FAIL/undefined→Error), per-hook error isolation, empty-applicable-set case.
- `tst/unit/services/guard/GuardEngine.test.ts` (modified) — syntactic pre-check coverage: unclosed brace, empty rule, comments-only, mismatched brackets, well-formed rule, brackets in strings/regex ignored, `#` in strings not treated as a comment, escaped quotes.
- Build (`tsc -b`) and lint pass.
