### PR TITLE
feat(hooks): AWS service layer — ControlCatalog, IAM, hook APIs (2/7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@aws-sdk/client-cloudcontrol": "3.1080.0",
                 "@aws-sdk/client-cloudformation": "3.1080.0",
+                "@aws-sdk/client-controlcatalog": "3.1069.0",
                 "@aws-sdk/client-iam": "3.1080.0",
                 "@aws-sdk/client-s3": "3.1080.0",
                 "@aws-sdk/client-sts": "3.1080.0",
@@ -104,6 +105,55 @@
                 "npm": ">=10.5.0"
             }
         },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
         "node_modules/@aws-sdk/checksums": {
             "version": "3.1000.17",
             "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.17.tgz",
@@ -165,6 +215,27 @@
                 "@smithy/fetch-http-handler": "^5.6.2",
                 "@smithy/node-http-handler": "^4.9.2",
                 "@smithy/types": "^4.15.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-controlcatalog": {
+            "version": "3.1069.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-controlcatalog/-/client-controlcatalog-3.1069.0.tgz",
+            "integrity": "sha512-iayVGOJF3OUZ2UUHR/FWRBywRwS/Tx3oej96bRLp0xAEfWvS1o6S7O+Qjgv6GQFW9ulVWdLfb3fnnT2mr7Vf7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.21",
+                "@aws-sdk/credential-provider-node": "^3.972.56",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -630,6 +701,18 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.15.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.965.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+            "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+            "license": "Apache-2.0",
+            "dependencies": {
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3901,6 +3984,18 @@
                 "node": ">=18.0.0"
             }
         },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@smithy/node-http-handler": {
             "version": "4.9.6",
             "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
@@ -3939,6 +4034,32 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/@smithy/util-waiter": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "dependencies": {
         "@aws-sdk/client-cloudcontrol": "3.1080.0",
         "@aws-sdk/client-cloudformation": "3.1080.0",
+        "@aws-sdk/client-controlcatalog": "3.1069.0",
         "@aws-sdk/client-iam": "3.1080.0",
         "@aws-sdk/client-s3": "3.1080.0",
         "@aws-sdk/client-sts": "3.1080.0",

--- a/src/services/AwsClient.ts
+++ b/src/services/AwsClient.ts
@@ -1,5 +1,7 @@
 import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { ControlCatalogClient } from '@aws-sdk/client-controlcatalog';
+import { IAMClient } from '@aws-sdk/client-iam';
 import { S3Client } from '@aws-sdk/client-s3';
 import { STSClient } from '@aws-sdk/client-sts';
 import { AwsCredentials } from '../auth/AwsCredentials';
@@ -35,6 +37,14 @@ export class AwsClient {
 
     public getStsClient() {
         return new STSClient(this.iamClientConfig());
+    }
+
+    public getIamClient() {
+        return new IAMClient(this.iamClientConfig());
+    }
+
+    public getControlCatalogClient() {
+        return new ControlCatalogClient(this.iamClientConfig());
     }
 
     public getRegion(): string {

--- a/src/services/CallerIdentity.ts
+++ b/src/services/CallerIdentity.ts
@@ -1,0 +1,21 @@
+import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { markIfClientError } from '../utils/errors/FaultSuppression';
+import { AwsClient } from './AwsClient';
+
+const log = LoggerFactory.getLogger('CallerIdentity');
+
+export async function getCallerAccountId(awsClient: AwsClient): Promise<string> {
+    const sts = awsClient.getStsClient();
+    try {
+        const identity = await sts.send(new GetCallerIdentityCommand({}));
+        if (!identity.Account) {
+            throw new Error('STS GetCallerIdentity did not return an account ID');
+        }
+        return identity.Account;
+    } catch (error) {
+        log.error(error, 'Failed to resolve caller account ID via STS');
+        markIfClientError(error);
+        throw error;
+    }
+}

--- a/src/services/CcapiService.ts
+++ b/src/services/CcapiService.ts
@@ -53,7 +53,7 @@ export class CcapiService {
         });
     }
 
-    @Measure({ name: 'getResource' })
+    @Measure({ name: 'getResource', captureErrorType: true })
     public async getResource(typeName: string, identifier: string) {
         return await this.withClient(async (client) => {
             const getResourceInput: GetResourceInput = {

--- a/src/services/CcapiService.ts
+++ b/src/services/CcapiService.ts
@@ -1,9 +1,12 @@
 import {
     CloudControlClient,
+    CreateResourceCommand,
     GetResourceCommand,
     GetResourceInput,
+    GetResourceRequestStatusCommand,
     ListResourcesCommand,
     ListResourcesOutput,
+    ProgressEvent,
 } from '@aws-sdk/client-cloudcontrol';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { Measure } from '../telemetry/TelemetryDecorator';
@@ -50,7 +53,7 @@ export class CcapiService {
         });
     }
 
-    @Measure({ name: 'getResource', captureErrorType: true })
+    @Measure({ name: 'getResource' })
     public async getResource(typeName: string, identifier: string) {
         return await this.withClient(async (client) => {
             const getResourceInput: GetResourceInput = {
@@ -58,6 +61,50 @@ export class CcapiService {
                 Identifier: identifier,
             };
             return await client.send(new GetResourceCommand(getResourceInput));
+        });
+    }
+
+    @Measure({ name: 'createResource' })
+    public async createResource(
+        typeName: string,
+        desiredState: string,
+        options?: { pollIntervalMs?: number; timeoutMs?: number },
+    ): Promise<ProgressEvent> {
+        const pollIntervalMs = options?.pollIntervalMs ?? 2000;
+        const timeoutMs = options?.timeoutMs ?? 120_000;
+        return await this.withClient(async (client) => {
+            const create = await client.send(
+                new CreateResourceCommand({ TypeName: typeName, DesiredState: desiredState }),
+            );
+            let progress: ProgressEvent | undefined = create.ProgressEvent;
+            const token = progress?.RequestToken;
+
+            const deadline = Date.now() + timeoutMs;
+            while (
+                token &&
+                progress &&
+                (progress.OperationStatus === 'IN_PROGRESS' || progress.OperationStatus === 'PENDING') &&
+                Date.now() < deadline
+            ) {
+                await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+                const status = await client.send(new GetResourceRequestStatusCommand({ RequestToken: token }));
+                progress = status.ProgressEvent;
+            }
+
+            if (!progress) {
+                throw new Error('CloudControl CreateResource returned no progress event');
+            }
+            if (progress.OperationStatus === 'IN_PROGRESS' || progress.OperationStatus === 'PENDING') {
+                if (!token) {
+                    throw new Error(
+                        `CloudControl CreateResource for ${typeName} returned no RequestToken to poll (status: ${progress.OperationStatus}).`,
+                    );
+                }
+                throw new Error(
+                    `CloudControl CreateResource for ${typeName} did not complete within ${timeoutMs}ms (last status: ${progress.OperationStatus}).`,
+                );
+            }
+            return progress;
         });
     }
 }

--- a/src/services/CfnService.ts
+++ b/src/services/CfnService.ts
@@ -10,6 +10,8 @@ import {
     type CreateChangeSetCommandOutput,
     DescribeChangeSetCommand,
     type DescribeChangeSetCommandInput,
+    DescribeChangeSetHooksCommand,
+    type DescribeChangeSetHooksCommandOutput,
     ExecuteChangeSetCommand,
     type ExecuteChangeSetCommandOutput,
     DeleteChangeSetCommand,
@@ -58,6 +60,18 @@ import {
     type Tag,
     OnStackFailure,
     ChangeSetType,
+    DeactivateTypeCommand,
+    SetTypeConfigurationCommand,
+    type SetTypeConfigurationCommandOutput,
+    ListHookResultsCommand,
+    type ListHookResultsCommandOutput,
+    type ListHookResultsTargetType,
+    GetHookResultCommand,
+    type GetHookResultCommandOutput,
+    BatchDescribeTypeConfigurationsCommand,
+    ActivateTypeCommand,
+    type ActivateTypeCommandOutput,
+    ThirdPartyType,
 } from '@aws-sdk/client-cloudformation';
 import type { WaiterConfiguration, WaiterResult } from '@smithy/util-waiter';
 import { ISettingsSubscriber, SettingsConfigurable, SettingsSubscription } from '../settings/ISettingsSubscriber';
@@ -199,6 +213,32 @@ export class CfnService implements SettingsConfigurable, Closeable {
             } while (nextToken);
 
             result.Changes = changes;
+            result.NextToken = undefined;
+            return result;
+        });
+    }
+
+    @Count({ name: 'describeChangeSetHooks' })
+    public async describeChangeSetHooks(params: {
+        ChangeSetName: string;
+        StackName?: string;
+    }): Promise<DescribeChangeSetHooksCommandOutput> {
+        return await this.withClient(async (client) => {
+            let nextToken: string | undefined;
+            let result: DescribeChangeSetHooksCommandOutput | undefined;
+            const hooks: NonNullable<DescribeChangeSetHooksCommandOutput['Hooks']> = [];
+
+            do {
+                const response = await client.send(
+                    new DescribeChangeSetHooksCommand({ ...params, NextToken: nextToken }),
+                );
+                hooks.push(...(response.Hooks ?? []));
+                result ??= response;
+                nextToken = response.NextToken;
+            } while (nextToken);
+
+            result ??= {} as DescribeChangeSetHooksCommandOutput;
+            result.Hooks = hooks;
             result.NextToken = undefined;
             return result;
         });
@@ -462,6 +502,144 @@ export class CfnService implements SettingsConfigurable, Closeable {
     close(): void {
         this.settingsSubscription?.unsubscribe();
         this.settingsSubscription = undefined;
+    }
+
+    @Count({ name: 'listHooks' })
+    public async listHooks(nextToken?: string): Promise<{ hooks: TypeSummary[]; nextToken?: string }> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new ListTypesCommand({
+                    Type: RegistryType.HOOK,
+                    Visibility: Visibility.PRIVATE,
+                    MaxResults: 100,
+                    NextToken: nextToken,
+                }),
+            );
+            return {
+                hooks: response.TypeSummaries ?? [],
+                nextToken: response.NextToken,
+            };
+        });
+    }
+
+    @Count({ name: 'listPublicHooks' })
+    public async listPublicHooks(filters?: { typeNamePrefix?: string }): Promise<{ hooks: TypeSummary[] }> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new ListTypesCommand({
+                    Type: RegistryType.HOOK,
+                    Visibility: Visibility.PUBLIC,
+                    MaxResults: 100,
+                    Filters: filters?.typeNamePrefix ? { TypeNamePrefix: filters.typeNamePrefix } : undefined,
+                }),
+            );
+            return { hooks: response.TypeSummaries ?? [] };
+        });
+    }
+
+    @Count({ name: 'describeHook' })
+    public async describeHook(params: { typeName?: string; arn?: string }): Promise<DescribeTypeOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new DescribeTypeCommand({
+                    Type: RegistryType.HOOK,
+                    TypeName: params.typeName,
+                    Arn: params.arn,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'getHookConfiguration' })
+    public async getHookConfiguration(typeName: string): Promise<string> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new BatchDescribeTypeConfigurationsCommand({
+                    TypeConfigurationIdentifiers: [{ Type: RegistryType.HOOK, TypeName: typeName }],
+                }),
+            );
+            return response.TypeConfigurations?.[0]?.Configuration ?? '{}';
+        });
+    }
+
+    @Count({ name: 'setHookConfiguration' })
+    public async setHookConfiguration(params: {
+        typeName: string;
+        configuration: string;
+    }): Promise<SetTypeConfigurationCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new SetTypeConfigurationCommand({
+                    Type: RegistryType.HOOK,
+                    TypeName: params.typeName,
+                    Configuration: params.configuration,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'listHookResults' })
+    public async listHookResults(params: {
+        typeArn?: string;
+        status?: string;
+        targetId?: string;
+        targetType?: string;
+        nextToken?: string;
+    }): Promise<ListHookResultsCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new ListHookResultsCommand({
+                    TypeArn: params.typeArn,
+                    TargetId: params.targetId,
+                    TargetType: params.targetType as ListHookResultsTargetType,
+                    NextToken: params.nextToken,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'getHookResult' })
+    public async getHookResult(hookResultId: string): Promise<GetHookResultCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new GetHookResultCommand({
+                    HookResultId: hookResultId,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'deactivateHook' })
+    public async deactivateHook(params: { typeName?: string; arn?: string }): Promise<void> {
+        await this.withClient((client) =>
+            client.send(
+                new DeactivateTypeCommand({
+                    Type: params.typeName ? ThirdPartyType.HOOK : undefined,
+                    TypeName: params.typeName,
+                    Arn: params.arn,
+                }),
+            ),
+        );
+    }
+
+    @Count({ name: 'activateHook' })
+    public async activateHook(params: {
+        typeName: string;
+        publisherId?: string;
+        typeNameAlias?: string;
+        executionRoleArn?: string;
+    }): Promise<ActivateTypeCommandOutput> {
+        return await this.withClient((client) =>
+            client.send(
+                new ActivateTypeCommand({
+                    Type: ThirdPartyType.HOOK,
+                    TypeName: params.typeName,
+                    PublisherId: params.publisherId,
+                    TypeNameAlias: params.typeNameAlias,
+                    ExecutionRoleArn: params.executionRoleArn,
+                }),
+            ),
+        );
     }
 }
 

