### PR TITLE
Defer cfn-lint and Guard initialization until needed

### DIFF
--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -7,6 +7,7 @@ import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
 import { Telemetry } from '../telemetry/TelemetryDecorator';
 import { Closeable } from '../utils/Closeable';
 import { Delayer } from '../utils/Delayer';
+import { RequestCancellationError } from '../utils/errors/ErrorClasses';
 import { CloudFormationFileType, Document, DocumentType } from './Document';
 import { DocumentMetadata } from './DocumentProtocol';
 
@@ -102,7 +103,7 @@ export class DocumentManager implements SettingsConfigurable, Closeable {
                 delay,
             )
             .catch((error) => {
-                if (error instanceof Error && error.message.includes('Request cancelled')) {
+                if (error instanceof RequestCancellationError) {
                     return;
                 }
                 this.log.error(error, 'Failed to send document metadata');

--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -166,10 +166,9 @@ export class DocumentManager implements SettingsConfigurable, Closeable {
         }
     }
 
-    hasTemplateFiles() {
-        return [...this.documentMap.values()].some((doc) => {
-            return doc.isTemplate();
-        });
+    hasFilesOfType(...fileTypes: CloudFormationFileType[]): boolean {
+        const supportedFileTypes = new Set(fileTypes);
+        return [...this.documentMap.values()].some((document) => supportedFileTypes.has(document.cfnFileType));
     }
 
     private emitDocSize() {

--- a/src/document/DocumentManager.ts
+++ b/src/document/DocumentManager.ts
@@ -166,6 +166,12 @@ export class DocumentManager implements SettingsConfigurable, Closeable {
         }
     }
 
+    hasTemplateFiles() {
+        return [...this.documentMap.values()].some((doc) => {
+            return doc.isTemplate();
+        });
+    }
+
     private emitDocSize() {
         for (const doc of this.documentMap.values()) {
             if (doc.isTemplate()) {

--- a/src/handlers/DocumentHandler.ts
+++ b/src/handlers/DocumentHandler.ts
@@ -179,8 +179,8 @@ function triggerValidation(
     });
 
     components.guardService.validateDelayed(content, uri, validationTrigger, debounce).catch((reason) => {
-        if (reason instanceof Error && reason.message.includes('Request cancelled')) {
-            // Do nothing
+        if (reason instanceof RequestCancellationError) {
+            // Do nothing - cancellation is expected behavior
         } else {
             log.error(reason, `Guard validation error for ${uri}`);
         }

--- a/src/handlers/DocumentHandler.ts
+++ b/src/handlers/DocumentHandler.ts
@@ -6,11 +6,10 @@ import { CloudFormationFileType, Document } from '../document/Document';
 import { createEdit } from '../document/DocumentUtils';
 import { LspDocuments } from '../protocol/LspDocuments';
 import { ServerComponents } from '../server/ServerComponents';
-import { LintTrigger } from '../services/cfnLint/CfnLintService';
-import { ValidationTrigger } from '../services/guard/GuardService';
 import { publishValidationDiagnostics } from '../stacks/actions/StackActionOperations';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { RequestCancellationError } from '../utils/errors/ErrorClasses';
+import { ValidationTrigger } from '../utils/ValidationUtils';
 
 const log = LoggerFactory.getLogger('DocumentHandler');
 
@@ -33,7 +32,7 @@ export function didOpenHandler(components: ServerComponents): (event: TextDocume
             }
         }
 
-        triggerValidation(components, content, uri, LintTrigger.OnOpen, ValidationTrigger.OnOpen);
+        triggerValidation(components, content, uri, ValidationTrigger.OnOpen);
 
         components.documentManager.sendDocumentMetadata();
     };
@@ -110,14 +109,7 @@ export function didChangeHandler(
             components.syntaxTreeManager.add(documentUri, finalContent);
         }
 
-        triggerValidation(
-            components,
-            finalContent,
-            documentUri,
-            LintTrigger.OnChange,
-            ValidationTrigger.OnChange,
-            true,
-        );
+        triggerValidation(components, finalContent, documentUri, ValidationTrigger.OnChange, true);
 
         // Republish validation diagnostics if available
         const validationDetails = components.validationManager
@@ -165,7 +157,7 @@ export function didSaveHandler(components: ServerComponents): (event: TextDocume
         const documentUri = event.document.uri;
         const documentContent = event.document.getText();
 
-        triggerValidation(components, documentContent, documentUri, LintTrigger.OnSave, ValidationTrigger.OnSave);
+        triggerValidation(components, documentContent, documentUri, ValidationTrigger.OnSave);
 
         components.documentManager.sendDocumentMetadata(0);
     };
@@ -175,11 +167,10 @@ function triggerValidation(
     components: ServerComponents,
     content: string,
     uri: string,
-    lintTrigger: LintTrigger,
     validationTrigger: ValidationTrigger,
     debounce?: boolean,
 ): void {
-    components.cfnLintService.lintDelayed(content, uri, lintTrigger, debounce).catch((reason) => {
+    components.cfnLintService.lintDelayed(content, uri, validationTrigger, debounce).catch((reason) => {
         if (reason instanceof RequestCancellationError) {
             // Do nothing - cancellation is expected behavior
         } else {

--- a/src/handlers/Initialize.ts
+++ b/src/handlers/Initialize.ts
@@ -7,7 +7,9 @@ export function initializedHandler(components: ServerComponents): () => void {
     return (): void => {
         components.settingsManager
             .syncConfiguration()
-            .then(() => components.schemaRetriever.initialize())
+            .then(() => {
+                return components.schemaRetriever.initialize();
+            })
             .catch((error: unknown) => {
                 logger.error(error, `Failed to initialize server`);
             });

--- a/src/handlers/Initialize.ts
+++ b/src/handlers/Initialize.ts
@@ -9,8 +9,7 @@ export function initializedHandler(workspace: LspWorkspace, components: ServerCo
         components.settingsManager
             .syncConfiguration()
             .then(() => {
-                components.schemaRetriever.initialize();
-                return components.cfnLintService.initialize();
+                return components.schemaRetriever.initialize();
             })
             .then(async () => {
                 // Process folders sequentially to avoid overwhelming the system

--- a/src/handlers/Initialize.ts
+++ b/src/handlers/Initialize.ts
@@ -1,26 +1,13 @@
-import { LspWorkspace } from '../protocol/LspWorkspace';
 import { ServerComponents } from '../server/ServerComponents';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 
 const logger = LoggerFactory.getLogger('InitializedHandler');
 
-export function initializedHandler(workspace: LspWorkspace, components: ServerComponents): () => void {
+export function initializedHandler(components: ServerComponents): () => void {
     return (): void => {
         components.settingsManager
             .syncConfiguration()
-            .then(() => {
-                return components.schemaRetriever.initialize();
-            })
-            .then(async () => {
-                // Process folders sequentially to avoid overwhelming the system
-                for (const folder of workspace.getAllWorkspaceFolders()) {
-                    try {
-                        await components.cfnLintService.mountFolder(folder);
-                    } catch (error) {
-                        logger.error(error, `Failed to mount folder ${folder.name}`);
-                    }
-                }
-            })
+            .then(() => components.schemaRetriever.initialize())
             .catch((error: unknown) => {
                 logger.error(error, `Failed to initialize server`);
             });

--- a/src/protocol/LspConnection.ts
+++ b/src/protocol/LspConnection.ts
@@ -19,7 +19,7 @@ import { LspWorkspace } from './LspWorkspace';
 type LspConnectionHandlers = {
     onInitialize?: (params: InitializeParams) => Promise<InitializeResult> | InitializeResult;
     onInitialized?: (params: InitializedParams) => unknown;
-    onShutdown?: () => void | Promise<void>;
+    onShutdown?: () => unknown;
     onExit?: () => unknown;
 };
 

--- a/src/protocol/LspConnection.ts
+++ b/src/protocol/LspConnection.ts
@@ -19,7 +19,7 @@ import { LspWorkspace } from './LspWorkspace';
 type LspConnectionHandlers = {
     onInitialize?: (params: InitializeParams) => Promise<InitializeResult> | InitializeResult;
     onInitialized?: (params: InitializedParams) => unknown;
-    onShutdown?: () => unknown;
+    onShutdown?: () => void | Promise<void>;
     onExit?: () => unknown;
 };
 
@@ -76,7 +76,7 @@ export class LspConnection {
         });
 
         this.connection.onShutdown(() => {
-            onShutdown();
+            return onShutdown();
         });
 
         this.connection.onExit(() => {

--- a/src/protocol/LspConnection.ts
+++ b/src/protocol/LspConnection.ts
@@ -19,7 +19,7 @@ import { LspWorkspace } from './LspWorkspace';
 type LspConnectionHandlers = {
     onInitialize?: (params: InitializeParams) => Promise<InitializeResult> | InitializeResult;
     onInitialized?: (params: InitializedParams) => unknown;
-    onShutdown?: () => unknown;
+    onShutdown?: () => void | Promise<void>;
     onExit?: () => unknown;
 };
 

--- a/src/server/CfnServer.ts
+++ b/src/server/CfnServer.ts
@@ -93,7 +93,7 @@ export class CfnServer {
             configurable.configure(this.core.settingsManager);
         }
 
-        initializedHandler(this.lsp.workspace, this.components)();
+        initializedHandler(this.components)();
     }
 
     private setupHandlers() {

--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -975,6 +975,8 @@ export class CfnLintService
      * - Resets the service status to uninitialized
      */
     public async close(): Promise<void> {
+        this.markClosed();
+
         // Unsubscribe from settings changes
         if (this.settingsSubscription) {
             this.settingsSubscription.unsubscribe();
@@ -984,13 +986,9 @@ export class CfnLintService
         // Cancel all pending requests
         this.cancelAllDelayedLinting();
 
-        if (this.status !== InitializationStatus.Uninitialized && this.status !== InitializationStatus.Failed) {
-            // Shutdown worker manager
-            await this.workerManager.shutdown();
-            this.localExecutor = undefined;
-        }
+        await this.workerManager.shutdown();
+        this.localExecutor = undefined;
         this.initializationPromise = undefined;
-        this.resetInitialization();
     }
 
     static create(

--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -40,6 +40,14 @@ export function sleep(ms: number): Promise<void> {
     });
 }
 
+interface QueuedLintRequest {
+    content: string;
+    forceUseContent: boolean;
+    timestamp: number;
+    resolve: () => void;
+    reject: (reason: unknown) => void;
+}
+
 export class CfnLintService
     extends DeferredValidationInitializer
     implements SettingsConfigurable, Closeable, ReadinessContributor
@@ -89,16 +97,7 @@ export class CfnLintService
     }
 
     // Request queue for handling requests during initialization
-    private readonly requestQueue = new Map<
-        string,
-        {
-            content: string;
-            forceUseContent: boolean;
-            timestamp: number;
-            resolve: () => void;
-            reject: (reason: unknown) => void;
-        }
-    >();
+    private readonly requestQueue = new Map<string, QueuedLintRequest>();
 
     constructor(
         private readonly documentManager: DocumentManager,
@@ -748,32 +747,66 @@ export class CfnLintService
         }
     }
 
+    private removeQueuedRequest(uri: string, expectedRequest?: QueuedLintRequest): QueuedLintRequest | undefined {
+        const request = this.requestQueue.get(uri);
+        if (!request || (expectedRequest !== undefined && request !== expectedRequest)) {
+            return;
+        }
+
+        this.requestQueue.delete(uri);
+        this.telemetry.countUpDown('lint.queue.depth', -1);
+        return request;
+    }
+
+    private takeQueuedRequests(): [string, QueuedLintRequest][] {
+        const requests = [...this.requestQueue.entries()];
+        if (requests.length === 0) {
+            return requests;
+        }
+
+        this.requestQueue.clear();
+        this.telemetry.countUpDown('lint.queue.depth', -requests.length);
+        return requests;
+    }
+
+    private cancelQueuedRequest(uri: string): void {
+        this.removeQueuedRequest(uri)?.reject(new RequestCancellationError(uri));
+    }
+
+    private cancelAllQueuedRequests(): void {
+        for (const [uri, request] of this.takeQueuedRequests()) {
+            request.reject(new RequestCancellationError(uri));
+        }
+    }
+
+    private rejectQueuedRequest(uri: string, expectedRequest: QueuedLintRequest, reason: unknown): void {
+        this.removeQueuedRequest(uri, expectedRequest)?.reject(reason);
+    }
+
     /**
      * Process all queued requests after initialization completes
      */
     private processQueuedRequests(): void {
-        if (this.requestQueue.size === 0) {
+        const queuedRequests = this.takeQueuedRequests();
+        if (queuedRequests.length === 0) {
             return;
         }
 
-        this.telemetry.count('lint.queue.processed', this.requestQueue.size);
+        this.telemetry.count('lint.queue.processed', queuedRequests.length);
 
-        // Process each queued request through the delayer
-        for (const [uri, request] of this.requestQueue.entries()) {
-            // Use delayer for queued requests too, to maintain debouncing behavior
+        for (const [uri, request] of queuedRequests) {
             this.delayer
                 .delay(uri, () => this.lint(request.content, uri, request.forceUseContent))
                 .then(() => {
                     request.resolve();
                 })
                 .catch((reason: unknown) => {
-                    this.logError(`processing queued request for ${uri}`, reason);
+                    if (!(reason instanceof RequestCancellationError)) {
+                        this.logError(`processing queued request for ${uri}`, reason);
+                    }
                     request.reject(reason);
                 });
         }
-
-        // Clear the queue
-        this.requestQueue.clear();
     }
 
     /**
@@ -828,25 +861,36 @@ export class CfnLintService
         }
 
         if (this.status !== InitializationStatus.Initialized) {
-            // Create a promise that will be resolved when the queued request is processed
-            return await new Promise<void>((resolve, reject) => {
-                // Queue the request (overwrites previous request for same URI - "last request wins")
-                this.requestQueue.set(uri, {
-                    content,
-                    forceUseContent,
-                    timestamp: Date.now(),
-                    resolve,
-                    reject,
-                });
+            try {
+                await new Promise<void>((resolve, reject) => {
+                    this.cancelQueuedRequest(uri);
+                    const request: QueuedLintRequest = {
+                        content,
+                        forceUseContent,
+                        timestamp: Date.now(),
+                        resolve,
+                        reject,
+                    };
+                    this.requestQueue.set(uri, request);
 
-                this.telemetry.count('lint.queue.enqueued', 1);
-                this.telemetry.countUpDown('lint.queue.depth', this.requestQueue.size, { unit: '1' });
+                    this.telemetry.count('lint.queue.enqueued', 1);
+                    this.telemetry.countUpDown('lint.queue.depth', 1);
 
-                // Trigger initialization if needed (but don't await it here)
-                this.ensureInitialized().catch((error) => {
-                    this.logError('ensuring initialization', error);
+                    void this.ensureInitialized().catch((error: unknown) => {
+                        const initializationError =
+                            error instanceof Error ? error : new Error(extractErrorMessage(error));
+                        this.logError('ensuring initialization', initializationError);
+                        this.rejectQueuedRequest(uri, request, initializationError);
+                    });
                 });
-            });
+            } catch (error) {
+                if (error instanceof RequestCancellationError) {
+                    this.telemetry.count('lint.cancelled', 1);
+                    return;
+                }
+                throw error;
+            }
+            return;
         }
 
         // Service is ready, process based on trigger type
@@ -875,6 +919,7 @@ export class CfnLintService
      */
     public cancelDelayedLinting(uri: string): void {
         this.delayer.cancel(uri);
+        this.cancelQueuedRequest(uri);
     }
 
     /**
@@ -882,6 +927,7 @@ export class CfnLintService
      */
     public cancelAllDelayedLinting(): void {
         this.delayer.cancelAll();
+        this.cancelAllQueuedRequests();
     }
 
     /**
@@ -917,14 +963,15 @@ export class CfnLintService
             this.settingsSubscription = undefined;
         }
 
-        // Cancel all pending delayed requests
-        this.delayer.cancelAll();
+        // Cancel all pending requests
+        this.cancelAllDelayedLinting();
 
         if (this.status !== InitializationStatus.Uninitialized && this.status !== InitializationStatus.Failed) {
             // Shutdown worker manager
             await this.workerManager.shutdown();
             this.localExecutor = undefined;
         }
+        this.initializationPromise = undefined;
         this.resetInitialization();
     }
 

--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -22,22 +22,10 @@ import {
 import { extractErrorMessage } from '../../utils/errors/ErrorUtils';
 import { ReadinessContributor, ReadinessStatus } from '../../utils/ReadinessContributor';
 import { byteSize } from '../../utils/String';
+import { DeferredValidationInitializer, InitializationStatus, ValidationTrigger } from '../../utils/ValidationUtils';
 import { DiagnosticCoordinator } from '../DiagnosticCoordinator';
 import { LocalCfnLintExecutor } from './LocalCfnLintExecutor';
 import { PyodideWorkerManager } from './PyodideWorkerManager';
-
-export enum LintTrigger {
-    OnOpen = 'onOpen',
-    OnChange = 'onChange',
-    OnSave = 'onSave',
-}
-
-enum STATUS {
-    Uninitialized = 0,
-    Initializing = 1,
-    Initialized = 2,
-    Failed = 3,
-}
 
 /**
  * Sleep utility function for async delays
@@ -52,10 +40,12 @@ export function sleep(ms: number): Promise<void> {
     });
 }
 
-export class CfnLintService implements SettingsConfigurable, Closeable, ReadinessContributor {
+export class CfnLintService
+    extends DeferredValidationInitializer
+    implements SettingsConfigurable, Closeable, ReadinessContributor
+{
     private static readonly CFN_LINT_SOURCE = 'cfn-lint';
 
-    private status: STATUS = STATUS.Uninitialized;
     private readonly delayer: Delayer<void>;
     private settings: CfnLintSettings;
     private settingsSubscription?: SettingsSubscription;
@@ -117,6 +107,11 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         workerManager?: PyodideWorkerManager,
         delayer?: Delayer<void>,
     ) {
+        super(
+            () => this.settings.enabled,
+            documentManager,
+            async () => await this.initializeRuntime(),
+        );
         this.settings = DefaultSettings.diagnostics.cfnLint;
         this.delayer = delayer ?? new Delayer<void>(this.settings.delayMs);
         this.workerManager = workerManager ?? new PyodideWorkerManager(this.settings.initialization, this.settings);
@@ -143,10 +138,10 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
     }
 
     isReady(): ReadinessStatus {
-        if (!this.settings.enabled) {
+        if (!this.isInitializationRequired()) {
             return { ready: true };
         }
-        return { ready: this.status === STATUS.Initialized };
+        return { ready: this.status === InitializationStatus.Initialized };
     }
 
     private onSettingsChanged(newSettings: CfnLintSettings): void {
@@ -176,23 +171,17 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      * @throws Error if initialization fails at any step
      */
     public async initialize(): Promise<void> {
-        if (!this.settings.enabled) {
-            this.log.info('cfn-lint is disabled, skipping Pyodide initialization');
-            return;
+        if (!(await this.initializeIfRequired())) {
+            this.log.info('cfn-lint is disabled or there are no templates, skipping Pyodide initialization');
         }
+    }
 
-        if (this.status !== STATUS.Uninitialized) {
-            return;
-        }
-
-        this.status = STATUS.Initializing;
-
+    private async initializeRuntime(): Promise<void> {
         const startTime = performance.now();
 
         if (this.settings.path) {
             // Local executor doesn't need heavy initialization
             this.localExecutor = new LocalCfnLintExecutor(this.settings.path);
-            this.status = STATUS.Initialized;
             this.telemetry.count('init.success', 1, { attributes: { mode: 'local' } });
             this.telemetry.histogram('init.duration', performance.now() - startTime, { unit: 'ms' });
             return;
@@ -216,7 +205,6 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
                 }
             }
 
-            this.status = STATUS.Initialized;
             this.telemetry.count('init.success', 1);
             this.telemetry.histogram('init.duration', performance.now() - startTime, { unit: 'ms' });
 
@@ -229,7 +217,6 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
                 this.log.warn(`Failed to get cfn-lint version: ${extractErrorMessage(error)}`);
             }
         } catch (error) {
-            this.status = STATUS.Failed;
             const phase = error instanceof CfnLintInitializationError ? error.phase : 'unknown';
             this.telemetry.error('init.fault', error, undefined, {
                 captureErrorType: true,
@@ -248,11 +235,11 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      * @throws Error if the service is not initialized or mounting fails
      */
     public async mountFolder(folder: WorkspaceFolder): Promise<void> {
-        if (!this.settings.enabled) {
+        if (!(await this.initializeIfRequired())) {
             return;
         }
 
-        if (this.status === STATUS.Uninitialized) {
+        if (this.status !== InitializationStatus.Initialized) {
             throw new Error('CfnLintService not initialized. Call initialize() first.');
         }
 
@@ -341,11 +328,11 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         maxDelayMs: number = 5000,
     ): Promise<void> {
         // Check if already initialized
-        if (this.status === STATUS.Initialized) {
+        if (this.status === InitializationStatus.Initialized) {
             return; // Service is ready
         }
 
-        if (this.status === STATUS.Uninitialized) {
+        if (this.status === InitializationStatus.Uninitialized) {
             throw new Error('CfnLintService is not initialized and not being initialized.');
         }
 
@@ -355,7 +342,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
 
         while (DateTime.now() < timeoutTime) {
             // @ts-expect-error: This comparison is intentional to check if initialization completed while waiting
-            if (this.status === STATUS.Initialized) {
+            if (this.status === InitializationStatus.Initialized) {
                 return; // Service is ready
             }
 
@@ -421,6 +408,9 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      */
     @Count({ name: 'lint.standaloneFile', captureErrorType: true })
     private async lintStandaloneFile(content: string, uri: string, fileType: CloudFormationFileType): Promise<void> {
+        if (!(await this.initializeIfRequired())) {
+            return;
+        }
         const startTime = performance.now();
         const doc = this.documentManager.get(uri);
         const sizeCategory = doc?.getTemplateSizeCategory() ?? 'unknown';
@@ -446,7 +436,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             }
             this.telemetry.count('lint.success', 1, { attributes: { fileType } });
         } catch (error) {
-            this.status = STATUS.Uninitialized;
+            this.resetInitialization();
             this.logError(`linting ${fileType} by string`, error);
             this.publishErrorDiagnostics(uri, error);
 
@@ -561,7 +551,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             }
             this.telemetry.count('lint.success', 1, { attributes: { fileType } });
         } catch (error) {
-            this.status = STATUS.Uninitialized;
+            this.resetInitialization();
             this.logError(`linting ${fileType} by file`, error);
             this.publishErrorDiagnostics(uri, error);
 
@@ -623,6 +613,12 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             return;
         }
 
+        if (!this.isInitializationRequired()) {
+            this.telemetry.count('lint.file.skipped', 1);
+            this.publishDiagnostics(uri, []);
+            return;
+        }
+
         // Track file type being linted
         this.telemetry.count(`lint.file.${fileType}`, 1);
 
@@ -636,7 +632,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         }
 
         // Redundant check but clears up TypeScript errors
-        if (this.status === STATUS.Uninitialized) {
+        if (this.status === InitializationStatus.Uninitialized) {
             this.telemetry.count('lint.uninitialized', 1);
             throw new Error('CfnLintService not initialized. Call initialize() first.');
         }
@@ -675,17 +671,17 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      * @throws Error if initialization fails or times out
      */
     private async ensureInitialized(timeoutMs: number = 120_000): Promise<void> {
-        if (this.status === STATUS.Initialized) {
+        if (this.status === InitializationStatus.Initialized) {
             return;
         }
 
-        if (this.status === STATUS.Failed) {
+        if (this.status === InitializationStatus.Failed) {
             throw new Error('CfnLintService initialization failed permanently. Restart the language server to retry.');
         }
 
-        if (this.status === STATUS.Uninitialized) {
+        if (this.status === InitializationStatus.Uninitialized) {
             this.initializationPromise = this.initialize();
-        } else if (this.status === STATUS.Initializing) {
+        } else if (this.status === InitializationStatus.Initializing) {
             // If initialization is in progress but we don't have a promise, create one
             this.initializationPromise ??= this.pollForInitialization();
         }
@@ -733,18 +729,18 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         const startTime = DateTime.now();
         const timeoutTime = startTime.plus({ milliseconds: timeoutMs });
 
-        while (this.status === STATUS.Initializing && DateTime.now() < timeoutTime) {
+        while (this.status === InitializationStatus.Initializing && DateTime.now() < timeoutTime) {
             await sleep(50); // Wait 50ms between checks
         }
 
         // Check if we timed out
-        if (DateTime.now() >= timeoutTime && this.status === STATUS.Initializing) {
+        if (DateTime.now() >= timeoutTime && this.status === InitializationStatus.Initializing) {
             const elapsedMs = DateTime.now().diff(startTime).as('milliseconds');
             throw new Error(`Initialization polling timeout after ${elapsedMs.toFixed(0)}ms`);
         }
 
-        if (this.status !== STATUS.Initialized) {
-            throw new Error(`Initialization failed, status: ${STATUS[this.status]}`);
+        if (this.status !== InitializationStatus.Initialized) {
+            throw new Error(`Initialization failed, status: ${InitializationStatus[this.status]}`);
         }
     }
 
@@ -795,7 +791,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
     public async lintDelayed(
         content: string,
         uri: string,
-        trigger: LintTrigger,
+        trigger: ValidationTrigger,
         forceUseContent: boolean = false,
     ): Promise<void> {
         if (!this.settings.enabled) {
@@ -804,13 +800,13 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
 
         // Check trigger-specific settings
         switch (trigger) {
-            case LintTrigger.OnOpen:
-            case LintTrigger.OnSave: {
+            case ValidationTrigger.OnOpen:
+            case ValidationTrigger.OnSave: {
                 // OnOpen and OnSave are controlled only by cfnlint.enabled
                 // No additional configuration needed
                 break;
             }
-            case LintTrigger.OnChange: {
+            case ValidationTrigger.OnChange: {
                 if (!this.settings.lintOnChange) {
                     return;
                 }
@@ -822,12 +818,12 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
             }
         }
 
-        if (this.status === STATUS.Failed) {
+        if (this.status === InitializationStatus.Failed) {
             this.telemetry.count('lint.uninitialized', 1);
             return;
         }
 
-        if (this.status !== STATUS.Initialized) {
+        if (this.status !== InitializationStatus.Initialized) {
             // Create a promise that will be resolved when the queued request is processed
             return await new Promise<void>((resolve, reject) => {
                 // Queue the request (overwrites previous request for same URI - "last request wins")
@@ -851,7 +847,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
 
         // Service is ready, process based on trigger type
         try {
-            if (trigger === LintTrigger.OnSave) {
+            if (trigger === ValidationTrigger.OnSave) {
                 // For save operations: execute immediately (0ms delay)
                 await this.delayer.delay(uri, () => this.lint(content, uri, forceUseContent), 0);
             } else {
@@ -899,7 +895,7 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
      * @returns true if the service is initialized and ready, false otherwise
      */
     public isInitialized(): boolean {
-        return this.status === STATUS.Initialized;
+        return this.status === InitializationStatus.Initialized;
     }
 
     /**
@@ -920,12 +916,12 @@ export class CfnLintService implements SettingsConfigurable, Closeable, Readines
         // Cancel all pending delayed requests
         this.delayer.cancelAll();
 
-        if (this.status !== STATUS.Uninitialized && this.status !== STATUS.Failed) {
+        if (this.status !== InitializationStatus.Uninitialized && this.status !== InitializationStatus.Failed) {
             // Shutdown worker manager
             await this.workerManager.shutdown();
             this.localExecutor = undefined;
         }
-        this.status = STATUS.Uninitialized;
+        this.resetInitialization();
     }
 
     static create(

--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -62,6 +62,7 @@ export class CfnLintService
     private localExecutor?: LocalCfnLintExecutor;
     private readonly log = LoggerFactory.getLogger(CfnLintService);
     private readonly mountedFolders = new Map<string, WorkspaceFolder>();
+    private readonly folderMountsInProgress = new Map<string, Promise<void>>();
 
     @Telemetry() private readonly telemetry!: ScopedTelemetry;
 
@@ -256,11 +257,28 @@ export class CfnLintService
         const fsDir = URI.parse(folder.uri).fsPath;
         const mountDir = '/'.concat(folder.name);
 
-        // Check if already mounted
         if (this.mountedFolders.has(mountDir)) {
             return;
         }
 
+        const existingMount = this.folderMountsInProgress.get(mountDir);
+        if (existingMount) {
+            await existingMount;
+            return;
+        }
+
+        const mount = this.mountFolderInWorker(fsDir, mountDir, folder);
+        this.folderMountsInProgress.set(mountDir, mount);
+        try {
+            await mount;
+        } finally {
+            if (this.folderMountsInProgress.get(mountDir) === mount) {
+                this.folderMountsInProgress.delete(mountDir);
+            }
+        }
+    }
+
+    private async mountFolderInWorker(fsDir: string, mountDir: string, folder: WorkspaceFolder): Promise<void> {
         try {
             const startTime = performance.now();
             await this.workerManager.mountFolder(fsDir, mountDir);

--- a/src/services/cfnLint/CfnLintService.ts
+++ b/src/services/cfnLint/CfnLintService.ts
@@ -109,7 +109,11 @@ export class CfnLintService
     ) {
         super(
             () => this.settings.enabled,
-            documentManager,
+            () =>
+                documentManager.hasFilesOfType(
+                    CloudFormationFileType.Template,
+                    CloudFormationFileType.GitSyncDeployment,
+                ),
             async () => await this.initializeRuntime(),
         );
         this.settings = DefaultSettings.diagnostics.cfnLint;

--- a/src/services/cfnLint/PyodideWorkerManager.ts
+++ b/src/services/cfnLint/PyodideWorkerManager.ts
@@ -6,7 +6,11 @@ import { CfnLintInitializationSettings, CfnLintSettings } from '../../settings/S
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../../telemetry/ScopedTelemetry';
 import { Telemetry } from '../../telemetry/TelemetryDecorator';
-import { CfnLintInitializationError, WorkerNotInitializedError } from '../../utils/errors/ErrorClasses';
+import {
+    CfnLintInitializationError,
+    WorkerNotInitializedError,
+    WorkerShutdownError,
+} from '../../utils/errors/ErrorClasses';
 import { extractErrorMessage } from '../../utils/errors/ErrorUtils';
 import { retryWithExponentialBackoff } from '../../utils/Retry';
 
@@ -34,6 +38,8 @@ export class PyodideWorkerManager {
     private readonly tasks = new Map<string, WorkerTask>();
     private initialized = false;
     private initializationPromise: Promise<void> | undefined = undefined;
+    private closed = false;
+    private shutdownPromise: Promise<void> | undefined = undefined;
 
     @Telemetry() private readonly telemetry!: ScopedTelemetry;
 
@@ -44,6 +50,10 @@ export class PyodideWorkerManager {
     ) {}
 
     public async initialize(): Promise<void> {
+        if (this.closed) {
+            throw new WorkerShutdownError();
+        }
+
         if (this.initialized) {
             return;
         }
@@ -60,6 +70,10 @@ export class PyodideWorkerManager {
         let attemptCount = 0;
         return await retryWithExponentialBackoff(
             async () => {
+                if (this.closed) {
+                    throw new WorkerShutdownError();
+                }
+
                 if (attemptCount > 0) {
                     this.telemetry.count('worker.restart', 1, { attributes: { attempt: attemptCount.toString() } });
                 }
@@ -74,6 +88,7 @@ export class PyodideWorkerManager {
                 jitterFactor: 0.1, // Add 10% jitter to prevent synchronized retry storms
                 operationName: 'Pyodide initialization',
                 totalTimeoutMs: this.retryConfig.totalTimeoutMs,
+                shouldRetry: (error) => !this.closed && !(error instanceof WorkerShutdownError),
             },
             this.log,
         );
@@ -92,6 +107,10 @@ export class PyodideWorkerManager {
 
                 // Add exit event handler to detect crashes
                 this.worker.on('exit', (code) => {
+                    if (this.closed) {
+                        return;
+                    }
+
                     if (code !== 0) {
                         this.log.error(`Worker exited unexpectedly with code ${code}`);
                         this.telemetry.count('worker.crash', 1, { attributes: { exitCode: code.toString() } });
@@ -290,22 +309,41 @@ export class PyodideWorkerManager {
     }
 
     public async shutdown(): Promise<void> {
-        if (this.worker) {
-            // Reject all pending tasks
-            for (const task of this.tasks.values()) {
-                task.reject(new Error('Worker shutdown'));
-            }
-            this.tasks.clear();
+        if (!this.shutdownPromise) {
+            this.closed = true;
+            this.shutdownPromise = this.releaseResources();
+        }
 
-            // Terminate worker and wait for completion
+        await this.shutdownPromise;
+    }
+
+    private async releaseResources(): Promise<void> {
+        const workerToTerminate = this.worker;
+        const initializationToSettle = this.initializationPromise;
+
+        this.worker = undefined;
+        this.initialized = false;
+        this.initializationPromise = undefined;
+
+        for (const task of this.tasks.values()) {
+            task.reject(new WorkerShutdownError());
+        }
+        this.tasks.clear();
+
+        if (initializationToSettle) {
+            void initializationToSettle.catch((error: unknown) => {
+                if (!(error instanceof WorkerShutdownError)) {
+                    this.log.error(error, 'Worker initialization failed while shutting down');
+                }
+            });
+        }
+
+        if (workerToTerminate) {
             try {
-                await this.worker.terminate();
+                await workerToTerminate.terminate();
             } catch (error) {
                 this.log.error(error, 'Error terminating worker');
             }
-            this.worker = undefined;
-            this.initialized = false;
-            this.initializationPromise = undefined;
         }
     }
 }

--- a/src/services/guard/GuardService.ts
+++ b/src/services/guard/GuardService.ts
@@ -4,7 +4,7 @@ import { SyntaxTreeManager } from '../../context/syntaxtree/SyntaxTreeManager';
 import { CloudFormationFileType } from '../../document/Document';
 import { DocumentManager } from '../../document/DocumentManager';
 import { ServerComponents } from '../../server/ServerComponents';
-import { SettingsConfigurable, ISettingsSubscriber, SettingsSubscription } from '../../settings/ISettingsSubscriber';
+import { ISettingsSubscriber, SettingsConfigurable, SettingsSubscription } from '../../settings/ISettingsSubscriber';
 import { DefaultSettings, GuardSettings } from '../../settings/Settings';
 import { LoggerFactory } from '../../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../../telemetry/ScopedTelemetry';
@@ -16,16 +16,11 @@ import { extractErrorMessage } from '../../utils/errors/ErrorUtils';
 import { readFileIfExistsAsync } from '../../utils/File';
 import { ReadinessContributor, ReadinessStatus } from '../../utils/ReadinessContributor';
 import { byteSize } from '../../utils/String';
+import { DeferredValidationInitializer, InitializationStatus, ValidationTrigger } from '../../utils/ValidationUtils';
 import { DiagnosticCoordinator } from '../DiagnosticCoordinator';
-import { getRulesForPack, getAvailableRulePacks, GuardRuleData } from './GeneratedGuardRules';
-import { GuardEngine, GuardViolation, GuardRule } from './GuardEngine';
+import { getAvailableRulePacks, getRulesForPack, GuardRuleData } from './GeneratedGuardRules';
+import { GuardEngine, GuardRule, GuardViolation } from './GuardEngine';
 import { RuleConfiguration } from './RuleConfiguration';
-
-export enum ValidationTrigger {
-    OnOpen = 'onOpen',
-    OnChange = 'onChange',
-    OnSave = 'onSave',
-}
 
 /**
  * GuardService provides policy-as-code validation for CloudFormation templates
@@ -43,7 +38,10 @@ interface ValidationQueueEntry {
     reject: (error: Error) => void;
 }
 
-export class GuardService implements SettingsConfigurable, Closeable, ReadinessContributor {
+export class GuardService
+    extends DeferredValidationInitializer
+    implements SettingsConfigurable, Closeable, ReadinessContributor
+{
     private static readonly CFN_GUARD_SOURCE = 'cfn-guard';
 
     private settings: GuardSettings;
@@ -62,9 +60,6 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
     // Cache loaded rules
     private enabledRules: GuardRule[] = [];
 
-    // Track async rule loading state
-    private isLoadingRules = false;
-
     // Validation queuing for concurrent requests
     private readonly validationQueue: ValidationQueueEntry[] = [];
     private readonly activeValidations = new Map<string, Promise<GuardViolation[]>>();
@@ -80,6 +75,11 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
         ruleConfiguration?: RuleConfiguration,
         delayer?: Delayer<void>,
     ) {
+        super(
+            () => this.settings.enabled,
+            documentManager,
+            async () => await this.loadRulesUnlessDisabled(),
+        );
         this.settings = DefaultSettings.diagnostics.cfnGuard;
         this.delayer = delayer ?? new Delayer<void>(this.settings.delayMs);
         this.guardEngine = guardEngine ?? new GuardEngine();
@@ -87,36 +87,46 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
 
         // Initialize rule configuration with current settings
         this.ruleConfiguration.updateFromSettings(this.settings);
-
-        // Load initial rules
-        this.loadRulesUnlessDisabled();
     }
 
-    private loadRulesUnlessDisabled() {
-        if (!this.settings.enabled) {
-            this.enabledRules = [];
-            this.log.info(`cfn-guard is disabled, skipping rules load`);
-            return;
+    private async loadRulesUnlessDisabled(): Promise<void> {
+        const settingsAtLoadStart = this.settings;
+        const enabledRules = await this.getEnabledRulesByConfiguration();
+        if (this.settings === settingsAtLoadStart) {
+            this.enabledRules = enabledRules;
         }
+        this.rebuildRuleCustomMessages();
+    }
 
-        this.isLoadingRules = true;
-        this.getEnabledRulesByConfiguration()
-            .then((rules) => {
-                this.enabledRules = rules;
-            })
-            .catch((error) => {
-                this.log.error(`Failed to load rules: ${extractErrorMessage(error)}`);
-            })
-            .finally(() => {
-                this.isLoadingRules = false;
-            });
+    private rebuildRuleCustomMessages(): void {
+        this.ruleCustomMessages.clear();
+        for (const rule of this.enabledRules) {
+            if (rule.message) {
+                this.ruleCustomMessages.set(rule.name, rule.message);
+            }
+            this.recordCustomMessages(rule.content);
+        }
+    }
+
+    private recordCustomMessages(content: string): void {
+        const ruleBlockMatches = content.matchAll(
+            // eslint-disable-next-line security/detect-unsafe-regex
+            /^rule\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:when\s+[^{]+)?\s*\{([\s\S]*?)^\}/gm,
+        );
+        for (const match of ruleBlockMatches) {
+            const ruleName = match[1];
+            const extractedMessage = GuardEngine.extractRuleMessage(match[0]);
+            if (extractedMessage) {
+                this.ruleCustomMessages.set(ruleName, extractedMessage);
+            }
+        }
     }
 
     public isReady(): ReadinessStatus {
-        if (!this.settings.enabled) {
+        if (!this.isInitializationRequired()) {
             return { ready: true };
         }
-        return { ready: !this.isLoadingRules && this.enabledRules.length > 0 };
+        return { ready: this.status === InitializationStatus.Initialized && this.enabledRules.length > 0 };
     }
 
     /**
@@ -130,9 +140,6 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
         }
 
         this.settings = settingsManager.getCurrentSettings().diagnostics.cfnGuard;
-
-        // Load rules with current settings
-        this.loadRulesUnlessDisabled();
 
         // Subscribe to diagnostics settings changes
         this.settingsSubscription = settingsManager.subscribe('diagnostics', (newDiagnosticsSettings) => {
@@ -159,10 +166,13 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
             return;
         }
 
-        // Rule metadata is rebuilt by the load below, or dropped entirely while disabled.
         this.ruleToPacksMap.clear();
         this.ruleCustomMessages.clear();
-        this.loadRulesUnlessDisabled();
+        this.enabledRules = [];
+        this.resetInitialization();
+        void this.initializeIfRequired().catch((error) => {
+            this.log.error(`Failed to reload rules: ${extractErrorMessage(error)}`);
+        });
     }
 
     /**
@@ -170,11 +180,11 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
      *
      * @param content The template content as a string
      * @param uri The document URI
-     * @param forceUseContent If true, always use the provided content (for consistency with CfnLintService)
+     * @param _forceUseContent If true, always use the provided content (for consistency with CfnLintService)
      */
     @Count({ name: 'validate', captureErrorType: true })
     async validate(content: string, uri: string, _forceUseContent?: boolean): Promise<void> {
-        if (!this.settings.enabled) {
+        if (!this.isInitializationRequired()) {
             // Keeps the cfn-guard WASM module and rule packs out of memory when the feature is off.
             this.telemetry.count('validate.disabled', 1);
             this.publishDiagnostics(uri, []);
@@ -209,6 +219,8 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
         const sizeCategory = doc?.getTemplateSizeCategory() ?? 'unknown';
 
         try {
+            await this.initializeIfRequired();
+
             // Validate rule configuration against available packs
             const availablePacks = getAvailableRulePacks();
             const validationErrors = this.validateRuleConfiguration(availablePacks);
@@ -649,6 +661,7 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
     private async ensureRulesLoaded(): Promise<void> {
         if (this.enabledRules.length === 0) {
             this.enabledRules = await this.getEnabledRulesByConfiguration();
+            this.rebuildRuleCustomMessages();
         }
     }
 
@@ -746,18 +759,7 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
         }
 
         // Extract messages from rule blocks and store them
-        const ruleBlockMatches = content.matchAll(
-            // eslint-disable-next-line security/detect-unsafe-regex
-            /^rule\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:when\s+[^{]+)?\s*\{([\s\S]*?)^\}/gm,
-        );
-        for (const match of ruleBlockMatches) {
-            const ruleName = match[1];
-            const ruleContent = match[0];
-            const extractedMessage = GuardEngine.extractRuleMessage(ruleContent);
-            if (extractedMessage) {
-                this.ruleCustomMessages.set(ruleName, extractedMessage);
-            }
-        }
+        this.recordCustomMessages(content);
 
         if (ruleNames.length === 0) {
             this.log.warn(`No valid rules found in file '${filePath}'`);
@@ -786,27 +788,6 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
     }
 
     /**
-     * Parse a single rule block
-     */
-    private parseRuleBlock(ruleName: string, fullRuleContent: string): GuardRule | null {
-        // Extract message from rule content if available
-        const extractedMessage = GuardEngine.extractRuleMessage(fullRuleContent);
-
-        const description = `Custom rule ${ruleName}`;
-        const message = extractedMessage ?? undefined; // Let Guard engine handle default messaging
-
-        return {
-            name: ruleName,
-            content: fullRuleContent,
-            description,
-            severity: this.getDefaultSeverity(),
-            tags: ['custom', 'file'],
-            pack: 'custom',
-            message,
-        };
-    }
-
-    /**
      * Convert GuardRuleData to GuardRule format expected by GuardEngine
      */
     private convertRuleDataToGuardRule(ruleData: GuardRuleData): GuardRule {
@@ -819,29 +800,6 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
             pack: 'generated', // All rules are from generated data
             message: ruleData.message,
         };
-    }
-
-    /**
-     * Convert severity string to DiagnosticSeverity enum
-     */
-    private convertSeverityStringToDiagnosticSeverity(severity: string): DiagnosticSeverity {
-        switch (severity.toUpperCase()) {
-            case 'ERROR': {
-                return DiagnosticSeverity.Error;
-            }
-            case 'WARNING': {
-                return DiagnosticSeverity.Warning;
-            }
-            case 'INFO': {
-                return DiagnosticSeverity.Information;
-            }
-            case 'HINT': {
-                return DiagnosticSeverity.Hint;
-            }
-            default: {
-                return DiagnosticSeverity.Error;
-            }
-        }
     }
 
     /**
@@ -865,6 +823,8 @@ export class GuardService implements SettingsConfigurable, Closeable, ReadinessC
 
         // Clear active validations (don't wait for them to complete)
         this.activeValidations.clear();
+        this.enabledRules = [];
+        this.resetInitialization();
     }
 
     /**

--- a/src/services/guard/GuardService.ts
+++ b/src/services/guard/GuardService.ts
@@ -219,6 +219,10 @@ export class GuardService
         const sizeCategory = doc?.getTemplateSizeCategory() ?? 'unknown';
 
         try {
+            if (this.status === InitializationStatus.Failed) {
+                this.resetInitialization();
+            }
+
             if (!(await this.initializeIfRequired())) {
                 this.telemetry.count('validate.disabled', 1);
                 this.publishDiagnostics(uri, []);
@@ -797,6 +801,8 @@ export class GuardService
      * Shutdown the Guard service and clean up resources
      */
     close(): void {
+        this.markClosed();
+
         // Unsubscribe from settings changes
         if (this.settingsSubscription) {
             this.settingsSubscription.unsubscribe();
@@ -815,7 +821,6 @@ export class GuardService
         // Clear active validations (don't wait for them to complete)
         this.activeValidations.clear();
         this.enabledRules = [];
-        this.resetInitialization();
     }
 
     /**

--- a/src/services/guard/GuardService.ts
+++ b/src/services/guard/GuardService.ts
@@ -77,7 +77,7 @@ export class GuardService
     ) {
         super(
             () => this.settings.enabled,
-            documentManager,
+            () => documentManager.hasFilesOfType(CloudFormationFileType.Template),
             async () => await this.loadRulesUnlessDisabled(),
         );
         this.settings = DefaultSettings.diagnostics.cfnGuard;

--- a/src/services/guard/GuardService.ts
+++ b/src/services/guard/GuardService.ts
@@ -219,7 +219,11 @@ export class GuardService
         const sizeCategory = doc?.getTemplateSizeCategory() ?? 'unknown';
 
         try {
-            await this.initializeIfRequired();
+            if (!(await this.initializeIfRequired())) {
+                this.telemetry.count('validate.disabled', 1);
+                this.publishDiagnostics(uri, []);
+                return;
+            }
 
             // Validate rule configuration against available packs
             const availablePacks = getAvailableRulePacks();
@@ -228,9 +232,6 @@ export class GuardService
                 this.log.warn(`Rule configuration errors: ${validationErrors.join(', ')}`);
                 // Continue with validation but log the issues
             }
-
-            // Wait for rules to be loaded if they're still loading
-            await this.ensureRulesLoaded();
 
             if (this.enabledRules.length === 0) {
                 this.publishDiagnostics(uri, []);
@@ -653,16 +654,6 @@ export class GuardService
         }
 
         return errors;
-    }
-
-    /**
-     * Ensure rules are loaded before validation
-     */
-    private async ensureRulesLoaded(): Promise<void> {
-        if (this.enabledRules.length === 0) {
-            this.enabledRules = await this.getEnabledRulesByConfiguration();
-            this.rebuildRuleCustomMessages();
-        }
     }
 
     /**

--- a/src/utils/Retry.ts
+++ b/src/utils/Retry.ts
@@ -9,6 +9,7 @@ export type RetryOptions = {
     jitterFactor?: number;
     operationName: string;
     totalTimeoutMs: number;
+    shouldRetry?: (error: Error) => boolean;
 };
 
 export function sleep(ms: number): Promise<void> {
@@ -48,9 +49,7 @@ export async function retryWithExponentialBackoff<T>(
     fn: () => Promise<T>,
     options: RetryOptions,
     log: Logger,
-    sleepFn: (ms: number) => Promise<void> = (ms: number) => {
-        return sleep(ms);
-    },
+    sleepFn: (ms: number) => Promise<void> = sleep,
 ): Promise<T> {
     const {
         maxRetries = DefaultRetryOptions.maxRetries,
@@ -60,6 +59,7 @@ export async function retryWithExponentialBackoff<T>(
         jitterFactor = DefaultRetryOptions.jitterFactor,
         operationName,
         totalTimeoutMs,
+        shouldRetry,
     } = options;
 
     if (backoffMultiplier < 1) {
@@ -86,6 +86,10 @@ export async function retryWithExponentialBackoff<T>(
             return await fn();
         } catch (error) {
             lastError = error instanceof Error ? error : new Error(extractErrorMessage(error));
+            if (shouldRetry && !shouldRetry(lastError)) {
+                throw lastError;
+            }
+
             if (attemptIdx === attempts - 1) {
                 throw new Error(`${operationName} failed after ${attempts} attempts. Last error: ${lastError.message}`);
             }

--- a/src/utils/ValidationUtils.ts
+++ b/src/utils/ValidationUtils.ts
@@ -1,0 +1,69 @@
+import { DocumentManager } from '../document/DocumentManager';
+
+export enum InitializationStatus {
+    Uninitialized = 0,
+    Initializing = 1,
+    Initialized = 2,
+    Failed = 3,
+}
+
+export enum ValidationTrigger {
+    OnOpen = 'onOpen',
+    OnChange = 'onChange',
+    OnSave = 'onSave',
+}
+
+export abstract class DeferredValidationInitializer {
+    private initPromise?: Promise<void>;
+    private initializationGeneration = 0;
+    protected status = InitializationStatus.Uninitialized;
+
+    protected constructor(
+        private readonly isEnabled: () => boolean,
+        private readonly validationDocumentManager: DocumentManager,
+        private readonly initializeValidation: () => Promise<void>,
+    ) {}
+
+    protected isInitializationRequired(): boolean {
+        return this.isEnabled() && this.validationDocumentManager.hasTemplateFiles();
+    }
+
+    protected async initializeIfRequired(): Promise<boolean> {
+        if (!this.isInitializationRequired()) {
+            return false;
+        }
+
+        if (this.status === InitializationStatus.Uninitialized) {
+            const generation = this.initializationGeneration;
+            this.status = InitializationStatus.Initializing;
+            const initializationPromise = this.initializeValidation();
+            this.initPromise = initializationPromise;
+
+            try {
+                await initializationPromise;
+                if (generation === this.initializationGeneration) {
+                    this.status = InitializationStatus.Initialized;
+                }
+            } catch (error) {
+                if (generation === this.initializationGeneration) {
+                    this.status = InitializationStatus.Failed;
+                }
+                throw error;
+            } finally {
+                if (this.initPromise === initializationPromise) {
+                    this.initPromise = undefined;
+                }
+            }
+        } else if (this.status === InitializationStatus.Initializing && this.initPromise) {
+            await this.initPromise;
+        }
+
+        return true;
+    }
+
+    protected resetInitialization(): void {
+        this.initializationGeneration += 1;
+        this.initPromise = undefined;
+        this.status = InitializationStatus.Uninitialized;
+    }
+}

--- a/src/utils/ValidationUtils.ts
+++ b/src/utils/ValidationUtils.ts
@@ -13,6 +13,7 @@ export enum ValidationTrigger {
 
 export abstract class DeferredValidationInitializer {
     private initPromise?: Promise<void>;
+    private initializationError?: Error;
     private initializationGeneration = 0;
     protected status = InitializationStatus.Uninitialized;
 
@@ -27,41 +28,78 @@ export abstract class DeferredValidationInitializer {
     }
 
     protected async initializeIfRequired(): Promise<boolean> {
-        if (!this.isInitializationRequired()) {
-            return false;
-        }
+        while (this.isInitializationRequired()) {
+            switch (this.status) {
+                case InitializationStatus.Uninitialized: {
+                    const generation = this.initializationGeneration;
+                    this.status = InitializationStatus.Initializing;
+                    this.initializationError = undefined;
 
-        if (this.status === InitializationStatus.Uninitialized) {
-            const generation = this.initializationGeneration;
-            this.status = InitializationStatus.Initializing;
-            const initializationPromise = this.initializeValidation();
-            this.initPromise = initializationPromise;
+                    let initializationPromise: Promise<void>;
+                    try {
+                        initializationPromise = this.initializeValidation();
+                    } catch (error) {
+                        if (generation === this.initializationGeneration) {
+                            const initializationError = this.toInitializationError(error);
+                            this.status = InitializationStatus.Failed;
+                            this.initializationError = initializationError;
+                            throw initializationError;
+                        }
+                        continue;
+                    }
 
-            try {
-                await initializationPromise;
-                if (generation === this.initializationGeneration) {
-                    this.status = InitializationStatus.Initialized;
+                    this.initPromise = initializationPromise;
+                    await this.awaitInitialization(generation, initializationPromise);
+                    break;
                 }
-            } catch (error) {
-                if (generation === this.initializationGeneration) {
-                    this.status = InitializationStatus.Failed;
+                case InitializationStatus.Initializing: {
+                    if (!this.initPromise) {
+                        throw new Error('Validation initialization is in progress without an initialization promise.');
+                    }
+                    await this.awaitInitialization(this.initializationGeneration, this.initPromise);
+                    break;
                 }
-                throw error;
-            } finally {
-                if (this.initPromise === initializationPromise) {
-                    this.initPromise = undefined;
+                case InitializationStatus.Initialized: {
+                    return true;
+                }
+                case InitializationStatus.Failed: {
+                    throw this.initializationError ?? new Error('Validation initialization failed.');
                 }
             }
-        } else if (this.status === InitializationStatus.Initializing && this.initPromise) {
-            await this.initPromise;
         }
 
-        return true;
+        return false;
+    }
+
+    private async awaitInitialization(generation: number, initializationPromise: Promise<void>): Promise<void> {
+        try {
+            await initializationPromise;
+            if (generation === this.initializationGeneration) {
+                this.status = InitializationStatus.Initialized;
+                this.initializationError = undefined;
+            }
+        } catch (error) {
+            if (generation === this.initializationGeneration) {
+                const initializationError = this.toInitializationError(error);
+                this.status = InitializationStatus.Failed;
+                this.initializationError = initializationError;
+                throw initializationError;
+            }
+        } finally {
+            if (this.initPromise === initializationPromise) {
+                this.initPromise = undefined;
+            }
+        }
+    }
+
+    private toInitializationError(error: unknown): Error {
+        return error instanceof Error ? error : new Error(String(error));
     }
 
     protected resetInitialization(): void {
         this.initializationGeneration += 1;
         this.initPromise = undefined;
+        this.initializationError = undefined;
         this.status = InitializationStatus.Uninitialized;
     }
 }

--- a/src/utils/ValidationUtils.ts
+++ b/src/utils/ValidationUtils.ts
@@ -1,5 +1,3 @@
-import { DocumentManager } from '../document/DocumentManager';
-
 export enum InitializationStatus {
     Uninitialized = 0,
     Initializing = 1,
@@ -20,12 +18,12 @@ export abstract class DeferredValidationInitializer {
 
     protected constructor(
         private readonly isEnabled: () => boolean,
-        private readonly validationDocumentManager: DocumentManager,
+        private readonly hasValidationDocuments: () => boolean,
         private readonly initializeValidation: () => Promise<void>,
     ) {}
 
     protected isInitializationRequired(): boolean {
-        return this.isEnabled() && this.validationDocumentManager.hasTemplateFiles();
+        return this.isEnabled() && this.hasValidationDocuments();
     }
 
     protected async initializeIfRequired(): Promise<boolean> {

--- a/src/utils/ValidationUtils.ts
+++ b/src/utils/ValidationUtils.ts
@@ -12,6 +12,7 @@ export enum ValidationTrigger {
 }
 
 export abstract class DeferredValidationInitializer {
+    private isClosed = false;
     private initPromise?: Promise<void>;
     private initializationError?: Error;
     private initializationGeneration = 0;
@@ -24,7 +25,7 @@ export abstract class DeferredValidationInitializer {
     ) {}
 
     protected isInitializationRequired(): boolean {
-        return this.isEnabled() && this.hasValidationDocuments();
+        return !this.isClosed && this.isEnabled() && this.hasValidationDocuments();
     }
 
     protected async initializeIfRequired(): Promise<boolean> {
@@ -94,6 +95,15 @@ export abstract class DeferredValidationInitializer {
 
     private toInitializationError(error: unknown): Error {
         return error instanceof Error ? error : new Error(String(error));
+    }
+
+    protected markClosed(): void {
+        if (this.isClosed) {
+            return;
+        }
+
+        this.isClosed = true;
+        this.resetInitialization();
     }
 
     protected resetInitialization(): void {

--- a/src/utils/errors/ErrorClasses.ts
+++ b/src/utils/errors/ErrorClasses.ts
@@ -31,6 +31,14 @@ export class WorkerNotInitializedError extends Error {
     }
 }
 
+export class WorkerShutdownError extends Error {
+    constructor(options?: ErrorOptions) {
+        super('Worker shutdown', options);
+        this.name = 'WorkerShutdownError';
+        Object.setPrototypeOf(this, WorkerShutdownError.prototype);
+    }
+}
+
 export class CfnLintInitializationError extends Error {
     public readonly phase: string;
 

--- a/tools/lspClient/LspClient.ts
+++ b/tools/lspClient/LspClient.ts
@@ -31,6 +31,7 @@ export class LspClient implements LspConnection {
     public readonly encryptionKey: Buffer;
     public readonly clientId: string;
     private isShutdown = false;
+    private isServerProcessClosed = false;
     private workspaceConfig: Record<string, unknown>[];
 
     private documentMetadata: DocumentMetadata[] = [];
@@ -171,6 +172,10 @@ export class LspClient implements LspConnection {
             } else {
                 this.serverLogger.info(`Process exited with code ${code}`);
             }
+        });
+
+        this.serverProcess.on('close', () => {
+            this.isServerProcessClosed = true;
         });
     }
 
@@ -328,11 +333,22 @@ export class LspClient implements LspConnection {
         return (await this.sendRequest('aws/system/status', {})) as GetSystemStatusResponse;
     }
 
+    private waitForServerProcessClose(): Promise<void> {
+        if (this.isServerProcessClosed) {
+            return Promise.resolve();
+        }
+
+        return new Promise<void>((resolve) => {
+            this.serverProcess.once('close', () => resolve());
+        });
+    }
+
     async shutdown() {
         if (this.isShutdown) return;
 
         this.clientLogger.info('LSP connection shutting down');
         this.isShutdown = true;
+        const serverProcessClose = this.waitForServerProcessClose();
 
         try {
             await this.connection.sendRequest('shutdown', {});
@@ -342,6 +358,9 @@ export class LspClient implements LspConnection {
         }
 
         this.connection.dispose();
-        this.serverProcess.kill();
+        if (!this.isServerProcessClosed) {
+            this.serverProcess.kill();
+        }
+        await serverProcessClose;
     }
 }

--- a/tst/unit/document/DocumentManager.test.ts
+++ b/tst/unit/document/DocumentManager.test.ts
@@ -48,6 +48,28 @@ describe('DocumentManager', () => {
         });
     });
 
+    describe('hasFilesOfType', () => {
+        it('should detect tracked templates and GitSync deployment files independently', () => {
+            const template = new Document(
+                TextDocument.create(
+                    'file:///template.yaml',
+                    'yaml',
+                    1,
+                    'Resources:\n  Bucket:\n    Type: AWS::S3::Bucket',
+                ),
+            );
+            const deployment = new Document(
+                TextDocument.create('file:///deployment.json', 'json', 1, '{"template-file-path":"template.yaml"}'),
+            );
+            documentManager.updateDocument(template.uri, template);
+            documentManager.updateDocument(deployment.uri, deployment);
+
+            expect(documentManager.hasFilesOfType(CloudFormationFileType.Template)).toBe(true);
+            expect(documentManager.hasFilesOfType(CloudFormationFileType.GitSyncDeployment)).toBe(true);
+            expect(documentManager.hasFilesOfType(CloudFormationFileType.Other)).toBe(false);
+        });
+    });
+
     describe('updateDocument', () => {
         it('should update cached document', () => {
             const uri = 'file:///template.yaml';

--- a/tst/unit/handlers/DocumentHandler.test.ts
+++ b/tst/unit/handlers/DocumentHandler.test.ts
@@ -10,7 +10,7 @@ import {
     didCloseHandler,
     didSaveHandler,
 } from '../../../src/handlers/DocumentHandler';
-import { LintTrigger } from '../../../src/services/cfnLint/CfnLintService';
+import { ValidationTrigger } from '../../../src/utils/ValidationUtils';
 import { createMockComponents, MockedServerComponents } from '../../utils/MockServerComponents';
 import { Templates } from '../../utils/TemplateUtils';
 import { flushAllPromises } from '../../utils/Utils';
@@ -68,9 +68,9 @@ describe('DocumentHandler', () => {
             const handler = didOpenHandler(mockServices);
             handler(createEvent());
 
-            expect(mockServices.cfnLintService.lintDelayed.calledWith(testContent, testUri, LintTrigger.OnOpen)).toBe(
-                true,
-            );
+            expect(
+                mockServices.cfnLintService.lintDelayed.calledWith(testContent, testUri, ValidationTrigger.OnOpen),
+            ).toBe(true);
             expect(mockServices.guardService.validateDelayed.calledWith(testContent, testUri)).toBe(true);
         });
 
@@ -84,9 +84,9 @@ describe('DocumentHandler', () => {
             const handler = didOpenHandler(mockServices);
             handler(createEvent());
 
-            expect(mockServices.cfnLintService.lintDelayed.calledWith(testContent, testUri, LintTrigger.OnOpen)).toBe(
-                true,
-            );
+            expect(
+                mockServices.cfnLintService.lintDelayed.calledWith(testContent, testUri, ValidationTrigger.OnOpen),
+            ).toBe(true);
         });
 
         it('should handle errors when adding syntax tree', () => {
@@ -151,7 +151,7 @@ describe('DocumentHandler', () => {
                 mockServices.cfnLintService.lintDelayed.calledWith(
                     expectedContent,
                     testUri,
-                    LintTrigger.OnChange,
+                    ValidationTrigger.OnChange,
                     true,
                 ),
             ).toBe(true);
@@ -267,7 +267,12 @@ describe('DocumentHandler', () => {
 
             expect(mockServices.syntaxTreeManager.add.calledWith(testUri, newContent)).toBe(true);
             expect(
-                mockServices.cfnLintService.lintDelayed.calledWith(newContent, testUri, LintTrigger.OnChange, true),
+                mockServices.cfnLintService.lintDelayed.calledWith(
+                    newContent,
+                    testUri,
+                    ValidationTrigger.OnChange,
+                    true,
+                ),
             ).toBe(true);
             expect(mockServices.guardService.validateDelayed.calledWith(newContent, testUri)).toBe(true);
         });
@@ -422,9 +427,9 @@ describe('DocumentHandler', () => {
             const handler = didSaveHandler(mockServices);
             handler(createEvent());
 
-            expect(mockServices.cfnLintService.lintDelayed.calledWith(testContent, testUri, LintTrigger.OnSave)).toBe(
-                true,
-            );
+            expect(
+                mockServices.cfnLintService.lintDelayed.calledWith(testContent, testUri, ValidationTrigger.OnSave),
+            ).toBe(true);
             expect(mockServices.guardService.validateDelayed.calledWith(testContent, testUri)).toBe(true);
         });
 

--- a/tst/unit/handlers/DocumentHandler.test.ts
+++ b/tst/unit/handlers/DocumentHandler.test.ts
@@ -10,6 +10,7 @@ import {
     didCloseHandler,
     didSaveHandler,
 } from '../../../src/handlers/DocumentHandler';
+import { RequestCancellationError } from '../../../src/utils/errors/ErrorClasses';
 import { ValidationTrigger } from '../../../src/utils/ValidationUtils';
 import { createMockComponents, MockedServerComponents } from '../../utils/MockServerComponents';
 import { Templates } from '../../utils/TemplateUtils';
@@ -305,8 +306,8 @@ describe('DocumentHandler', () => {
         it('should handle linting and Guard validation cancellation gracefully', async () => {
             const textDocument = createTextDocument();
             mockDocuments({ get: vi.fn().mockReturnValue(textDocument) });
-            mockServices.cfnLintService.lintDelayed.rejects(new Error('Request cancelled'));
-            mockServices.guardService.validateDelayed.rejects(new Error('Request cancelled'));
+            mockServices.cfnLintService.lintDelayed.rejects(new RequestCancellationError(testUri));
+            mockServices.guardService.validateDelayed.rejects(new RequestCancellationError(testUri));
 
             const handler = didChangeHandler(mockServices.documents, mockServices);
 

--- a/tst/unit/handlers/Initialize.test.ts
+++ b/tst/unit/handlers/Initialize.test.ts
@@ -1,40 +1,26 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import { WorkspaceFolder } from 'vscode-languageserver';
 import { initializedHandler } from '../../../src/handlers/Initialize';
 import { createMockComponents } from '../../utils/MockServerComponents';
 import { flushAllPromises } from '../../utils/Utils';
 
 describe('InitializeHandler', () => {
-    const mockWorkspaceFolder: WorkspaceFolder = {
-        uri: 'file:///test',
-        name: 'test',
-    };
     let mockServices: ReturnType<typeof createMockComponents>;
 
     beforeEach(() => {
         vi.clearAllMocks();
         mockServices = createMockComponents();
-        mockServices.workspace.getAllWorkspaceFolders.returns([mockWorkspaceFolder]);
-        mockServices.cfnLintService.initialize.returns(Promise.resolve());
-        mockServices.cfnLintService.mountFolder.returns(Promise.resolve());
-
-        // Mock the settingsManager.syncConfiguration method
         vi.spyOn(mockServices.settingsManager, 'syncConfiguration').mockResolvedValue();
     });
 
-    test('should sync configuration and defer cfnLintService initialization', async () => {
-        mockServices.workspace.getAllWorkspaceFolders.returns([mockWorkspaceFolder]);
+    test('should sync configuration and defer cfn-lint initialization and mounting', async () => {
+        const handler = initializedHandler(mockServices);
 
-        const syncConfigSpy = vi.spyOn(mockServices.settingsManager, 'syncConfiguration').mockResolvedValue();
-
-        const handler = initializedHandler(mockServices.lsp.workspace, mockServices);
         handler();
-
-        // Wait for all async operations to complete
         await flushAllPromises();
 
-        expect(syncConfigSpy).toHaveBeenCalled();
+        expect(mockServices.settingsManager.syncConfiguration).toHaveBeenCalled();
+        expect(mockServices.schemaRetriever.initialize.calledOnce).toBe(true);
         expect(mockServices.cfnLintService.initialize.called).toBe(false);
-        expect(mockServices.cfnLintService.mountFolder.calledWith(mockWorkspaceFolder)).toBe(true);
+        expect(mockServices.cfnLintService.mountFolder.called).toBe(false);
     });
 });

--- a/tst/unit/handlers/Initialize.test.ts
+++ b/tst/unit/handlers/Initialize.test.ts
@@ -22,9 +22,8 @@ describe('InitializeHandler', () => {
         vi.spyOn(mockServices.settingsManager, 'syncConfiguration').mockResolvedValue();
     });
 
-    test('should sync configuration and initialize cfnLintService', async () => {
+    test('should sync configuration and defer cfnLintService initialization', async () => {
         mockServices.workspace.getAllWorkspaceFolders.returns([mockWorkspaceFolder]);
-        mockServices.cfnLintService.initialize.returns(Promise.resolve());
 
         const syncConfigSpy = vi.spyOn(mockServices.settingsManager, 'syncConfiguration').mockResolvedValue();
 
@@ -35,7 +34,7 @@ describe('InitializeHandler', () => {
         await flushAllPromises();
 
         expect(syncConfigSpy).toHaveBeenCalled();
-        expect(mockServices.cfnLintService.initialize.called).toBe(true);
+        expect(mockServices.cfnLintService.initialize.called).toBe(false);
         expect(mockServices.cfnLintService.mountFolder.calledWith(mockWorkspaceFolder)).toBe(true);
     });
 });

--- a/tst/unit/protocol/LspConnection.test.ts
+++ b/tst/unit/protocol/LspConnection.test.ts
@@ -73,10 +73,15 @@ describe('LspConnection', () => {
     });
 
     describe('shutdown and exit', () => {
-        it('should call custom shutdown handler', () => {
+        it('should return custom shutdown handler result', () => {
+            const expectedResult = Promise.resolve();
+            mockHandlers.onShutdown.mockReturnValue(expectedResult);
             const shutdownHandler = mockConnection.onShutdown.mock.calls[0][0];
-            shutdownHandler();
+
+            const result = shutdownHandler();
+
             expect(mockHandlers.onShutdown).toHaveBeenCalled();
+            expect(result).toBe(expectedResult);
         });
 
         it('should call custom exit handler', () => {

--- a/tst/unit/services/cfnLint/CfnLintService.test.ts
+++ b/tst/unit/services/cfnLint/CfnLintService.test.ts
@@ -1137,12 +1137,33 @@ describe('CfnLintService', () => {
             expect(mockWorkerManager.shutdown.called).toBe(true);
         });
 
-        test('should do nothing when not initialized', async () => {
+        test('should not reinitialize when an in-flight initialization settles after close', async () => {
+            let resolveInitialization!: () => void;
+            const initializationResult = new Promise<void>((resolve) => {
+                resolveInitialization = resolve;
+            });
+            mockWorkerManager.initialize.onFirstCall().returns(initializationResult);
+            mockWorkerManager.initialize.onSecondCall().resolves();
+
+            const initialization = service.initialize();
+            expect(mockWorkerManager.initialize.calledOnce).toBe(true);
+
+            await service.close();
+            resolveInitialization();
+            await initialization;
+
+            expect(mockWorkerManager.initialize.calledOnce).toBe(true);
+            expect(mockWorkerManager.shutdown.calledOnce).toBe(true);
+            expect(service.isInitialized()).toBe(false);
+        });
+
+        test('should close the worker manager when not initialized', async () => {
             expect(service.isInitialized()).toBe(false);
 
             await service.close();
 
             expect(service.isInitialized()).toBe(false);
+            expect(mockWorkerManager.shutdown.calledOnce).toBe(true);
         });
     });
 

--- a/tst/unit/services/cfnLint/CfnLintService.test.ts
+++ b/tst/unit/services/cfnLint/CfnLintService.test.ts
@@ -11,7 +11,7 @@ import { PyodideWorkerManager } from '../../../../src/services/cfnLint/PyodideWo
 import { SettingsState } from '../../../../src/settings/Settings';
 import { Delayer } from '../../../../src/utils/Delayer';
 import { createMockComponents, createMockSettingsManager } from '../../../utils/MockServerComponents';
-import { WorkerNotInitializedError } from '../../../../src/utils/errors/ErrorClasses';
+import { MountError, WorkerNotInitializedError } from '../../../../src/utils/errors/ErrorClasses';
 import { ValidationTrigger } from '../../../../src/utils/ValidationUtils';
 
 function createMockComponentsWithOpenTemplate(): ReturnType<typeof createMockComponents> {
@@ -373,6 +373,52 @@ describe('CfnLintService', () => {
             // Mount same folder again - should not call worker
             await service.mountFolder(mockWorkspaceFolder);
             expect(mockWorkerManager.mountFolder.callCount).toBe(1);
+        });
+
+        test('should share one mount between concurrent callers for the same folder', async () => {
+            let resolveMount!: () => void;
+            const pendingMount = new Promise<void>((resolve) => {
+                resolveMount = resolve;
+            });
+            mockWorkerManager.mountFolder.returns(pendingMount);
+            await service.initialize();
+
+            const firstMount = service.mountFolder({ ...mockWorkspaceFolder });
+            const secondMount = service.mountFolder({ ...mockWorkspaceFolder });
+
+            await vi.waitFor(() => expect(mockWorkerManager.mountFolder.calledOnce).toBe(true));
+            resolveMount();
+            await Promise.all([firstMount, secondMount]);
+
+            expect(mockWorkerManager.mountFolder.calledOnce).toBe(true);
+        });
+
+        test('should share mount failures between concurrent callers and allow retry', async () => {
+            let rejectMount!: (error: Error) => void;
+            const pendingMount = new Promise<void>((_resolve, reject) => {
+                rejectMount = reject;
+            });
+            mockWorkerManager.mountFolder.returns(pendingMount);
+            await service.initialize();
+
+            const firstMountOutcome = service
+                .mountFolder({ ...mockWorkspaceFolder })
+                .then(undefined, (error: unknown) => error);
+            const secondMountOutcome = service
+                .mountFolder({ ...mockWorkspaceFolder })
+                .then(undefined, (error: unknown) => error);
+
+            await vi.waitFor(() => expect(mockWorkerManager.mountFolder.calledOnce).toBe(true));
+            rejectMount(new Error('Mount failed'));
+            const [firstError, secondError] = await Promise.all([firstMountOutcome, secondMountOutcome]);
+
+            expect(firstError).toBeInstanceOf(MountError);
+            expect(secondError).toBe(firstError);
+            expect(mockWorkerManager.mountFolder.calledOnce).toBe(true);
+
+            mockWorkerManager.mountFolder.resolves();
+            await service.mountFolder({ ...mockWorkspaceFolder });
+            expect(mockWorkerManager.mountFolder.callCount).toBe(2);
         });
 
         test('should remount folders after worker recovery', async () => {

--- a/tst/unit/services/cfnLint/CfnLintService.test.ts
+++ b/tst/unit/services/cfnLint/CfnLintService.test.ts
@@ -14,9 +14,15 @@ import { createMockComponents, createMockSettingsManager } from '../../../utils/
 import { WorkerNotInitializedError } from '../../../../src/utils/errors/ErrorClasses';
 import { ValidationTrigger } from '../../../../src/utils/ValidationUtils';
 
+function createMockComponentsWithOpenTemplate(): ReturnType<typeof createMockComponents> {
+    const components = createMockComponents();
+    components.documentManager.hasFilesOfType.returns(true);
+    return components;
+}
+
 // Helper functions for special test cases that need different configurations
 const createServiceWithFileType = (fileType: CloudFormationFileType) => {
-    const components = createMockComponents();
+    const components = createMockComponentsWithOpenTemplate();
     components.diagnostics.publishDiagnostics.resolves();
     const mockFile = stubInterface<Document>();
     (mockFile as any).cfnFileType = fileType;
@@ -40,7 +46,7 @@ const createTestServiceWithState = (
         initializationPromise?: Promise<void>;
     } = {},
 ) => {
-    const components = createMockComponents();
+    const components = createMockComponentsWithOpenTemplate();
     components.diagnostics.publishDiagnostics.resolves();
 
     const workerManager = stubInterface<PyodideWorkerManager>();
@@ -82,7 +88,7 @@ const createGitSyncService = (lintFileResult: any[] = []) => {
     gitSyncWorkerManager.initialize.resolves();
     gitSyncWorkerManager.lintFile.resolves(lintFileResult);
 
-    const gitSyncComponents = createMockComponents();
+    const gitSyncComponents = createMockComponentsWithOpenTemplate();
     gitSyncComponents.diagnostics.publishDiagnostics.resolves();
     const mockFile = stubInterface<Document>();
     (mockFile as any).cfnFileType = CloudFormationFileType.GitSyncDeployment;
@@ -222,7 +228,7 @@ describe('CfnLintService', () => {
         };
 
         // Use createMockComponents for consistent mocking
-        mockComponents = createMockComponents();
+        mockComponents = createMockComponentsWithOpenTemplate();
 
         // Set up the publishDiagnostics mock to return a Promise
         mockComponents.diagnostics.publishDiagnostics.resolves();
@@ -595,7 +601,7 @@ describe('CfnLintService', () => {
             gitSyncWorkerManager.initialize.resolves();
             gitSyncWorkerManager.lintFile.resolves([]); // Empty results to trigger the GitSync logic
 
-            const gitSyncComponents = createMockComponents();
+            const gitSyncComponents = createMockComponentsWithOpenTemplate();
             gitSyncComponents.diagnostics.publishDiagnostics.resolves();
             const mockFile = stubInterface<Document>();
             (mockFile as any).cfnFileType = CloudFormationFileType.GitSyncDeployment;
@@ -728,7 +734,7 @@ describe('CfnLintService', () => {
             const uninitializedDelayer = stubObject<Delayer<void>>(new Delayer<void>(1000));
 
             const uninitializedService = CfnLintService.create(
-                createMockComponents(),
+                createMockComponentsWithOpenTemplate(),
                 uninitializedWorkerManager,
                 uninitializedDelayer,
             );
@@ -756,6 +762,143 @@ describe('CfnLintService', () => {
             await lintPromise;
 
             ensureSpy.mockRestore();
+        });
+
+        test('should settle a superseded queued request and retain the latest request', async () => {
+            const pendingInitialization = new Promise<void>(() => {});
+            const ensureSpy = vi.spyOn(service as any, 'ensureInitialized').mockReturnValue(pendingInitialization);
+
+            const firstLint = service.lintDelayed('first content', mockUri, ValidationTrigger.OnOpen);
+            const firstRequest = (service as any).requestQueue.get(mockUri);
+            const firstRejectSpy = sinon.spy(firstRequest, 'reject');
+
+            const secondLint = service.lintDelayed('latest content', mockUri, ValidationTrigger.OnOpen);
+
+            expect(firstRejectSpy.calledOnce).toBe(true);
+            expect(firstRejectSpy.firstCall.args[0]).toMatchObject({
+                name: 'CancellationError',
+                message: `Request cancelled for key: ${mockUri}`,
+            });
+            await expect(firstLint).resolves.toBeUndefined();
+            expect((service as any).requestQueue.get(mockUri).content).toBe('latest content');
+
+            service.cancelDelayedLinting(mockUri);
+            await expect(secondLint).resolves.toBeUndefined();
+            expect((service as any).requestQueue.size).toBe(0);
+            ensureSpy.mockRestore();
+        });
+
+        test('should not let a stale initialization failure reject a replacement request', async () => {
+            let rejectFirstInitialization!: (reason: unknown) => void;
+            let rejectSecondInitialization!: (reason: unknown) => void;
+            const firstInitialization = new Promise<void>((_resolve, reject) => {
+                rejectFirstInitialization = reject;
+            });
+            const secondInitialization = new Promise<void>((_resolve, reject) => {
+                rejectSecondInitialization = reject;
+            });
+            const ensureSpy = vi
+                .spyOn(service as any, 'ensureInitialized')
+                .mockReturnValueOnce(firstInitialization)
+                .mockReturnValueOnce(secondInitialization);
+
+            const firstLint = service.lintDelayed('first content', mockUri, ValidationTrigger.OnOpen);
+            const secondLint = service.lintDelayed('latest content', mockUri, ValidationTrigger.OnOpen);
+            const secondOutcome = secondLint.then(
+                () => undefined,
+                (error: unknown) => error,
+            );
+
+            await expect(firstLint).resolves.toBeUndefined();
+
+            const staleInitializationError = new Error('Stale initialization failure');
+            rejectFirstInitialization(staleInitializationError);
+            await expect(firstInitialization).rejects.toBe(staleInitializationError);
+
+            expect((service as any).requestQueue.get(mockUri)?.content).toBe('latest content');
+
+            const currentInitializationError = new Error('Current initialization failure');
+            rejectSecondInitialization(currentInitializationError);
+            await expect(secondInitialization).rejects.toBe(currentInitializationError);
+            await expect(secondOutcome).resolves.toBe(currentInitializationError);
+            expect((service as any).requestQueue.size).toBe(0);
+            ensureSpy.mockRestore();
+        });
+
+        test('should reject every queued request when initialization fails', async () => {
+            const initializationError = new Error('Initialization failed');
+            const ensureSpy = vi.spyOn(service as any, 'ensureInitialized').mockRejectedValue(initializationError);
+
+            const firstLint = service.lintDelayed('first content', 'file:///first.yaml', ValidationTrigger.OnOpen);
+            const secondLint = service.lintDelayed('second content', 'file:///second.yaml', ValidationTrigger.OnOpen);
+
+            await expect(firstLint).rejects.toBe(initializationError);
+            await expect(secondLint).rejects.toBe(initializationError);
+            expect((service as any).requestQueue.size).toBe(0);
+            ensureSpy.mockRestore();
+        });
+
+        test('should settle a queued request when linting for its URI is cancelled', async () => {
+            const ensureSpy = vi
+                .spyOn(service as any, 'ensureInitialized')
+                .mockReturnValue(new Promise<void>(() => {}));
+            const lintPromise = service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnOpen);
+
+            service.cancelDelayedLinting(mockUri);
+
+            await expect(lintPromise).resolves.toBeUndefined();
+            expect((service as any).requestQueue.has(mockUri)).toBe(false);
+            ensureSpy.mockRestore();
+        });
+
+        test('should settle all queued requests when delayed linting is cancelled', async () => {
+            const ensureSpy = vi
+                .spyOn(service as any, 'ensureInitialized')
+                .mockReturnValue(new Promise<void>(() => {}));
+            const firstLint = service.lintDelayed('first content', 'file:///first.yaml', ValidationTrigger.OnOpen);
+            const secondLint = service.lintDelayed('second content', 'file:///second.yaml', ValidationTrigger.OnOpen);
+
+            service.cancelAllDelayedLinting();
+
+            await expect(firstLint).resolves.toBeUndefined();
+            await expect(secondLint).resolves.toBeUndefined();
+            expect((service as any).requestQueue.size).toBe(0);
+            ensureSpy.mockRestore();
+        });
+
+        test('should settle queued requests when the service closes', async () => {
+            const ensureSpy = vi
+                .spyOn(service as any, 'ensureInitialized')
+                .mockReturnValue(new Promise<void>(() => {}));
+            const lintPromise = service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnOpen);
+
+            await service.close();
+
+            await expect(lintPromise).resolves.toBeUndefined();
+            expect((service as any).requestQueue.size).toBe(0);
+            ensureSpy.mockRestore();
+        });
+
+        test('should remove queued requests before dispatching them', async () => {
+            const queuedRequest = {
+                content: mockTemplate,
+                forceUseContent: false,
+                timestamp: Date.now(),
+                resolve: sinon.stub(),
+                reject: sinon.stub(),
+            };
+            (service as any).requestQueue.set(mockUri, queuedRequest);
+            const lintStub = sinon.stub(service, 'lint').resolves();
+            mockDelayer.delay.callsFake((_key, callback) => {
+                expect((service as any).requestQueue.size).toBe(0);
+                return callback();
+            });
+
+            (service as any).processQueuedRequests();
+            await Promise.resolve();
+
+            expect(lintStub.calledOnce).toBe(true);
+            expect(queuedRequest.resolve.calledOnce).toBe(true);
         });
 
         test('should process requests through delayer when initialized', async () => {
@@ -1096,7 +1239,10 @@ describe('CfnLintService', () => {
             test('should wait and resolve when initialization completes', async () => {
                 // Create a new service instance that's initializing
                 mockComponents.diagnostics.publishDiagnostics.resolves();
-                const initializingService = CfnLintService.create(createMockComponents(), mockWorkerManager);
+                const initializingService = CfnLintService.create(
+                    createMockComponentsWithOpenTemplate(),
+                    mockWorkerManager,
+                );
 
                 // Set status to initializing
                 (initializingService as any).status = 1; // STATUS.Initializing
@@ -1142,7 +1288,10 @@ describe('CfnLintService', () => {
             test('should throw on timeout', async () => {
                 // Create a new service instance that's initializing
                 mockComponents.diagnostics.publishDiagnostics.resolves();
-                const initializingService = CfnLintService.create(createMockComponents(), mockWorkerManager);
+                const initializingService = CfnLintService.create(
+                    createMockComponentsWithOpenTemplate(),
+                    mockWorkerManager,
+                );
 
                 // Set status to initializing
                 (initializingService as any).status = 1; // STATUS.Initializing
@@ -1180,7 +1329,10 @@ describe('CfnLintService', () => {
             test('should resolve when initialization completes', async () => {
                 // Create a new service instance that's initializing
                 mockComponents.diagnostics.publishDiagnostics.resolves();
-                const initializingService = CfnLintService.create(createMockComponents(), mockWorkerManager);
+                const initializingService = CfnLintService.create(
+                    createMockComponentsWithOpenTemplate(),
+                    mockWorkerManager,
+                );
 
                 // Set status to initializing
                 (initializingService as any).status = 1; // STATUS.Initializing
@@ -1215,7 +1367,10 @@ describe('CfnLintService', () => {
             test('should throw on timeout', async () => {
                 // Create a new service instance that's initializing
                 mockComponents.diagnostics.publishDiagnostics.resolves();
-                const initializingService = CfnLintService.create(createMockComponents(), mockWorkerManager);
+                const initializingService = CfnLintService.create(
+                    createMockComponentsWithOpenTemplate(),
+                    mockWorkerManager,
+                );
 
                 // Set status to initializing
                 (initializingService as any).status = 1; // STATUS.Initializing
@@ -1250,7 +1405,10 @@ describe('CfnLintService', () => {
             test('should throw if initialization fails', async () => {
                 // Create a new service instance that's initializing
                 mockComponents.diagnostics.publishDiagnostics.resolves();
-                const initializingService = CfnLintService.create(createMockComponents(), mockWorkerManager);
+                const initializingService = CfnLintService.create(
+                    createMockComponentsWithOpenTemplate(),
+                    mockWorkerManager,
+                );
 
                 // Set status to initializing
                 (initializingService as any).status = 1; // STATUS.Initializing
@@ -1303,7 +1461,7 @@ describe('CfnLintService', () => {
                 mockWorkerManager.lintTemplate.resolves([]);
 
                 // Create a new service instance
-                const testService = CfnLintService.create(createMockComponents(), mockWorkerManager);
+                const testService = CfnLintService.create(createMockComponentsWithOpenTemplate(), mockWorkerManager);
                 (testService as any).workerManager = mockWorkerManager;
 
                 // Set the service status to initialized (skip the initialize call)
@@ -1382,7 +1540,7 @@ describe('CfnLintService', () => {
                 mockWorkerManager.lintTemplate.resolves([]);
 
                 // Create a new service instance
-                const testService = CfnLintService.create(createMockComponents(), mockWorkerManager);
+                const testService = CfnLintService.create(createMockComponentsWithOpenTemplate(), mockWorkerManager);
                 (testService as any).workerManager = mockWorkerManager;
 
                 // Set the service status to initialized (skip the initialize call)
@@ -1452,7 +1610,7 @@ describe('CfnLintService', () => {
                 mockWorkerManager.lintTemplate.rejects(new Error('Linting failed'));
 
                 // Create a new service instance
-                const testService = CfnLintService.create(createMockComponents(), mockWorkerManager);
+                const testService = CfnLintService.create(createMockComponentsWithOpenTemplate(), mockWorkerManager);
                 (testService as any).workerManager = mockWorkerManager;
 
                 // Set the service status to initialized (skip the initialize call)
@@ -1502,7 +1660,7 @@ describe('CfnLintService', () => {
 
     describe('trigger settings', () => {
         test('should respect lintOnChange setting', async () => {
-            const service = CfnLintService.create(createMockComponents(), mockWorkerManager);
+            const service = CfnLintService.create(createMockComponentsWithOpenTemplate(), mockWorkerManager);
             await service.initialize();
 
             // Create base settings and disable lintOnChange
@@ -1532,7 +1690,7 @@ describe('CfnLintService', () => {
         });
 
         test('should lint on open and save when cfnlint is enabled', async () => {
-            const service = CfnLintService.create(createMockComponents(), mockWorkerManager);
+            const service = CfnLintService.create(createMockComponentsWithOpenTemplate(), mockWorkerManager);
             await service.initialize();
 
             // Use default settings where cfnlint is enabled
@@ -1550,7 +1708,7 @@ describe('CfnLintService', () => {
         });
 
         test('should not lint on open and save when cfnlint is disabled', async () => {
-            const service = CfnLintService.create(createMockComponents(), mockWorkerManager);
+            const service = CfnLintService.create(createMockComponentsWithOpenTemplate(), mockWorkerManager);
             await service.initialize();
 
             // Create settings with cfnlint disabled
@@ -1584,7 +1742,11 @@ describe('CfnLintService', () => {
             mockDelayer.delay.callsFake((key, callback, _delayMs) => callback());
             mockDelayer.cancel.returns();
 
-            const service = CfnLintService.create(createMockComponents(), mockWorkerManager, mockDelayer);
+            const service = CfnLintService.create(
+                createMockComponentsWithOpenTemplate(),
+                mockWorkerManager,
+                mockDelayer,
+            );
             await service.initialize();
 
             const lintStub = sinon.stub(service, 'lint').resolves();
@@ -1618,7 +1780,7 @@ describe('CfnLintService', () => {
 
     describe('local cfn-lint path functionality', () => {
         test('should switch to local executor when path is set', () => {
-            const components = createMockComponents();
+            const components = createMockComponentsWithOpenTemplate();
             const service = CfnLintService.create(components);
             const baseSettings = new SettingsState().toSettings();
             const settingsWithPath = {
@@ -1640,7 +1802,7 @@ describe('CfnLintService', () => {
         });
 
         test('should switch to local executor on settings change', () => {
-            const components = createMockComponents();
+            const components = createMockComponentsWithOpenTemplate();
             const service = CfnLintService.create(components);
             const settingsManager = createMockSettingsManager();
 
@@ -1661,7 +1823,7 @@ describe('CfnLintService', () => {
         });
 
         test('should switch back to pyodide when path is cleared', () => {
-            const components = createMockComponents();
+            const components = createMockComponentsWithOpenTemplate();
             const service = CfnLintService.create(components);
             const settingsManager = createMockSettingsManager();
 
@@ -1690,7 +1852,7 @@ describe('CfnLintService', () => {
         });
 
         test('should initialize immediately when using local executor', async () => {
-            const components = createMockComponents();
+            const components = createMockComponentsWithOpenTemplate();
             const baseSettings = new SettingsState().toSettings();
             const settingsWithPath = {
                 ...baseSettings,

--- a/tst/unit/services/cfnLint/CfnLintService.test.ts
+++ b/tst/unit/services/cfnLint/CfnLintService.test.ts
@@ -273,7 +273,7 @@ describe('CfnLintService', () => {
         });
 
         test('should defer initialization and remain ready when no valid template is open', async () => {
-            mockComponents.documentManager.hasTemplateFiles.returns(false);
+            mockComponents.documentManager.hasFilesOfType.returns(false);
 
             await service.initialize();
 
@@ -342,7 +342,7 @@ describe('CfnLintService', () => {
         });
 
         test('should defer mounting when no valid template is open', async () => {
-            mockComponents.documentManager.hasTemplateFiles.returns(false);
+            mockComponents.documentManager.hasFilesOfType.returns(false);
 
             await service.mountFolder(mockWorkspaceFolder);
 
@@ -664,7 +664,7 @@ describe('CfnLintService', () => {
             const nonTemplateFile = stubInterface<Document>();
             (nonTemplateFile as any).cfnFileType = CloudFormationFileType.Other;
             mockComponents.documentManager.get.returns(nonTemplateFile);
-            mockComponents.documentManager.hasTemplateFiles.returns(false);
+            mockComponents.documentManager.hasFilesOfType.returns(false);
 
             await service.lintDelayed('name: example', mockUri, ValidationTrigger.OnOpen);
 
@@ -674,18 +674,32 @@ describe('CfnLintService', () => {
             );
         });
 
-        test('should clear GitSync diagnostics without initialization when no valid template is open', async () => {
+        test('should lazily initialize and lint a GitSync deployment file when no template is open', async () => {
             const deploymentFile = stubInterface<Document>();
             (deploymentFile as any).cfnFileType = CloudFormationFileType.GitSyncDeployment;
             mockComponents.documentManager.get.returns(deploymentFile);
-            mockComponents.documentManager.hasTemplateFiles.returns(false);
-
-            await service.lintDelayed('{"template-file-path":"template.yaml"}', mockUri, ValidationTrigger.OnOpen);
-
-            expect(mockWorkerManager.initialize.called).toBe(false);
-            expect(mockComponents.diagnosticCoordinator.publishDiagnostics.calledWith('cfn-lint', mockUri, [])).toBe(
-                true,
+            mockComponents.documentManager.hasFilesOfType.callsFake((...fileTypes) =>
+                fileTypes.includes(CloudFormationFileType.GitSyncDeployment),
             );
+            mockComponents.workspace.getWorkspaceFolder.returns(mockWorkspaceFolder);
+
+            await service.lintDelayed(mockDeploymentFile, mockUri, ValidationTrigger.OnOpen);
+
+            expect(
+                mockComponents.documentManager.hasFilesOfType.calledWith(
+                    CloudFormationFileType.Template,
+                    CloudFormationFileType.GitSyncDeployment,
+                ),
+            ).toBe(true);
+            expect(mockWorkerManager.initialize.calledOnce).toBe(true);
+            expect(mockWorkerManager.mountFolder.calledWith('/path/to/workspace/project', '/project')).toBe(true);
+            expect(
+                mockWorkerManager.lintFile.calledWith(
+                    '/project/template.yaml',
+                    mockUri,
+                    CloudFormationFileType.GitSyncDeployment,
+                ),
+            ).toBe(true);
         });
 
         test('should provide delayed linting functionality', async () => {

--- a/tst/unit/services/cfnLint/CfnLintService.test.ts
+++ b/tst/unit/services/cfnLint/CfnLintService.test.ts
@@ -6,12 +6,13 @@ import { describe, expect, beforeEach, afterEach, vi, Mock, test } from 'vitest'
 import { WorkspaceFolder, DiagnosticSeverity } from 'vscode-languageserver';
 import { URI } from 'vscode-uri';
 import { CloudFormationFileType, Document } from '../../../../src/document/Document';
-import { CfnLintService, LintTrigger, sleep } from '../../../../src/services/cfnLint/CfnLintService';
+import { CfnLintService, sleep } from '../../../../src/services/cfnLint/CfnLintService';
 import { PyodideWorkerManager } from '../../../../src/services/cfnLint/PyodideWorkerManager';
 import { SettingsState } from '../../../../src/settings/Settings';
 import { Delayer } from '../../../../src/utils/Delayer';
 import { createMockComponents, createMockSettingsManager } from '../../../utils/MockServerComponents';
 import { WorkerNotInitializedError } from '../../../../src/utils/errors/ErrorClasses';
+import { ValidationTrigger } from '../../../../src/utils/ValidationUtils';
 
 // Helper functions for special test cases that need different configurations
 const createServiceWithFileType = (fileType: CloudFormationFileType) => {
@@ -271,6 +272,33 @@ describe('CfnLintService', () => {
             expect(service.isInitialized()).toBe(true);
         });
 
+        test('should defer initialization and remain ready when no valid template is open', async () => {
+            mockComponents.documentManager.hasTemplateFiles.returns(false);
+
+            await service.initialize();
+
+            expect(mockWorkerManager.initialize.called).toBe(false);
+            expect(service.isInitialized()).toBe(false);
+            expect(service.isReady()).toEqual({ ready: true });
+        });
+
+        test('should initialize once for concurrent valid-template requests', async () => {
+            let resolveInitialization!: () => void;
+            const initialization = new Promise<void>((resolve) => {
+                resolveInitialization = resolve;
+            });
+            mockWorkerManager.initialize.returns(initialization);
+
+            const firstInitialization = service.initialize();
+            const secondInitialization = service.initialize();
+
+            expect(mockWorkerManager.initialize.calledOnce).toBe(true);
+            resolveInitialization();
+            await Promise.all([firstInitialization, secondInitialization]);
+
+            expect(service.isInitialized()).toBe(true);
+        });
+
         test('should not reinitialize if already initialized', async () => {
             await service.initialize();
             // Reset call history
@@ -306,10 +334,20 @@ describe('CfnLintService', () => {
             expect(mockWorkerManager.mountFolder.calledWith('/path/to/workspace/project', '/project')).toBe(true);
         });
 
-        test('should throw error if not initialized', async () => {
-            await expect(service.mountFolder(mockWorkspaceFolder)).rejects.toThrow(
-                'CfnLintService not initialized. Call initialize() first.',
-            );
+        test('should lazily initialize before mounting', async () => {
+            await service.mountFolder(mockWorkspaceFolder);
+
+            expect(mockWorkerManager.initialize.calledOnce).toBe(true);
+            expect(mockWorkerManager.mountFolder.calledOnce).toBe(true);
+        });
+
+        test('should defer mounting when no valid template is open', async () => {
+            mockComponents.documentManager.hasTemplateFiles.returns(false);
+
+            await service.mountFolder(mockWorkspaceFolder);
+
+            expect(mockWorkerManager.initialize.called).toBe(false);
+            expect(mockWorkerManager.mountFolder.called).toBe(false);
         });
 
         test('should handle mounting errors', async () => {
@@ -338,11 +376,11 @@ describe('CfnLintService', () => {
 
             // Simulate worker crash - this sets status to uninitialized
             mockWorkerManager.lintTemplate.rejects(new Error('Worker crashed'));
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnSave);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnSave);
 
             // Reset mock to succeed and trigger recovery
             mockWorkerManager.lintTemplate.resolves([]);
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnSave);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnSave);
 
             // Should have remounted during recovery
             expect(mockWorkerManager.mountFolder.callCount).toBe(2);
@@ -612,6 +650,44 @@ describe('CfnLintService', () => {
     });
 
     describe('delayed linting', () => {
+        test('should lazily initialize and process repeated valid-template requests', async () => {
+            const lintStub = sinon.stub(service, 'lint').resolves();
+
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnOpen);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnOpen);
+
+            expect(mockWorkerManager.initialize.calledOnce).toBe(true);
+            expect(lintStub.callCount).toBe(2);
+        });
+
+        test('should clear diagnostics without initialization when no valid template is open', async () => {
+            const nonTemplateFile = stubInterface<Document>();
+            (nonTemplateFile as any).cfnFileType = CloudFormationFileType.Other;
+            mockComponents.documentManager.get.returns(nonTemplateFile);
+            mockComponents.documentManager.hasTemplateFiles.returns(false);
+
+            await service.lintDelayed('name: example', mockUri, ValidationTrigger.OnOpen);
+
+            expect(mockWorkerManager.initialize.called).toBe(false);
+            expect(mockComponents.diagnosticCoordinator.publishDiagnostics.calledWith('cfn-lint', mockUri, [])).toBe(
+                true,
+            );
+        });
+
+        test('should clear GitSync diagnostics without initialization when no valid template is open', async () => {
+            const deploymentFile = stubInterface<Document>();
+            (deploymentFile as any).cfnFileType = CloudFormationFileType.GitSyncDeployment;
+            mockComponents.documentManager.get.returns(deploymentFile);
+            mockComponents.documentManager.hasTemplateFiles.returns(false);
+
+            await service.lintDelayed('{"template-file-path":"template.yaml"}', mockUri, ValidationTrigger.OnOpen);
+
+            expect(mockWorkerManager.initialize.called).toBe(false);
+            expect(mockComponents.diagnosticCoordinator.publishDiagnostics.calledWith('cfn-lint', mockUri, [])).toBe(
+                true,
+            );
+        });
+
         test('should provide delayed linting functionality', async () => {
             await service.initialize();
             mockComponents.workspace.getWorkspaceFolder.returns(undefined);
@@ -619,7 +695,7 @@ describe('CfnLintService', () => {
             // Replace the lint method with a function that tracks calls
             const lintStub = sinon.stub(service, 'lint').resolves();
 
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnChange);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnChange);
 
             expect(mockDelayer.delay.called).toBe(true);
             expect(lintStub.calledWith(mockTemplate, mockUri)).toBe(true);
@@ -649,7 +725,7 @@ describe('CfnLintService', () => {
                 .mockResolvedValueOnce(undefined);
 
             // Call lintDelayed (should queue the request)
-            const lintPromise = uninitializedService.lintDelayed(mockTemplate, mockUri, LintTrigger.OnChange);
+            const lintPromise = uninitializedService.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnChange);
 
             // Verify request was queued
             expect((uninitializedService as any).requestQueue.size).toBe(1);
@@ -673,7 +749,7 @@ describe('CfnLintService', () => {
 
             const lintStub = sinon.stub(service, 'lint').resolves();
 
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnChange);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnChange);
 
             expect(mockDelayer.delay.called).toBe(true);
             expect(lintStub.calledWith(mockTemplate, mockUri)).toBe(true);
@@ -1433,11 +1509,11 @@ describe('CfnLintService', () => {
             const lintStub = sinon.stub(service, 'lint').resolves();
 
             // Should not lint when lintOnChange is disabled
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnChange);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnChange);
             expect(lintStub.called).toBe(false);
 
             // Should still lint for other triggers
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnOpen);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnOpen);
             expect(lintStub.called).toBe(true);
         });
 
@@ -1449,13 +1525,13 @@ describe('CfnLintService', () => {
             const lintStub = sinon.stub(service, 'lint').resolves();
 
             // Should lint on open when cfnlint is enabled
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnOpen);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnOpen);
             expect(lintStub.calledOnce).toBe(true);
 
             lintStub.resetHistory();
 
             // Should lint on save when cfnlint is enabled
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnSave);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnSave);
             expect(lintStub.calledOnce).toBe(true);
         });
 
@@ -1481,11 +1557,11 @@ describe('CfnLintService', () => {
             const lintStub = sinon.stub(service, 'lint').resolves();
 
             // Should not lint on open when cfnlint is disabled
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnOpen);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnOpen);
             expect(lintStub.called).toBe(false);
 
             // Should not lint on save when cfnlint is disabled
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnSave);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnSave);
             expect(lintStub.called).toBe(false);
         });
 
@@ -1500,7 +1576,7 @@ describe('CfnLintService', () => {
             const lintStub = sinon.stub(service, 'lint').resolves();
 
             // Test OnSave behavior
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnSave);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnSave);
 
             // The delayer.delay method handles cancellation internally, so we don't expect explicit cancel calls
             // Should call delayer.delay with 0ms delay for OnSave
@@ -1515,7 +1591,7 @@ describe('CfnLintService', () => {
             mockDelayer.delay.resetHistory();
 
             // Test OnChange behavior for comparison
-            await service.lintDelayed(mockTemplate, mockUri, LintTrigger.OnChange);
+            await service.lintDelayed(mockTemplate, mockUri, ValidationTrigger.OnChange);
             // Should call delayer.delay without custom delay (uses default)
             const changeDelayCall = mockDelayer.delay.getCall(0); // First call after reset
             expect(changeDelayCall.args[0]).toBe(mockUri);

--- a/tst/unit/services/cfnLint/PyodideWorkerManager.test.ts
+++ b/tst/unit/services/cfnLint/PyodideWorkerManager.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, beforeEach, vi, test, Mock } from 'vitest';
 import { CloudFormationFileType } from '../../../../src/document/Document';
 import { PyodideWorkerManager } from '../../../../src/services/cfnLint/PyodideWorkerManager';
 import { CfnLintSettings } from '../../../../src/settings/Settings';
+import { WorkerShutdownError } from '../../../../src/utils/errors/ErrorClasses';
 import * as RetryModule from '../../../../src/utils/Retry';
 import { mockLogger } from '../../../utils/MockServerComponents';
 
@@ -510,6 +511,75 @@ describe('PyodideWorkerManager', () => {
         });
     });
 
+    describe('shutdown during initialization', () => {
+        test('should terminate the in-flight worker and stop initialization retries', async () => {
+            mockWorker.postMessage.callsFake((message: { id: string }) => {
+                if (message.id !== '1') {
+                    queueMicrotask(() => {
+                        messageHandler({
+                            id: message.id,
+                            error: 'Unexpected retry after shutdown',
+                            success: false,
+                        });
+                    });
+                }
+            });
+            const retryingWorkerManager = new PyodideWorkerManager(
+                {
+                    maxRetries: 1,
+                    initialDelayMs: 0,
+                    maxDelayMs: 0,
+                    backoffMultiplier: 1,
+                    totalTimeoutMs: 5000,
+                },
+                createDefaultCfnLintSettings(),
+                mockLogging,
+            );
+
+            const initialization = retryingWorkerManager.initialize();
+            const shutdown = retryingWorkerManager.shutdown();
+
+            await expect(initialization).rejects.toBeInstanceOf(WorkerShutdownError);
+            await shutdown;
+            expect(workerConstructor).toHaveBeenCalledTimes(1);
+            expect(mockWorker.terminate.calledOnce).toBe(true);
+        });
+
+        test('should not create a worker after shutdown during retry backoff', async () => {
+            workerConstructor.mockImplementationOnce(function () {
+                throw new Error('Initial worker creation failed');
+            });
+            mockWorker.postMessage.callsFake((message: { id: string }) => {
+                queueMicrotask(() => {
+                    messageHandler({
+                        id: message.id,
+                        error: 'Unexpected worker creation after shutdown',
+                        success: false,
+                    });
+                });
+            });
+            const retryingWorkerManager = new PyodideWorkerManager(
+                {
+                    maxRetries: 1,
+                    initialDelayMs: 100,
+                    maxDelayMs: 100,
+                    backoffMultiplier: 1,
+                    totalTimeoutMs: 5000,
+                },
+                createDefaultCfnLintSettings(),
+                mockLogging,
+            );
+
+            const initialization = retryingWorkerManager.initialize();
+            const initializationResult = initialization.catch((error: unknown) => error);
+            await waitUntil(() => mockLogging.warn.calledOnce, { timeout: 1000 });
+
+            await retryingWorkerManager.shutdown();
+            await expect(initializationResult).resolves.toBeInstanceOf(WorkerShutdownError);
+            expect(workerConstructor).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('shutdown', () => {
         beforeEach(async () => {
             // Initialize the worker manager
@@ -554,6 +624,22 @@ describe('PyodideWorkerManager', () => {
             expect((workerManager as any).worker).toBeUndefined();
             expect((workerManager as any).initialized).toBe(false);
             expect((workerManager as any).initializationPromise).toBeUndefined();
+        });
+
+        test('should reject initialization after shutdown', async () => {
+            await workerManager.shutdown();
+            mockWorker.postMessage.callsFake((message: { id: string }) => {
+                queueMicrotask(() => {
+                    messageHandler({
+                        id: message.id,
+                        error: 'Unexpected worker creation after shutdown',
+                        success: false,
+                    });
+                });
+            });
+
+            await expect(workerManager.initialize()).rejects.toBeInstanceOf(WorkerShutdownError);
+            expect(workerConstructor).toHaveBeenCalledTimes(1);
         });
 
         test('should do nothing if not initialized', async () => {
@@ -759,6 +845,7 @@ describe('PyodideWorkerManager', () => {
                     totalTimeoutMs: 9999,
                     jitterFactor: 0.1,
                     operationName: 'Pyodide initialization',
+                    shouldRetry: expect.any(Function),
                 }),
                 expect.anything(),
             );

--- a/tst/unit/services/guard/GuardService.test.ts
+++ b/tst/unit/services/guard/GuardService.test.ts
@@ -30,8 +30,9 @@ describe('GuardService', () => {
     };
 
     beforeEach(() => {
-        // Create mock components
+        // Create mock components with an open template by default
         mockComponents = createMockComponents();
+        mockComponents.documentManager.hasFilesOfType.returns(true);
 
         // Create mock GuardEngine
         mockGuardEngine = stubInterface<GuardEngine>();

--- a/tst/unit/services/guard/GuardService.test.ts
+++ b/tst/unit/services/guard/GuardService.test.ts
@@ -5,10 +5,11 @@ import { DiagnosticSeverity } from 'vscode-languageserver';
 import { CloudFormationFileType, Document } from '../../../../src/document/Document';
 import { getAvailableRulePacks } from '../../../../src/services/guard/GeneratedGuardRules';
 import { GuardEngine, GuardViolation } from '../../../../src/services/guard/GuardEngine';
-import { GuardService, ValidationTrigger } from '../../../../src/services/guard/GuardService';
+import { GuardService } from '../../../../src/services/guard/GuardService';
 import { RuleConfiguration } from '../../../../src/services/guard/RuleConfiguration';
 import { GuardSettings, DefaultSettings, DiagnosticsSettings } from '../../../../src/settings/Settings';
 import { Delayer } from '../../../../src/utils/Delayer';
+import { InitializationStatus, ValidationTrigger } from '../../../../src/utils/ValidationUtils';
 import { createMockComponents, createMockSettingsManager } from '../../../utils/MockServerComponents';
 
 describe('GuardService', () => {
@@ -149,6 +150,52 @@ describe('GuardService', () => {
                     [],
                 ),
             ).toBe(true);
+        });
+
+        it('should skip rule loading and validation when no valid template is open', async () => {
+            mockComponents.documentManager.hasTemplateFiles.returns(false);
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration').resolves([]);
+
+            await guardService.validate('content', 'file:///template.yaml');
+
+            expect(loadRules.called).toBe(false);
+            expect(mockGuardEngine.validateTemplate.called).toBe(false);
+            expect(
+                mockComponents.diagnosticCoordinator.publishDiagnostics.calledWith(
+                    'cfn-guard',
+                    'file:///template.yaml',
+                    [],
+                ),
+            ).toBe(true);
+        });
+
+        it('should load rules once and validate repeated requests', async () => {
+            const mockRules = [{ name: 'test-rule', content: 'rule test {}', pack: 'test' }];
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration').resolves(mockRules);
+
+            await guardService.validate('content', 'file:///template.yaml');
+            await guardService.validate('content', 'file:///template.yaml');
+
+            expect(loadRules.calledOnce).toBe(true);
+            expect(mockGuardEngine.validateTemplate.callCount).toBe(2);
+        });
+
+        it('should share rule initialization between concurrent validations', async () => {
+            const mockRules = [{ name: 'test-rule', content: 'rule test {}', pack: 'test' }];
+            let resolveRules!: (rules: typeof mockRules) => void;
+            const rulesPromise = new Promise<typeof mockRules>((resolve) => {
+                resolveRules = resolve;
+            });
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration').returns(rulesPromise);
+
+            const firstValidation = guardService.validate('content', 'file:///first.yaml');
+            const secondValidation = guardService.validate('content', 'file:///second.yaml');
+
+            expect(loadRules.calledOnce).toBe(true);
+            resolveRules(mockRules);
+            await Promise.all([firstValidation, secondValidation]);
+
+            expect(mockGuardEngine.validateTemplate.callCount).toBe(2);
         });
 
         it('should validate template and publish diagnostics for violations', async () => {
@@ -546,29 +593,104 @@ describe('GuardService', () => {
             guardService.configure(mockSettingsManager);
         });
 
-        it('should trigger revalidation when rulesFile setting changes', () => {
+        it('should reload rules when the rulesFile setting changes', async () => {
+            const mockRules = [{ name: 'test-rule', content: 'rule test {}', pack: 'test' }];
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration').resolves(mockRules);
             const mockSettingsManager = createMockSettingsManager({
                 diagnostics: {
                     cfnGuard: defaultSettings,
                 },
             } as any);
-
-            // Configure with initial settings
             guardService.configure(mockSettingsManager);
-
-            // Get the callback that was registered
             const settingsCallback = mockSettingsManager.subscribe.getCall(0).args[1];
 
-            // Call the callback with new settings that have rulesFile
+            await guardService.validate('content', 'file:///template.yaml');
             settingsCallback({
                 cfnGuard: {
                     ...defaultSettings,
                     rulesFile: '/new/path/rules.guard',
                 },
             } as any);
+            await guardService.validate('content', 'file:///template.yaml');
 
-            // Verify the callback was called (revalidation would be triggered)
-            expect(mockSettingsManager.subscribe.called).toBe(true);
+            expect(loadRules.callCount).toBe(2);
+            expect(mockGuardEngine.validateTemplate.callCount).toBe(2);
+        });
+
+        it('should defer a rulesFile reload until a valid template is open', async () => {
+            const mockRules = [{ name: 'test-rule', content: 'rule test {}', pack: 'test' }];
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration').resolves(mockRules);
+            const mockSettingsManager = createMockSettingsManager({
+                diagnostics: {
+                    cfnGuard: defaultSettings,
+                },
+            } as any);
+            guardService.configure(mockSettingsManager);
+            const settingsCallback = mockSettingsManager.subscribe.getCall(0).args[1];
+            mockComponents.documentManager.hasTemplateFiles.returns(false);
+
+            settingsCallback({
+                cfnGuard: {
+                    ...defaultSettings,
+                    rulesFile: '/new/path/rules.guard',
+                },
+            } as any);
+            await Promise.resolve();
+            expect(loadRules.called).toBe(false);
+
+            mockComponents.documentManager.hasTemplateFiles.returns(true);
+            await guardService.validate('content', 'file:///template.yaml');
+
+            expect(loadRules.calledOnce).toBe(true);
+            expect(mockGuardEngine.validateTemplate.calledOnce).toBe(true);
+        });
+
+        it('should keep newer custom messages when an older rulesFile load finishes last', async () => {
+            let resolveOldLoad!: () => void;
+            let resolveNewLoad!: () => void;
+            const oldLoad = new Promise<void>((resolve) => {
+                resolveOldLoad = resolve;
+            });
+            const newLoad = new Promise<void>((resolve) => {
+                resolveNewLoad = resolve;
+            });
+            const parseRules = (guardService as any).parseRulesFromContent.bind(guardService);
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration');
+            loadRules.onFirstCall().callsFake(async () => {
+                await oldLoad;
+                return parseRules(
+                    'rule SHARED_RULE {\n    Resources exists\n    <<\n        Violation: old settings\n    >>\n}',
+                    '/old/rules.guard',
+                );
+            });
+            loadRules.onSecondCall().callsFake(async () => {
+                await newLoad;
+                return parseRules(
+                    'rule SHARED_RULE {\n    Resources exists\n    <<\n        Violation: new settings\n    >>\n}',
+                    '/new/rules.guard',
+                );
+            });
+            const mockSettingsManager = createMockSettingsManager({
+                diagnostics: {
+                    cfnGuard: { ...defaultSettings, rulesFile: '/old/rules.guard' },
+                },
+            } as any);
+            guardService.configure(mockSettingsManager);
+            const settingsCallback = mockSettingsManager.subscribe.getCall(0).args[1];
+
+            const oldValidation = guardService.validate('content', 'file:///old-template.yaml');
+            settingsCallback({
+                cfnGuard: { ...defaultSettings, rulesFile: '/new/rules.guard' },
+            } as any);
+            const newValidation = guardService.validate('content', 'file:///new-template.yaml');
+
+            resolveNewLoad();
+            await newValidation;
+            resolveOldLoad();
+            await oldValidation;
+
+            expect(loadRules.callCount).toBe(2);
+            expect((guardService as any).ruleCustomMessages.get('SHARED_RULE')).toBe('Violation: new settings');
         });
 
         it('should show error diagnostic when rulesFile cannot be read', async () => {
@@ -690,11 +812,16 @@ rule S3_BUCKET_ENCRYPTION {
             expect(result).toEqual({ ready: false });
         });
 
-        it('should return not ready when loading rules', () => {
+        it('should return ready when no valid template is open', () => {
+            mockComponents.documentManager.hasTemplateFiles.returns(false);
             const service = GuardService.create(mockComponents, mockGuardEngine, mockRuleConfiguration, mockDelayer);
 
-            // Set the loading state via private property access
-            (service as any).isLoadingRules = true;
+            expect(service.isReady()).toEqual({ ready: true });
+        });
+
+        it('should return not ready while required rule initialization is in progress', () => {
+            const service = GuardService.create(mockComponents, mockGuardEngine, mockRuleConfiguration, mockDelayer);
+            (service as any).status = InitializationStatus.Initializing;
 
             const result = service.isReady();
             expect(result).toEqual({ ready: false });

--- a/tst/unit/services/guard/GuardService.test.ts
+++ b/tst/unit/services/guard/GuardService.test.ts
@@ -133,16 +133,19 @@ describe('GuardService', () => {
             ).toBe(true);
         });
 
-        it('should publish empty diagnostics for GitSync deployment files', async () => {
+        it('should publish empty diagnostics without loading rules for a GitSync deployment file', async () => {
             const mockFile = stubInterface<Document>();
             Object.defineProperty(mockFile, 'cfnFileType', {
                 value: CloudFormationFileType.GitSyncDeployment,
                 writable: true,
             });
             mockComponents.documentManager.get.returns(mockFile);
+            mockComponents.documentManager.hasFilesOfType.returns(false);
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration').resolves([]);
 
             await guardService.validate('content', 'file:///deployment.json');
 
+            expect(loadRules.called).toBe(false);
             expect(
                 mockComponents.diagnosticCoordinator.publishDiagnostics.calledWith(
                     'cfn-guard',
@@ -153,7 +156,7 @@ describe('GuardService', () => {
         });
 
         it('should skip rule loading and validation when no valid template is open', async () => {
-            mockComponents.documentManager.hasTemplateFiles.returns(false);
+            mockComponents.documentManager.hasFilesOfType.returns(false);
             const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration').resolves([]);
 
             await guardService.validate('content', 'file:///template.yaml');
@@ -627,7 +630,7 @@ describe('GuardService', () => {
             } as any);
             guardService.configure(mockSettingsManager);
             const settingsCallback = mockSettingsManager.subscribe.getCall(0).args[1];
-            mockComponents.documentManager.hasTemplateFiles.returns(false);
+            mockComponents.documentManager.hasFilesOfType.returns(false);
 
             settingsCallback({
                 cfnGuard: {
@@ -638,7 +641,7 @@ describe('GuardService', () => {
             await Promise.resolve();
             expect(loadRules.called).toBe(false);
 
-            mockComponents.documentManager.hasTemplateFiles.returns(true);
+            mockComponents.documentManager.hasFilesOfType.returns(true);
             await guardService.validate('content', 'file:///template.yaml');
 
             expect(loadRules.calledOnce).toBe(true);
@@ -813,7 +816,7 @@ rule S3_BUCKET_ENCRYPTION {
         });
 
         it('should return ready when no valid template is open', () => {
-            mockComponents.documentManager.hasTemplateFiles.returns(false);
+            mockComponents.documentManager.hasFilesOfType.returns(false);
             const service = GuardService.create(mockComponents, mockGuardEngine, mockRuleConfiguration, mockDelayer);
 
             expect(service.isReady()).toEqual({ ready: true });

--- a/tst/unit/services/guard/GuardService.test.ts
+++ b/tst/unit/services/guard/GuardService.test.ts
@@ -202,6 +202,44 @@ describe('GuardService', () => {
             expect(mockGuardEngine.validateTemplate.callCount).toBe(2);
         });
 
+        it('should stop an in-flight validation when Guard is disabled during rule initialization', async () => {
+            const settingsManager = createMockSettingsManager({
+                diagnostics: {
+                    cfnGuard: defaultSettings,
+                },
+            } as any);
+            guardService.configure(settingsManager);
+            const mockRules = [{ name: 'test-rule', content: 'rule test {}', pack: 'test' }];
+            let resolveRules!: (rules: typeof mockRules) => void;
+            const rulesPromise = new Promise<typeof mockRules>((resolve) => {
+                resolveRules = resolve;
+            });
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration').returns(rulesPromise);
+
+            const validation = guardService.validate('content', 'file:///template.yaml');
+            expect(loadRules.calledOnce).toBe(true);
+
+            const settingsCallback = settingsManager.subscribe.getCall(0).args[1];
+            settingsCallback({
+                cfnGuard: {
+                    ...defaultSettings,
+                    enabled: false,
+                },
+            } as DiagnosticsSettings);
+            resolveRules(mockRules);
+            await validation;
+
+            expect(loadRules.calledOnce).toBe(true);
+            expect(mockGuardEngine.validateTemplate.called).toBe(false);
+            expect(
+                mockComponents.diagnosticCoordinator.publishDiagnostics.calledWith(
+                    'cfn-guard',
+                    'file:///template.yaml',
+                    [],
+                ),
+            ).toBe(true);
+        });
+
         it('should validate template and publish diagnostics for violations', async () => {
             const mockFile = stubInterface<Document>();
             Object.defineProperty(mockFile, 'cfnFileType', {

--- a/tst/unit/services/guard/GuardService.test.ts
+++ b/tst/unit/services/guard/GuardService.test.ts
@@ -184,6 +184,26 @@ describe('GuardService', () => {
             expect(mockGuardEngine.validateTemplate.callCount).toBe(2);
         });
 
+        it('should retry a transient rule-load failure on the next validation', async () => {
+            const initializationError = new Error('Temporary rules-file read failure');
+            const mockRules = [{ name: 'test-rule', content: 'rule test {}', pack: 'test' }];
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration');
+            loadRules.onFirstCall().rejects(initializationError);
+            loadRules.onSecondCall().resolves(mockRules);
+
+            await guardService.validate('content', 'file:///template.yaml');
+
+            expect(loadRules.calledOnce).toBe(true);
+            expect((guardService as any).status).toBe(InitializationStatus.Failed);
+            expect(mockGuardEngine.validateTemplate.called).toBe(false);
+
+            await guardService.validate('content', 'file:///template.yaml');
+
+            expect(loadRules.calledTwice).toBe(true);
+            expect((guardService as any).status).toBe(InitializationStatus.Initialized);
+            expect(mockGuardEngine.validateTemplate.calledOnce).toBe(true);
+        });
+
         it('should share rule initialization between concurrent validations', async () => {
             const mockRules = [{ name: 'test-rule', content: 'rule test {}', pack: 'test' }];
             let resolveRules!: (rules: typeof mockRules) => void;
@@ -619,6 +639,26 @@ describe('GuardService', () => {
 
             expect(mockUnsubscribe.called).toBe(true);
             expect(mockDelayer.cancelAll.called).toBe(true);
+        });
+
+        it('should not reload rules when an in-flight load settles after close', async () => {
+            let resolveRuleLoad!: (rules: never[]) => void;
+            const firstRuleLoad = new Promise<never[]>((resolve) => {
+                resolveRuleLoad = resolve;
+            });
+            const loadRules = stub(guardService as any, 'getEnabledRulesByConfiguration');
+            loadRules.onFirstCall().returns(firstRuleLoad);
+            loadRules.onSecondCall().resolves([]);
+
+            const validation = guardService.validate('content', 'file:///template.yaml');
+            expect(loadRules.calledOnce).toBe(true);
+
+            guardService.close();
+            resolveRuleLoad([]);
+            await validation;
+
+            expect(loadRules.calledOnce).toBe(true);
+            expect(mockGuardEngine.validateTemplate.called).toBe(false);
         });
     });
 

--- a/tst/unit/tools/lspClient/LspClient.test.ts
+++ b/tst/unit/tools/lspClient/LspClient.test.ts
@@ -1,0 +1,73 @@
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { describe, beforeEach, expect, it, vi } from 'vitest';
+import { LspClient } from '../../../../tools/lspClient/LspClient';
+
+vi.mock('child_process', async () => {
+    const childProcess = await vi.importActual<typeof import('child_process')>('child_process');
+    return { ...childProcess, spawn: vi.fn() };
+});
+
+// EventEmitter matches Node's ChildProcess event contract used by LspClient.
+// eslint-disable-next-line unicorn/prefer-event-target
+class TestChildProcess extends EventEmitter {
+    readonly stdout = new PassThrough();
+    readonly stderr = new PassThrough();
+    readonly kill = vi.fn(() => true);
+}
+
+describe('LspClient', () => {
+    let serverProcess: TestChildProcess;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        serverProcess = new TestChildProcess();
+        vi.mocked(spawn).mockReturnValue(serverProcess as unknown as ReturnType<typeof spawn>);
+    });
+
+    it('should wait for the server process to close before resolving shutdown', async () => {
+        let notifyKillCalled: () => void;
+        const killCalled = new Promise<void>((resolve) => {
+            notifyKillCalled = resolve;
+        });
+        serverProcess.kill.mockImplementation(() => {
+            notifyKillCalled();
+            return true;
+        });
+
+        const client = new LspClient({
+            serverPath: '/test/cfn-lsp-server.js',
+            mode: 'ipc',
+            clientConfig: { name: 'test-client', version: '1.0.0' },
+            awsConfig: {
+                clientInfo: {
+                    clientId: 'test-client',
+                    extension: { name: 'test-extension', version: '1.0.0' },
+                },
+                telemetryEnabled: false,
+            },
+        });
+        const connection = {
+            sendRequest: vi.fn().mockResolvedValue(undefined),
+            sendNotification: vi.fn().mockResolvedValue(undefined),
+            dispose: vi.fn(),
+        };
+        Object.assign(client, { connection });
+
+        let shutdownResolved = false;
+        const shutdownPromise = client.shutdown().then(() => {
+            shutdownResolved = true;
+        });
+        await killCalled;
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(shutdownResolved).toBe(false);
+
+        serverProcess.emit('close', 0, 'SIGTERM');
+        await shutdownPromise;
+
+        expect(connection.dispose).toHaveBeenCalledOnce();
+        expect(serverProcess.kill).toHaveBeenCalledOnce();
+    });
+});

--- a/tst/unit/utils/Retry.test.ts
+++ b/tst/unit/utils/Retry.test.ts
@@ -192,6 +192,27 @@ describe('retryWithExponentialBackoff', () => {
         expect(sleepFn.args[1][0]).toBe(20); // 10 * 2^1 = 20
     });
 
+    it('should not retry when the failure is non-retryable', async () => {
+        const nonRetryableError = new Error('Operation shut down');
+        const mockFn = vi.fn().mockRejectedValue(nonRetryableError);
+        const shouldRetry = vi.fn().mockReturnValue(false);
+
+        const retryResult = retryWithExponentialBackoff(
+            mockFn,
+            {
+                ...options,
+                shouldRetry,
+            },
+            mockLog,
+            sleepFn,
+        );
+
+        await expect(retryResult).rejects.toBe(nonRetryableError);
+        expect(shouldRetry).toHaveBeenCalledWith(nonRetryableError);
+        expect(mockFn).toHaveBeenCalledTimes(1);
+        expect(sleepFn.callCount).toBe(0);
+    });
+
     it('should log warnings on retry attempts', async () => {
         const mockFn = vi.fn().mockRejectedValueOnce(new Error('Test error')).mockResolvedValue('success');
 

--- a/tst/unit/utils/ValidationUtils.test.ts
+++ b/tst/unit/utils/ValidationUtils.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { DocumentManager } from '../../../src/document/DocumentManager';
 import { DeferredValidationInitializer, InitializationStatus } from '../../../src/utils/ValidationUtils';
 
 class TestValidationInitializer extends DeferredValidationInitializer {
-    constructor(isEnabled: () => boolean, documentManager: DocumentManager, initializeValidation: () => Promise<void>) {
-        super(isEnabled, documentManager, initializeValidation);
+    constructor(
+        isEnabled: () => boolean,
+        hasValidationDocuments: () => boolean,
+        initializeValidation: () => Promise<void>,
+    ) {
+        super(isEnabled, hasValidationDocuments, initializeValidation);
     }
 
     initialize(): Promise<boolean> {
@@ -20,10 +23,8 @@ class TestValidationInitializer extends DeferredValidationInitializer {
     }
 }
 
-function createDocumentManager(hasValidTemplate: boolean): DocumentManager {
-    return {
-        hasValidTemplate: vi.fn(() => hasValidTemplate),
-    } as unknown as DocumentManager;
+function createValidationDocumentPredicate(hasValidTemplate: boolean): () => boolean {
+    return () => hasValidTemplate;
 }
 
 describe('DeferredValidationInitializer', () => {
@@ -31,7 +32,7 @@ describe('DeferredValidationInitializer', () => {
         const initializeValidation = vi.fn<() => Promise<void>>().mockResolvedValue();
         const initializer = new TestValidationInitializer(
             () => true,
-            createDocumentManager(false),
+            createValidationDocumentPredicate(false),
             initializeValidation,
         );
 
@@ -48,7 +49,7 @@ describe('DeferredValidationInitializer', () => {
         const initializeValidation = vi.fn<() => Promise<void>>().mockReturnValue(initialization);
         const initializer = new TestValidationInitializer(
             () => true,
-            createDocumentManager(true),
+            createValidationDocumentPredicate(true),
             initializeValidation,
         );
 
@@ -74,7 +75,7 @@ describe('DeferredValidationInitializer', () => {
             .mockResolvedValueOnce();
         const initializer = new TestValidationInitializer(
             () => true,
-            createDocumentManager(true),
+            createValidationDocumentPredicate(true),
             initializeValidation,
         );
 

--- a/tst/unit/utils/ValidationUtils.test.ts
+++ b/tst/unit/utils/ValidationUtils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DocumentManager } from '../../../src/document/DocumentManager';
+import { DeferredValidationInitializer, InitializationStatus } from '../../../src/utils/ValidationUtils';
+
+class TestValidationInitializer extends DeferredValidationInitializer {
+    constructor(isEnabled: () => boolean, documentManager: DocumentManager, initializeValidation: () => Promise<void>) {
+        super(isEnabled, documentManager, initializeValidation);
+    }
+
+    initialize(): Promise<boolean> {
+        return this.initializeIfRequired();
+    }
+
+    reset(): void {
+        this.resetInitialization();
+    }
+
+    getStatus(): InitializationStatus {
+        return this.status;
+    }
+}
+
+function createDocumentManager(hasValidTemplate: boolean): DocumentManager {
+    return {
+        hasValidTemplate: vi.fn(() => hasValidTemplate),
+    } as unknown as DocumentManager;
+}
+
+describe('DeferredValidationInitializer', () => {
+    it('should not initialize when no valid template is open', async () => {
+        const initializeValidation = vi.fn<() => Promise<void>>().mockResolvedValue();
+        const initializer = new TestValidationInitializer(
+            () => true,
+            createDocumentManager(false),
+            initializeValidation,
+        );
+
+        await expect(initializer.initialize()).resolves.toBe(false);
+        expect(initializeValidation).not.toHaveBeenCalled();
+        expect(initializer.getStatus()).toBe(InitializationStatus.Uninitialized);
+    });
+
+    it('should share one initialization between concurrent callers', async () => {
+        let resolveInitialization!: () => void;
+        const initialization = new Promise<void>((resolve) => {
+            resolveInitialization = resolve;
+        });
+        const initializeValidation = vi.fn<() => Promise<void>>().mockReturnValue(initialization);
+        const initializer = new TestValidationInitializer(
+            () => true,
+            createDocumentManager(true),
+            initializeValidation,
+        );
+
+        const first = initializer.initialize();
+        const second = initializer.initialize();
+
+        expect(initializeValidation).toHaveBeenCalledTimes(1);
+        expect(initializer.getStatus()).toBe(InitializationStatus.Initializing);
+        resolveInitialization();
+
+        await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+        expect(initializer.getStatus()).toBe(InitializationStatus.Initialized);
+    });
+
+    it('should ignore a stale failure after reset and successful reinitialization', async () => {
+        let rejectFirstInitialization!: (error: Error) => void;
+        const firstInitialization = new Promise<void>((_resolve, reject) => {
+            rejectFirstInitialization = reject;
+        });
+        const initializeValidation = vi
+            .fn<() => Promise<void>>()
+            .mockReturnValueOnce(firstInitialization)
+            .mockResolvedValueOnce();
+        const initializer = new TestValidationInitializer(
+            () => true,
+            createDocumentManager(true),
+            initializeValidation,
+        );
+
+        const staleInitialization = initializer.initialize();
+        initializer.reset();
+        await expect(initializer.initialize()).resolves.toBe(true);
+
+        rejectFirstInitialization(new Error('stale initialization failed'));
+        await expect(staleInitialization).rejects.toThrow('stale initialization failed');
+        expect(initializer.getStatus()).toBe(InitializationStatus.Initialized);
+        expect(initializeValidation).toHaveBeenCalledTimes(2);
+    });
+});

--- a/tst/unit/utils/ValidationUtils.test.ts
+++ b/tst/unit/utils/ValidationUtils.test.ts
@@ -18,6 +18,10 @@ class TestValidationInitializer extends DeferredValidationInitializer {
         this.resetInitialization();
     }
 
+    close(): void {
+        this.markClosed();
+    }
+
     getStatus(): InitializationStatus {
         return this.status;
     }
@@ -142,5 +146,30 @@ describe('DeferredValidationInitializer', () => {
         await expect(Promise.all([staleInitialization, replacement])).resolves.toEqual([true, true]);
         expect(initializer.getStatus()).toBe(InitializationStatus.Initialized);
         expect(initializeValidation).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not reinitialize when an in-flight initialization settles after close', async () => {
+        let resolveInitialization!: () => void;
+        const initialization = new Promise<void>((resolve) => {
+            resolveInitialization = resolve;
+        });
+        const initializeValidation = vi
+            .fn<() => Promise<void>>()
+            .mockReturnValueOnce(initialization)
+            .mockResolvedValueOnce();
+        const initializer = new TestValidationInitializer(
+            () => true,
+            createValidationDocumentPredicate(true),
+            initializeValidation,
+        );
+
+        const inFlightInitialization = initializer.initialize();
+        initializer.close();
+        resolveInitialization();
+
+        await expect(inFlightInitialization).resolves.toBe(false);
+        await expect(initializer.initialize()).resolves.toBe(false);
+        expect(initializeValidation).toHaveBeenCalledTimes(1);
+        expect(initializer.getStatus()).toBe(InitializationStatus.Uninitialized);
     });
 });

--- a/tst/unit/utils/ValidationUtils.test.ts
+++ b/tst/unit/utils/ValidationUtils.test.ts
@@ -64,6 +64,22 @@ describe('DeferredValidationInitializer', () => {
         expect(initializer.getStatus()).toBe(InitializationStatus.Initialized);
     });
 
+    it('should preserve and rethrow a current-generation initialization failure', async () => {
+        const initializationError = new Error('initialization failed');
+        const initializeValidation = vi.fn<() => Promise<void>>().mockRejectedValue(initializationError);
+        const initializer = new TestValidationInitializer(
+            () => true,
+            createValidationDocumentPredicate(true),
+            initializeValidation,
+        );
+
+        await expect(initializer.initialize()).rejects.toBe(initializationError);
+        expect(initializer.getStatus()).toBe(InitializationStatus.Failed);
+
+        await expect(initializer.initialize()).rejects.toBe(initializationError);
+        expect(initializeValidation).toHaveBeenCalledTimes(1);
+    });
+
     it('should ignore a stale failure after reset and successful reinitialization', async () => {
         let rejectFirstInitialization!: (error: Error) => void;
         const firstInitialization = new Promise<void>((_resolve, reject) => {
@@ -84,7 +100,46 @@ describe('DeferredValidationInitializer', () => {
         await expect(initializer.initialize()).resolves.toBe(true);
 
         rejectFirstInitialization(new Error('stale initialization failed'));
-        await expect(staleInitialization).rejects.toThrow('stale initialization failed');
+        await expect(staleInitialization).resolves.toBe(true);
+        expect(initializer.getStatus()).toBe(InitializationStatus.Initialized);
+        expect(initializeValidation).toHaveBeenCalledTimes(2);
+    });
+
+    it('should wait for a replacement generation after an in-flight initialization is reset', async () => {
+        let resolveFirstInitialization!: () => void;
+        let resolveReplacementInitialization!: () => void;
+        const firstInitialization = new Promise<void>((resolve) => {
+            resolveFirstInitialization = resolve;
+        });
+        const replacementInitialization = new Promise<void>((resolve) => {
+            resolveReplacementInitialization = resolve;
+        });
+        const initializeValidation = vi
+            .fn<() => Promise<void>>()
+            .mockReturnValueOnce(firstInitialization)
+            .mockReturnValueOnce(replacementInitialization);
+        const initializer = new TestValidationInitializer(
+            () => true,
+            createValidationDocumentPredicate(true),
+            initializeValidation,
+        );
+
+        const staleInitialization = initializer.initialize();
+        initializer.reset();
+        const replacement = initializer.initialize();
+        const staleOutcome = staleInitialization.then(() => 'settled' as const);
+
+        resolveFirstInitialization();
+        const outcomeBeforeReplacement = await Promise.race([
+            staleOutcome,
+            new Promise<'pending'>((resolve) => {
+                setImmediate(() => resolve('pending'));
+            }),
+        ]);
+        expect(outcomeBeforeReplacement).toBe('pending');
+
+        resolveReplacementInitialization();
+        await expect(Promise.all([staleInitialization, replacement])).resolves.toEqual([true, true]);
         expect(initializer.getStatus()).toBe(InitializationStatus.Initialized);
         expect(initializeValidation).toHaveBeenCalledTimes(2);
     });

--- a/tst/utils/MockServerComponents.ts
+++ b/tst/utils/MockServerComponents.ts
@@ -73,6 +73,7 @@ export function createMockDocumentManager(customSettings?: Settings) {
     const mock = stubInterface<DocumentManager>();
     const settings = customSettings ?? DefaultSettings;
     mock.getEditorSettingsForDocument.returns(settings.editor);
+    mock.hasFilesOfType.returns(false);
     return mock;
 }
 

--- a/tst/utils/TemplateBuilder.ts
+++ b/tst/utils/TemplateBuilder.ts
@@ -248,6 +248,7 @@ export class TemplateBuilder {
 
         // Create syntax tree using proper document detection (like real LSP)
         const document = new Document(textDocument);
+        this.documentManager.updateDocument(this.uri, document);
         this.syntaxTreeManager.addWithTypes(this.uri, document.contents(), document.documentType, document.cfnFileType);
     }
 
@@ -290,6 +291,7 @@ export class TemplateBuilder {
 
         // Update the TextDocuments collection
         (this.textDocuments as any)._syncedDocuments.set(this.uri, updatedDoc);
+        this.documentManager.updateDocument(this.uri, new Document(updatedDoc));
 
         // Update or create syntax tree (simulating didChangeHandler behavior)
         try {


### PR DESCRIPTION
## Motivation

Previously, the language server initialized the Pyodide-based cfn-lint runtime, mounted every workspace folder during startup, and loaded Guard rules before a compatible document needed validation. This added avoidable startup work and memory usage for workspaces without CloudFormation files.

The existing lifecycle also had races around failed or superseded initialization, Guard settings changes, concurrent workspace mounts, queued lint requests, and shutdown during worker initialization.

## Changes

* Add a shared, generation-aware deferred initialization lifecycle. cfn-lint now activates only for CloudFormation templates or GitSync deployment files, while Guard activates only for templates; concurrent callers share initialization, current failures are preserved, and stale results are ignored.
* Initialize cfn-lint and mount workspace folders on first use instead of during server startup. Concurrent mounts for the same folder share one request, propagate the same failure, and remain retryable.
* Settle queued lint requests deterministically when superseded, explicitly cancelled, initialization fails, or the service closes. Track skipped/cancelled lint work and queue depth consistently.
* Load and reload Guard rules through the deferred lifecycle. Settings changes reset initialization, transient load failures can recover on the next validation, stale loads cannot overwrite newer settings, and disabling or closing Guard stops pending validation work.
* Make shutdown race-safe: propagate asynchronous cleanup through the LSP shutdown response, make Pyodide worker shutdown idempotent, reject in-flight worker tasks, stop initialization retries after shutdown, and always close the worker manager.
* Update the test LSP client to wait for the server process to close during shutdown, fixing the lifecycle issue exposed by deferred initialization.
* Add unit coverage for deferred readiness, concurrent initialization and mounts, stale generations, cancellation and failure settlement, Guard reloads, and shutdown during initialization.

### Issue

https://github.com/aws/aws-toolkit-jetbrains/issues/6380