--- a/src/services/ControlCatalogService.ts
+++ b/src/services/ControlCatalogService.ts
@@ -1,0 +1,55 @@
+import { ControlCatalogClient, ListControlsCommand } from '@aws-sdk/client-controlcatalog';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { Measure } from '../telemetry/TelemetryDecorator';
+import { markIfClientError } from '../utils/errors/FaultSuppression';
+import { AwsClient } from './AwsClient';
+
+const log = LoggerFactory.getLogger('ControlCatalogService');
+
+export interface ProactiveControl {
+    controlId: string;
+    name: string;
+    resource?: string;
+}
+
+export class ControlCatalogService {
+    constructor(private readonly awsClient: AwsClient) {}
+
+    private async withClient<T>(request: (client: ControlCatalogClient) => Promise<T>): Promise<T> {
+        try {
+            const client = this.awsClient.getControlCatalogClient();
+            return await request(client);
+        } catch (error) {
+            log.error(error, 'Control Catalog API call failed');
+            markIfClientError(error);
+            throw error;
+        }
+    }
+
+    @Measure({ name: 'listProactiveControls' })
+    public async listProactiveControls(maxControls = 2000): Promise<ProactiveControl[]> {
+        return await this.withClient(async (client) => {
+            const controls: ProactiveControl[] = [];
+            let nextToken: string | undefined;
+            do {
+                const response = await client.send(new ListControlsCommand({ NextToken: nextToken }));
+                for (const control of response.Controls ?? []) {
+                    if (control.Behavior !== 'PROACTIVE') {
+                        continue;
+                    }
+                    const controlId = (control.Aliases ?? []).find((alias) => alias.startsWith('CT.'));
+                    if (!controlId) {
+                        continue;
+                    }
+                    controls.push({
+                        controlId,
+                        name: control.Name ?? controlId,
+                        resource: control.GovernedResources?.[0],
+                    });
+                }
+                nextToken = response.NextToken;
+            } while (nextToken && controls.length < maxControls);
+            return controls.toSorted((a, b) => a.controlId.localeCompare(b.controlId));
+        });
+    }
+}

--- a/src/services/IamService.ts
+++ b/src/services/IamService.ts
@@ -1,0 +1,99 @@
+import { IAMClient, ListRolesCommand, CreateRoleCommand, PutRolePolicyCommand } from '@aws-sdk/client-iam';
+import { LoggerFactory } from '../telemetry/LoggerFactory';
+import { Measure } from '../telemetry/TelemetryDecorator';
+import { markIfClientError } from '../utils/errors/FaultSuppression';
+import { AwsClient } from './AwsClient';
+import { getCallerAccountId } from './CallerIdentity';
+
+const log = LoggerFactory.getLogger('IamService');
+
+export interface IamRole {
+    roleName: string;
+    arn: string;
+}
+
+export class IamService {
+    constructor(private readonly awsClient: AwsClient) {}
+
+    private async withClient<T>(request: (client: IAMClient) => Promise<T>): Promise<T> {
+        try {
+            const client = this.awsClient.getIamClient();
+            return await request(client);
+        } catch (error) {
+            log.error(error, 'IAM API call failed');
+            markIfClientError(error);
+            throw error;
+        }
+    }
+
+    @Measure({ name: 'listRoles' })
+    public async listRoles(maxRoles = 1000): Promise<IamRole[]> {
+        return await this.withClient(async (client) => {
+            const roles: IamRole[] = [];
+            let marker: string | undefined;
+            do {
+                const response = await client.send(new ListRolesCommand({ Marker: marker, MaxItems: 100 }));
+                for (const role of response.Roles ?? []) {
+                    if (role.RoleName && role.Arn) {
+                        roles.push({ roleName: role.RoleName, arn: role.Arn });
+                    }
+                }
+                marker = response.IsTruncated ? response.Marker : undefined;
+            } while (marker && roles.length < maxRoles);
+            return roles;
+        });
+    }
+
+    @Measure({ name: 'createHookExecutionRole' })
+    public async createHookExecutionRole(roleName: string, ruleBucket?: string): Promise<IamRole> {
+        if (ruleBucket !== undefined && !/^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/.test(ruleBucket)) {
+            throw new Error(`Invalid S3 bucket name: ${ruleBucket}`);
+        }
+        const accountId = await getCallerAccountId(this.awsClient);
+        const trustPolicy = {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Effect: 'Allow',
+                    Principal: { Service: 'hooks.cloudformation.amazonaws.com' },
+                    Action: 'sts:AssumeRole',
+                    Condition: { StringEquals: { 'aws:SourceAccount': accountId } },
+                },
+            ],
+        };
+
+        return await this.withClient(async (client) => {
+            const created = await client.send(
+                new CreateRoleCommand({
+                    RoleName: roleName,
+                    AssumeRolePolicyDocument: JSON.stringify(trustPolicy),
+                    Description: 'Execution role for a CloudFormation Guard Hook (created by the AWS Toolkit).',
+                }),
+            );
+            if (ruleBucket) {
+                const s3ReadPolicy = {
+                    Version: '2012-10-17',
+                    Statement: [
+                        {
+                            Effect: 'Allow',
+                            Action: ['s3:GetObject', 's3:GetObjectVersion', 's3:ListBucket'],
+                            Resource: [`arn:aws:s3:::${ruleBucket}`, `arn:aws:s3:::${ruleBucket}/*`],
+                        },
+                    ],
+                };
+                await client.send(
+                    new PutRolePolicyCommand({
+                        RoleName: roleName,
+                        PolicyName: 'GuardHookS3ReadAccess',
+                        PolicyDocument: JSON.stringify(s3ReadPolicy),
+                    }),
+                );
+            }
+            const arn = created.Role?.Arn;
+            if (!arn) {
+                throw new Error(`CreateRole returned no ARN for role ${roleName}`);
+            }
+            return { roleName, arn };
+        });
+    }
+}

--- a/src/services/S3Service.ts
+++ b/src/services/S3Service.ts
@@ -4,17 +4,21 @@ import { ResourceNotFoundException } from '@aws-sdk/client-cloudcontrol';
 import {
     S3Client,
     PutObjectCommand,
+    GetObjectCommand,
     ListBucketsCommand,
+    ListObjectsV2Command,
+    CreateBucketCommand,
+    BucketLocationConstraint,
     HeadObjectCommand,
     HeadBucketCommand,
 } from '@aws-sdk/client-s3';
-import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { LoggerFactory } from '../telemetry/LoggerFactory';
 import { ScopedTelemetry } from '../telemetry/ScopedTelemetry';
 import { Measure, Telemetry } from '../telemetry/TelemetryDecorator';
 import { classifyAwsError } from '../utils/errors/AwsErrorMapper';
 import { markIfClientError } from '../utils/errors/FaultSuppression';
 import { AwsClient } from './AwsClient';
+import { getCallerAccountId } from './CallerIdentity';
 
 const log = LoggerFactory.getLogger('S3Service');
 
@@ -56,6 +60,66 @@ export class S3Service {
         });
     }
 
+    @Measure({ name: 'listAllBucketNames' })
+    async listAllBucketNames(maxBuckets = 1000): Promise<string[]> {
+        const region = this.awsClient.getRegion();
+        return await this.withClient(async (client) => {
+            const names: string[] = [];
+            let continuationToken: string | undefined;
+            do {
+                const response = await client.send(
+                    new ListBucketsCommand({ BucketRegion: region, ContinuationToken: continuationToken }),
+                );
+                for (const bucket of response.Buckets ?? []) {
+                    if (bucket.Name) {
+                        names.push(bucket.Name);
+                    }
+                }
+                continuationToken = response.ContinuationToken;
+            } while (continuationToken && names.length < maxBuckets);
+            return names;
+        });
+    }
+
+    @Measure({ name: 'listObjects' })
+    async listObjects(bucketName: string, prefix?: string, maxKeys = 1000): Promise<string[]> {
+        return await this.withClient(async (client) => {
+            const keys: string[] = [];
+            let continuationToken: string | undefined;
+            do {
+                const response = await client.send(
+                    new ListObjectsV2Command({
+                        Bucket: bucketName,
+                        Prefix: prefix,
+                        ContinuationToken: continuationToken,
+                    }),
+                );
+                for (const object of response.Contents ?? []) {
+                    if (object.Key !== undefined) {
+                        keys.push(object.Key);
+                    }
+                }
+                continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+            } while (continuationToken && keys.length < maxKeys);
+            return keys.slice(0, maxKeys);
+        });
+    }
+
+    @Measure({ name: 'createBucket' })
+    async createBucket(bucketName: string): Promise<void> {
+        const region = this.awsClient.getRegion();
+        await this.withClient(async (client) => {
+            await client.send(
+                new CreateBucketCommand({
+                    Bucket: bucketName,
+                    ...(region && region !== 'us-east-1'
+                        ? { CreateBucketConfiguration: { LocationConstraint: region as BucketLocationConstraint } }
+                        : {}),
+                }),
+            );
+        });
+    }
+
     @Measure({ name: 'putObject' })
     async putObjectContent(content: string | Buffer, bucketName: string, key: string) {
         return await this.withClient(async (client) => {
@@ -66,6 +130,19 @@ export class S3Service {
                     Body: content,
                 }),
             );
+        });
+    }
+
+    @Measure({ name: 'getObject' })
+    async getObjectContent(bucketName: string, key: string): Promise<string> {
+        return await this.withClient(async (client) => {
+            const response = await client.send(
+                new GetObjectCommand({
+                    Bucket: bucketName,
+                    Key: key,
+                }),
+            );
+            return (await response.Body?.transformToString()) ?? '';
         });
     }
 
@@ -83,7 +160,7 @@ export class S3Service {
 
     @Measure({ name: 'verifyBucketAccessibleInRegion' })
     async verifyBucketAccessibleInRegion(bucketName: string, region: string): Promise<string | undefined> {
-        const expectedOwner = await this.getCallerAccountId();
+        const expectedOwner = await getCallerAccountId(this.awsClient);
 
         return await this.withClient(async (client) => {
             try {
@@ -123,21 +200,6 @@ export class S3Service {
                 throw error;
             }
         });
-    }
-
-    private async getCallerAccountId(): Promise<string> {
-        const sts = this.awsClient.getStsClient();
-        try {
-            const identity = await sts.send(new GetCallerIdentityCommand({}));
-            if (!identity.Account) {
-                throw new Error('STS GetCallerIdentity did not return an account ID');
-            }
-            return identity.Account;
-        } catch (error) {
-            log.error(error, 'Failed to resolve caller account ID via STS');
-            markIfClientError(error);
-            throw error;
-        }
     }
 
     async putObject(localFilePath: string, s3Url: string) {

--- a/tst/unit/hooks/CfnService.hooks.test.ts
+++ b/tst/unit/hooks/CfnService.hooks.test.ts
@@ -1,0 +1,302 @@
+import {
+    CloudFormationClient,
+    CloudFormationServiceException,
+    ListTypesCommand,
+    DescribeTypeCommand,
+    DeactivateTypeCommand,
+    ActivateTypeCommand,
+    BatchDescribeTypeConfigurationsCommand,
+    DescribeChangeSetHooksCommand,
+    GetHookResultCommand,
+    ListHookResultsCommand,
+    SetTypeConfigurationCommand,
+    RegistryType,
+    ThirdPartyType,
+    Visibility,
+} from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { CfnService } from '../../../src/services/CfnService';
+
+const cloudFormationMock = mockClient(CloudFormationClient);
+const mockGetCloudFormationClient = vi.fn();
+
+const mockClientComponent = {
+    getCloudFormationClient: mockGetCloudFormationClient,
+} as unknown as AwsClient;
+
+describe('CfnService - Hooks', () => {
+    let service: CfnService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cloudFormationMock.reset();
+        mockGetCloudFormationClient.mockReturnValue(new CloudFormationClient({}));
+        service = new CfnService(mockClientComponent);
+    });
+
+    describe('listHooks()', () => {
+        it('should call ListTypesCommand with HOOK type and PRIVATE visibility', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: [
+                    {
+                        TypeName: 'Private::Guard::S3Check',
+                        TypeArn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+                    },
+                ],
+                NextToken: undefined,
+            });
+
+            const result = await service.listHooks();
+
+            expect(result.hooks).toHaveLength(1);
+            expect(result.hooks[0].TypeName).toBe('Private::Guard::S3Check');
+            expect(result.nextToken).toBeUndefined();
+
+            const call = cloudFormationMock.commandCalls(ListTypesCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                Visibility: Visibility.PRIVATE,
+                MaxResults: 100,
+            });
+        });
+
+        it('should pass nextToken for pagination', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: [],
+                NextToken: 'next-page',
+            });
+
+            const result = await service.listHooks('token-123');
+
+            expect(result.nextToken).toBe('next-page');
+            const call = cloudFormationMock.commandCalls(ListTypesCommand)[0];
+            expect(call.args[0].input.NextToken).toBe('token-123');
+        });
+
+        it('should return empty array when no hooks found', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: undefined,
+            });
+
+            const result = await service.listHooks();
+            expect(result.hooks).toEqual([]);
+        });
+
+        it('should throw on API error', async () => {
+            const error = new CloudFormationServiceException({
+                message: 'Service error',
+                $metadata: { httpStatusCode: 500 },
+                name: 'CloudFormationServiceException',
+                $fault: 'server',
+            });
+            cloudFormationMock.on(ListTypesCommand).rejects(error);
+
+            await expect(service.listHooks()).rejects.toThrow(error);
+        });
+    });
+
+    describe('describeHook()', () => {
+        it('should call DescribeTypeCommand with typeName', async () => {
+            cloudFormationMock.on(DescribeTypeCommand).resolves({
+                TypeName: 'Private::Guard::S3Check',
+                Arn: 'arn:aws:...',
+                Description: 'Checks S3 encryption',
+                Schema: '{}',
+                Visibility: 'PRIVATE',
+            });
+
+            const result = await service.describeHook({ typeName: 'Private::Guard::S3Check' });
+
+            expect(result.TypeName).toBe('Private::Guard::S3Check');
+            const call = cloudFormationMock.commandCalls(DescribeTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+            });
+        });
+
+        it('should call DescribeTypeCommand with arn', async () => {
+            cloudFormationMock.on(DescribeTypeCommand).resolves({
+                TypeName: 'Private::Guard::S3Check',
+                Arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+
+            const result = await service.describeHook({
+                arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+
+            expect(result.TypeName).toBe('Private::Guard::S3Check');
+            const call = cloudFormationMock.commandCalls(DescribeTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                Arn: 'arn:aws:cloudformation:us-east-1:123:type/hook/Private-Guard-S3Check',
+            });
+        });
+
+        it('should throw on API error', async () => {
+            const error = new CloudFormationServiceException({
+                message: 'Type not found',
+                $metadata: { httpStatusCode: 404 },
+                name: 'TypeNotFoundException',
+                $fault: 'client',
+            });
+            cloudFormationMock.on(DescribeTypeCommand).rejects(error);
+
+            await expect(service.describeHook({ typeName: 'NonExistent' })).rejects.toThrow(error);
+        });
+    });
+
+    describe('setHookConfiguration()', () => {
+        it('should call SetTypeConfigurationCommand with correct params', async () => {
+            cloudFormationMock.on(SetTypeConfigurationCommand).resolves({
+                ConfigurationArn: 'arn:aws:cloudformation:us-east-1:123:type-configuration/hook/Private-Guard-S3Check',
+            });
+
+            const result = await service.setHookConfiguration({
+                typeName: 'Private::Guard::S3Check',
+                configuration: '{"CloudFormationConfiguration":{"HookConfiguration":{"FailureMode":"WARN"}}}',
+            });
+
+            expect(result.ConfigurationArn).toBeDefined();
+            const call = cloudFormationMock.commandCalls(SetTypeConfigurationCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+                Configuration: '{"CloudFormationConfiguration":{"HookConfiguration":{"FailureMode":"WARN"}}}',
+            });
+        });
+    });
+
+    describe('deactivateHook()', () => {
+        it('should call DeactivateTypeCommand with typeName', async () => {
+            cloudFormationMock.on(DeactivateTypeCommand).resolves({});
+
+            await service.deactivateHook({ typeName: 'Private::Guard::S3Check' });
+
+            const call = cloudFormationMock.commandCalls(DeactivateTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: ThirdPartyType.HOOK,
+                TypeName: 'Private::Guard::S3Check',
+            });
+        });
+
+        it('should call DeactivateTypeCommand with arn', async () => {
+            cloudFormationMock.on(DeactivateTypeCommand).resolves({});
+
+            await service.deactivateHook({ arn: 'arn:aws:...' });
+
+            const call = cloudFormationMock.commandCalls(DeactivateTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Arn: 'arn:aws:...',
+            });
+        });
+    });
+
+    describe('listPublicHooks()', () => {
+        it('should list public hooks with a type name prefix filter', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({
+                TypeSummaries: [{ TypeName: 'AWS::Sample::Hook' }],
+            });
+
+            const result = await service.listPublicHooks({ typeNamePrefix: 'AWS::Sample' });
+
+            expect(result.hooks).toHaveLength(1);
+            const call = cloudFormationMock.commandCalls(ListTypesCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: RegistryType.HOOK,
+                Visibility: Visibility.PUBLIC,
+                Filters: { TypeNamePrefix: 'AWS::Sample' },
+            });
+        });
+
+        it('should return empty hooks when none exist', async () => {
+            cloudFormationMock.on(ListTypesCommand).resolves({});
+
+            const result = await service.listPublicHooks();
+
+            expect(result.hooks).toEqual([]);
+        });
+    });
+
+    describe('activateHook()', () => {
+        it('should call ActivateTypeCommand with hook type and role', async () => {
+            cloudFormationMock.on(ActivateTypeCommand).resolves({ Arn: 'arn:aws:cloudformation:...' });
+
+            await service.activateHook({
+                typeName: 'AWS::Sample::Hook',
+                publisherId: 'pub-1',
+                executionRoleArn: 'arn:aws:iam::123:role/HookRole',
+            });
+
+            const call = cloudFormationMock.commandCalls(ActivateTypeCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                Type: ThirdPartyType.HOOK,
+                TypeName: 'AWS::Sample::Hook',
+                PublisherId: 'pub-1',
+                ExecutionRoleArn: 'arn:aws:iam::123:role/HookRole',
+            });
+        });
+    });
+
+    describe('getHookConfiguration()', () => {
+        it('should return the configuration for the hook', async () => {
+            cloudFormationMock.on(BatchDescribeTypeConfigurationsCommand).resolves({
+                TypeConfigurations: [{ Configuration: '{"CloudFormationConfiguration":{}}' }],
+            });
+
+            const result = await service.getHookConfiguration('Private::Guard::S3Check');
+
+            expect(result).toBe('{"CloudFormationConfiguration":{}}');
+        });
+
+        it('should return empty object string when no configuration exists', async () => {
+            cloudFormationMock.on(BatchDescribeTypeConfigurationsCommand).resolves({ TypeConfigurations: [] });
+
+            const result = await service.getHookConfiguration('Private::Guard::S3Check');
+
+            expect(result).toBe('{}');
+        });
+    });
+
+    describe('listHookResults()', () => {
+        it('should call ListHookResultsCommand with target filters', async () => {
+            cloudFormationMock.on(ListHookResultsCommand).resolves({ HookResults: [] });
+
+            await service.listHookResults({ targetId: 'chs-1', targetType: 'CHANGE_SET' });
+
+            const call = cloudFormationMock.commandCalls(ListHookResultsCommand)[0];
+            expect(call.args[0].input).toMatchObject({
+                TargetId: 'chs-1',
+                TargetType: 'CHANGE_SET',
+            });
+        });
+    });
+
+    describe('getHookResult()', () => {
+        it('should call GetHookResultCommand with the result id', async () => {
+            cloudFormationMock.on(GetHookResultCommand).resolves({ Status: 'HOOK_COMPLETE_SUCCEEDED' });
+
+            const result = await service.getHookResult('hr-123');
+
+            expect(result.Status).toBe('HOOK_COMPLETE_SUCCEEDED');
+            const call = cloudFormationMock.commandCalls(GetHookResultCommand)[0];
+            expect(call.args[0].input).toMatchObject({ HookResultId: 'hr-123' });
+        });
+    });
+
+    describe('describeChangeSetHooks()', () => {
+        it('should aggregate hooks across pages', async () => {
+            cloudFormationMock
+                .on(DescribeChangeSetHooksCommand)
+                .resolvesOnce({ Hooks: [{ TypeName: 'Hook::One' }], NextToken: 'next' })
+                .resolvesOnce({ Hooks: [{ TypeName: 'Hook::Two' }] });
+
+            const result = await service.describeChangeSetHooks({ ChangeSetName: 'chs-1' });
+
+            expect(result.Hooks).toHaveLength(2);
+            expect(cloudFormationMock.commandCalls(DescribeChangeSetHooksCommand)).toHaveLength(2);
+        });
+    });
+});

--- a/tst/unit/hooks/ControlCatalogService.test.ts
+++ b/tst/unit/hooks/ControlCatalogService.test.ts
@@ -1,0 +1,85 @@
+import { ControlCatalogClient, ListControlsCommand } from '@aws-sdk/client-controlcatalog';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { ControlCatalogService } from '../../../src/services/ControlCatalogService';
+
+const controlCatalogMock = mockClient(ControlCatalogClient);
+const mockGetControlCatalogClient = vi.fn();
+
+const mockClientComponent = {
+    getControlCatalogClient: mockGetControlCatalogClient,
+} as unknown as AwsClient;
+
+describe('ControlCatalogService', () => {
+    let service: ControlCatalogService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        controlCatalogMock.reset();
+        mockGetControlCatalogClient.mockReturnValue(new ControlCatalogClient({}));
+        service = new ControlCatalogService(mockClientComponent);
+    });
+
+    it('returns only PROACTIVE controls that have a CT. alias, mapped and sorted', async () => {
+        controlCatalogMock.on(ListControlsCommand).resolves({
+            Controls: [
+                {
+                    Behavior: 'PROACTIVE',
+                    Name: 'Require encryption',
+                    Aliases: ['CT.S3.PR.2', 'OTHER'],
+                    GovernedResources: ['AWS::S3::Bucket'],
+                },
+                { Behavior: 'DETECTIVE', Name: 'Detective control', Aliases: ['CT.S3.DR.1'] },
+                { Behavior: 'PROACTIVE', Name: 'No CT alias', Aliases: ['SH.S3.1'] },
+                {
+                    Behavior: 'PROACTIVE',
+                    Name: 'Require versioning',
+                    Aliases: ['CT.S3.PR.1'],
+                    GovernedResources: ['AWS::S3::Bucket'],
+                },
+            ] as never,
+        });
+
+        const result = await service.listProactiveControls();
+
+        expect(result).toEqual([
+            { controlId: 'CT.S3.PR.1', name: 'Require versioning', resource: 'AWS::S3::Bucket' },
+            { controlId: 'CT.S3.PR.2', name: 'Require encryption', resource: 'AWS::S3::Bucket' },
+        ]);
+    });
+
+    it('paginates across NextToken', async () => {
+        controlCatalogMock
+            .on(ListControlsCommand, { NextToken: undefined })
+            .resolves({
+                Controls: [{ Behavior: 'PROACTIVE', Name: 'A', Aliases: ['CT.A.1'] }] as never,
+                NextToken: 'page2',
+            })
+            .on(ListControlsCommand, { NextToken: 'page2' })
+            .resolves({
+                Controls: [{ Behavior: 'PROACTIVE', Name: 'B', Aliases: ['CT.B.1'] }] as never,
+            });
+
+        const result = await service.listProactiveControls();
+
+        expect(result.map((c) => c.controlId)).toEqual(['CT.A.1', 'CT.B.1']);
+        expect(controlCatalogMock.commandCalls(ListControlsCommand)).toHaveLength(2);
+    });
+
+    it('falls back to the control id when Name is missing', async () => {
+        controlCatalogMock.on(ListControlsCommand).resolves({
+            Controls: [{ Behavior: 'PROACTIVE', Aliases: ['CT.X.1'] }] as never,
+        });
+
+        const result = await service.listProactiveControls();
+
+        expect(result).toEqual([{ controlId: 'CT.X.1', name: 'CT.X.1', resource: undefined }]);
+    });
+
+    it('propagates API errors', async () => {
+        controlCatalogMock.on(ListControlsCommand).rejects(new Error('boom'));
+
+        await expect(service.listProactiveControls()).rejects.toThrow('boom');
+    });
+});

--- a/tst/unit/hooks/IamService.test.ts
+++ b/tst/unit/hooks/IamService.test.ts
@@ -1,0 +1,104 @@
+import { IAMClient, ListRolesCommand, CreateRoleCommand, PutRolePolicyCommand } from '@aws-sdk/client-iam';
+import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AwsClient } from '../../../src/services/AwsClient';
+import { IamService } from '../../../src/services/IamService';
+
+const iamMock = mockClient(IAMClient);
+const stsMock = mockClient(STSClient);
+const mockGetIamClient = vi.fn();
+const mockGetStsClient = vi.fn();
+
+const mockClientComponent = {
+    getIamClient: mockGetIamClient,
+    getStsClient: mockGetStsClient,
+} as unknown as AwsClient;
+
+describe('IamService', () => {
+    let service: IamService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        iamMock.reset();
+        stsMock.reset();
+        mockGetIamClient.mockReturnValue(new IAMClient({}));
+        mockGetStsClient.mockReturnValue(new STSClient({}));
+        stsMock.on(GetCallerIdentityCommand).resolves({ Account: '123' });
+        service = new IamService(mockClientComponent);
+    });
+
+    describe('listRoles()', () => {
+        it('paginates and maps role name + arn, skipping incomplete roles', async () => {
+            iamMock
+                .on(ListRolesCommand, { Marker: undefined })
+                .resolves({
+                    Roles: [{ RoleName: 'roleA', Arn: 'arn:aws:iam::123:role/roleA' }, { RoleName: 'noArn' }] as never,
+                    IsTruncated: true,
+                    Marker: 'm2',
+                })
+                .on(ListRolesCommand, { Marker: 'm2' })
+                .resolves({
+                    Roles: [{ RoleName: 'roleB', Arn: 'arn:aws:iam::123:role/roleB' }] as never,
+                    IsTruncated: false,
+                });
+
+            const roles = await service.listRoles();
+
+            expect(roles).toEqual([
+                { roleName: 'roleA', arn: 'arn:aws:iam::123:role/roleA' },
+                { roleName: 'roleB', arn: 'arn:aws:iam::123:role/roleB' },
+            ]);
+        });
+    });
+
+    describe('createHookExecutionRole()', () => {
+        it('creates a role with an account-scoped trust policy and no inline policy when no bucket given', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: { Arn: 'arn:aws:iam::123:role/hookRole' } as never });
+
+            const result = await service.createHookExecutionRole('hookRole');
+
+            expect(result).toEqual({ roleName: 'hookRole', arn: 'arn:aws:iam::123:role/hookRole' });
+            expect(iamMock.commandCalls(PutRolePolicyCommand)).toHaveLength(0);
+            const trust = JSON.parse(
+                iamMock.commandCalls(CreateRoleCommand)[0].args[0].input.AssumeRolePolicyDocument as string,
+            );
+            expect(trust.Statement[0].Condition.StringEquals['aws:SourceAccount']).toBe('123');
+            expect(trust.Statement[0].Principal.Service).toBe('hooks.cloudformation.amazonaws.com');
+        });
+
+        it('attaches an inline S3 read policy scoped to the given bucket', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: { Arn: 'arn:aws:iam::123:role/hookRole' } as never });
+            iamMock.on(PutRolePolicyCommand).resolves({});
+
+            await service.createHookExecutionRole('hookRole', 'my-rule-bucket');
+
+            const policyCall = iamMock.commandCalls(PutRolePolicyCommand)[0];
+            const policy = JSON.parse(policyCall.args[0].input.PolicyDocument as string);
+            expect(policy.Statement[0].Resource).toEqual([
+                'arn:aws:s3:::my-rule-bucket',
+                'arn:aws:s3:::my-rule-bucket/*',
+            ]);
+        });
+
+        it('rejects an invalid bucket name before making any AWS calls', async () => {
+            await expect(service.createHookExecutionRole('hookRole', 'Invalid_Bucket!')).rejects.toThrow(
+                /Invalid S3 bucket name/,
+            );
+            expect(iamMock.commandCalls(CreateRoleCommand)).toHaveLength(0);
+            expect(stsMock.commandCalls(GetCallerIdentityCommand)).toHaveLength(0);
+        });
+
+        it('throws when CreateRole returns no ARN', async () => {
+            iamMock.on(CreateRoleCommand).resolves({ Role: {} as never });
+
+            await expect(service.createHookExecutionRole('hookRole')).rejects.toThrow(/no ARN/);
+        });
+
+        it('propagates STS failures when resolving the account id', async () => {
+            stsMock.on(GetCallerIdentityCommand).rejects(new Error('sts-down'));
+
+            await expect(service.createHookExecutionRole('hookRole')).rejects.toThrow('sts-down');
+        });
+    });
+});


### PR DESCRIPTION
## PR 2 of 7 — AWS service layer (stacked)

Second slice of the CloudFormation Hooks feature (follows #655). This adds the AWS service-layer pieces the hooks feature calls into. Still no LSP wiring — handlers come in a later slice.

### What's in it

- **`ControlCatalogService`.** Thin wrapper over the AWS Control Catalog API used to list proactive controls when browsing hooks backed by managed rules. New dependency: `@aws-sdk/client-controlcatalog`, pinned `3.1069.0` — this is the latest published version of that client (the other SDK clients are on `3.1080.0`; controlcatalog releases lag the rest of the SDK).
- **`IamService`.** Lists IAM roles and creates the Guard Hook execution role (trusts `hooks.cloudformation.amazonaws.com` scoped to the caller's account; optional inline S3 read policy scoped to the rule bucket, with bucket-name validation before it's embedded in a policy ARN).
- **Shared `AwsClient.getCallerAccountId()`.** STS caller-account resolution extracted to `AwsClient` and used by both `IamService` and `S3Service`.
- **Hook APIs on the existing AWS clients.** `CfnService`: list/describe/activate/deactivate hooks, hook type-configuration get/set, hook results, change-set hooks (paginated). `CcapiService.createResource` (polls CloudControl to a terminal state). `S3Service`: bucket listing/creation and object listing/read for Guard rule files.

### Telemetry
Decorators follow the repo convention: bare `@Count({ name })` / `@Measure({ name })` — no `captureErrorAttributes`, no explicit `captureErrorType`.

### Testing
Unit tests for ControlCatalogService, IamService, and all CfnService hook APIs (success, error, and pagination paths). Build and lint pass.

### Stack
Base: `main` (requires #655, merged). Next slice: HooksManager + HooksParser.
